### PR TITLE
fix(ingest): defer transient overpass failures before marking streets missing

### DIFF
--- a/ingest/geocoding/overpass/service.test.ts
+++ b/ingest/geocoding/overpass/service.test.ts
@@ -332,6 +332,30 @@ describe("overpass-geocoding-service", () => {
       vi.unstubAllGlobals();
     });
 
+    it("retries deferred intersections after transient network failures", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("Network request failed"))
+        .mockRejectedValueOnce(new Error("Network request failed"))
+        .mockRejectedValueOnce(new Error("Network request failed"))
+        .mockRejectedValueOnce(new Error("Network request failed"))
+        .mockResolvedValueOnce({
+          ok: true,
+          text: () => Promise.resolve(wayResponse),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          text: () => Promise.resolve(wayResponse),
+        });
+      vi.stubGlobal("fetch", fetchMock);
+
+      await overpassGeocodeIntersections(["ул. Пример ∩ ул. Фоо"]);
+
+      // First pass: both streets fail on two instances (4 calls).
+      // Retry pass: same intersection is reprocessed once (2 successful calls).
+      expect(fetchMock).toHaveBeenCalledTimes(6);
+    });
+
     it("deduplicates Overpass fetches when the same street appears in multiple intersections", async () => {
       vi.stubGlobal("fetch", mockFetch(wayResponse));
 

--- a/ingest/geocoding/overpass/service.test.ts
+++ b/ingest/geocoding/overpass/service.test.ts
@@ -349,11 +349,15 @@ describe("overpass-geocoding-service", () => {
         });
       vi.stubGlobal("fetch", fetchMock);
 
-      await overpassGeocodeIntersections(["ул. Пример ∩ ул. Фоо"]);
+      const results = await overpassGeocodeIntersections([
+        "ул. Пример ∩ ул. Фоо",
+      ]);
 
-      // First pass: both streets fail on two instances (4 calls).
-      // Retry pass: same intersection is reprocessed once (2 successful calls).
-      expect(fetchMock).toHaveBeenCalledTimes(6);
+      // The deferred retry pass should trigger additional calls beyond the
+      // initial transient-failure attempts, without depending on exact
+      // OVERPASS_INSTANCES size.
+      expect(fetchMock.mock.calls.length).toBeGreaterThan(4);
+      expect(results).toHaveLength(1);
     });
 
     it("deduplicates Overpass fetches when the same street appears in multiple intersections", async () => {

--- a/ingest/geocoding/overpass/service.test.ts
+++ b/ingest/geocoding/overpass/service.test.ts
@@ -333,30 +333,34 @@ describe("overpass-geocoding-service", () => {
     });
 
     it("retries deferred intersections after transient network failures", async () => {
-      const fetchMock = vi
-        .fn()
-        .mockRejectedValueOnce(new Error("Network request failed"))
-        .mockRejectedValueOnce(new Error("Network request failed"))
-        .mockRejectedValueOnce(new Error("Network request failed"))
-        .mockRejectedValueOnce(new Error("Network request failed"))
-        .mockResolvedValueOnce({
+      const attemptsByInstanceAndQuery = new Map<string, number>();
+      const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+        const instance = input instanceof URL ? input.toString() : String(input);
+        const query = typeof init?.body === "string" ? init.body : "";
+        const key = `${instance}|${query}`;
+        const attempts = attemptsByInstanceAndQuery.get(key) ?? 0;
+        attemptsByInstanceAndQuery.set(key, attempts + 1);
+
+        if (attempts === 0) {
+          throw new Error("Network request failed");
+        }
+
+        return {
           ok: true,
           text: () => Promise.resolve(wayResponse),
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          text: () => Promise.resolve(wayResponse),
-        });
+        };
+      });
       vi.stubGlobal("fetch", fetchMock);
 
       const results = await overpassGeocodeIntersections([
         "ул. Пример ∩ ул. Фоо",
       ]);
 
-      // The deferred retry pass should trigger additional calls beyond the
-      // initial transient-failure attempts, without depending on exact
-      // OVERPASS_INSTANCES size.
-      expect(fetchMock.mock.calls.length).toBeGreaterThan(4);
+      expect(
+        [...attemptsByInstanceAndQuery.values()].some(
+          (attempts) => attempts > 1,
+        ),
+      ).toBe(true);
       expect(results).toHaveLength(1);
     });
 

--- a/ingest/geocoding/overpass/service.ts
+++ b/ingest/geocoding/overpass/service.ts
@@ -4,6 +4,7 @@ import {
   OverpassGeometry,
   Coordinates,
 } from "../../lib/types";
+import { AsyncLocalStorage } from "node:async_hooks";
 import * as turf from "@turf/turf";
 import type { Feature, MultiLineString, Position } from "geojson";
 import {
@@ -52,8 +53,7 @@ function getStreetFeatureType(streetName: string): StreetGeometryFeatureType {
 
 // In-memory cache for street geometry lookups (keyed on type + normalized street name)
 const streetGeometryCache = new Map<string, Feature<MultiLineString> | null>();
-const deferredStreetGeometryKeys = new Set<string>();
-let deferredScopeDepth = 0;
+const deferredScopeStorage = new AsyncLocalStorage<Set<string>>();
 
 function getStreetGeometryCacheKey(streetName: string): string {
   return makeStreetGeometryCacheKey(
@@ -65,7 +65,6 @@ function getStreetGeometryCacheKey(streetName: string): string {
 /** Clear the street geometry cache. Exported for test isolation. */
 export function clearStreetGeometryCache(): void {
   streetGeometryCache.clear();
-  deferredStreetGeometryKeys.clear();
 }
 
 /**
@@ -86,8 +85,10 @@ export function getStreetGeometryCached(
  */
 export function hasStreetGeometryQueried(streetName: string): boolean {
   const cacheKey = getStreetGeometryCacheKey(streetName);
+  const deferredKeys = getCurrentDeferredStreetGeometryKeys();
   return (
-    streetGeometryCache.has(cacheKey) || deferredStreetGeometryKeys.has(cacheKey)
+    streetGeometryCache.has(cacheKey) ||
+    Boolean(deferredKeys?.has(cacheKey))
   );
 }
 
@@ -110,30 +111,29 @@ export function seedStreetGeometryCache(
 }
 
 function isStreetGeometryDeferred(streetName: string): boolean {
-  return deferredStreetGeometryKeys.has(getStreetGeometryCacheKey(streetName));
+  const deferredKeys = getCurrentDeferredStreetGeometryKeys();
+  return Boolean(deferredKeys?.has(getStreetGeometryCacheKey(streetName)));
 }
 
 function clearDeferredStreetGeometryKeys(): void {
-  deferredStreetGeometryKeys.clear();
+  const deferredKeys = getCurrentDeferredStreetGeometryKeys();
+  deferredKeys?.clear();
+}
+
+function getCurrentDeferredStreetGeometryKeys(): Set<string> | undefined {
+  return deferredScopeStorage.getStore();
 }
 
 async function runWithDeferredRetryScope<T>(
   work: () => Promise<T>,
 ): Promise<T> {
-  const isRootScope = deferredScopeDepth === 0;
-  if (isRootScope) {
-    clearDeferredStreetGeometryKeys();
+  const existingScope = deferredScopeStorage.getStore();
+  if (existingScope !== undefined) {
+    return work();
   }
 
-  deferredScopeDepth += 1;
-  try {
-    return await work();
-  } finally {
-    deferredScopeDepth -= 1;
-    if (isRootScope) {
-      clearDeferredStreetGeometryKeys();
-    }
-  }
+  const deferredKeys = new Set<string>();
+  return deferredScopeStorage.run(deferredKeys, work);
 }
 
 function parseIntersectionStreetNames(intersection: string): [string, string] {
@@ -250,8 +250,9 @@ export async function getStreetGeometryFromOverpass(
   streetName: string,
 ): Promise<Feature<MultiLineString> | null> {
   const cacheKey = getStreetGeometryCacheKey(streetName);
+  const deferredKeys = getCurrentDeferredStreetGeometryKeys();
 
-  if (deferredScopeDepth > 0 && deferredStreetGeometryKeys.has(cacheKey)) {
+  if (deferredKeys?.has(cacheKey)) {
     logger.debug("Street geometry deferred for retry", { streetName });
     return null;
   }
@@ -412,7 +413,7 @@ export async function getStreetGeometryFromOverpass(
       // No OSM ways found - API request succeeded but no data for this street name
       logger.info("Could not find street in OSM", { streetName });
       streetGeometryCache.set(cacheKey, null);
-      deferredStreetGeometryKeys.delete(cacheKey);
+      deferredKeys?.delete(cacheKey);
       return null;
     }
 
@@ -456,7 +457,7 @@ export async function getStreetGeometryFromOverpass(
     if (lineStrings.length === 0) {
       logger.info("No valid geometries in response", { streetName });
       streetGeometryCache.set(cacheKey, null);
-      deferredStreetGeometryKeys.delete(cacheKey);
+      deferredKeys?.delete(cacheKey);
       return null;
     }
 
@@ -476,7 +477,7 @@ export async function getStreetGeometryFromOverpass(
     };
 
     streetGeometryCache.set(cacheKey, multiLineString);
-    deferredStreetGeometryKeys.delete(cacheKey);
+    deferredKeys?.delete(cacheKey);
     return multiLineString;
   } catch (error) {
     const err: ErrorWithStatusCode =
@@ -487,16 +488,18 @@ export async function getStreetGeometryFromOverpass(
     });
 
     if (shouldTryFallback(err, err.statusCode)) {
-      if (deferredScopeDepth > 0) {
-        deferredStreetGeometryKeys.add(cacheKey);
+      if (deferredKeys) {
+        deferredKeys.add(cacheKey);
         logger.info("Deferring street geometry after transient failure", {
           streetName,
         });
       }
       return null;
     }
-
-    streetGeometryCache.set(cacheKey, null);
+    logger.error("Non-retryable Overpass error while resolving street", {
+      streetName,
+      error: err.message,
+    });
     return null;
   }
 }
@@ -744,31 +747,32 @@ export async function getStreetSectionGeometry(
     );
   }
 
-  try {
-    logger.info("Finding street section", {
-      streetName,
-      from: { lat: startCoords.lat, lng: startCoords.lng },
-      to: { lat: endCoords.lat, lng: endCoords.lng },
-    });
+  return runWithDeferredRetryScope(async () => {
+    try {
+      logger.info("Finding street section", {
+        streetName,
+        from: { lat: startCoords.lat, lng: startCoords.lng },
+        to: { lat: endCoords.lat, lng: endCoords.lng },
+      });
 
-    // Get full street geometry
-    const streetGeometry = await getStreetGeometryFromOverpass(streetName);
-    if (!streetGeometry) {
-      logger.warn("No geometry found for street", { streetName });
-      return null;
-    }
+      // Get full street geometry
+      const streetGeometry = await getStreetGeometryFromOverpass(streetName);
+      if (!streetGeometry) {
+        logger.warn("No geometry found for street", { streetName });
+        return null;
+      }
 
-    // Create points from coordinates
-    const startPoint = turf.point([startCoords.lng, startCoords.lat]);
-    const endPoint = turf.point([endCoords.lng, endCoords.lat]);
+      // Create points from coordinates
+      const startPoint = turf.point([startCoords.lng, startCoords.lat]);
+      const endPoint = turf.point([endCoords.lng, endCoords.lat]);
 
-    // Find which segments contain or are near our start/end points
-    const allSegments = streetGeometry.geometry.coordinates;
-    let bestSection: Position[] | null = null;
-    let minTotalDistance = Infinity;
+      // Find which segments contain or are near our start/end points
+      const allSegments = streetGeometry.geometry.coordinates;
+      let bestSection: Position[] | null = null;
+      let minTotalDistance = Infinity;
 
-    // Try each segment as a potential section
-    for (const segment of allSegments) {
+      // Try each segment as a potential section
+      for (const segment of allSegments) {
       if (segment.length < 2) continue;
 
       const line = turf.lineString(segment);
@@ -811,20 +815,20 @@ export async function getStreetSectionGeometry(
       }
     }
 
-    if (bestSection && bestSection.length >= 2) {
-      logger.info("Found street section", { points: bestSection.length });
-      return bestSection;
-    }
+      if (bestSection && bestSection.length >= 2) {
+        logger.info("Found street section", { points: bestSection.length });
+        return bestSection;
+      }
 
-    // Fallback: try to connect multiple segments
-    logger.info("No single segment found, trying to connect segments");
+      // Fallback: try to connect multiple segments
+      logger.info("No single segment found, trying to connect segments");
 
-    // Build a path by connecting segments
-    const connectedPath: Position[] = [];
-    let currentPoint = startPoint;
-    const usedSegments = new Set<number>();
+      // Build a path by connecting segments
+      const connectedPath: Position[] = [];
+      let currentPoint = startPoint;
+      const usedSegments = new Set<number>();
 
-    while (
+      while (
       connectedPath.length === 0 ||
       turf.distance(
         turf.point(connectedPath[connectedPath.length - 1]),
@@ -897,22 +901,23 @@ export async function getStreetSectionGeometry(
       }
     }
 
-    if (connectedPath.length >= 2) {
-      logger.info("Connected segments into path", {
-        segments: usedSegments.size,
-        points: connectedPath.length,
-      });
-      return connectedPath;
-    }
+      if (connectedPath.length >= 2) {
+        logger.info("Connected segments into path", {
+          segments: usedSegments.size,
+          points: connectedPath.length,
+        });
+        return connectedPath;
+      }
 
-    logger.info("Could not extract street section");
-    return null;
-  } catch (error) {
-    logger.error("Error getting street section geometry", {
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return null;
-  }
+      logger.info("Could not extract street section");
+      return null;
+    } catch (error) {
+      logger.error("Error getting street section geometry", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return null;
+    }
+  });
 }
 
 /**
@@ -1030,38 +1035,40 @@ export async function overpassGeocodeAddresses(
     return mockService.overpassGeocodeAddresses(addresses);
   }
 
-  const results: Address[] = [];
+  return runWithDeferredRetryScope(async () => {
+    const results: Address[] = [];
 
-  for (let i = 0; i < addresses.length; i++) {
-    const address = addresses[i];
+    for (let i = 0; i < addresses.length; i++) {
+      const address = addresses[i];
 
-    try {
-      const coords = await resolveSingleAddress(address);
-      if (coords) {
-        results.push({
-          originalText: address,
-          formattedAddress: address,
-          coordinates: coords,
-          geoJson: {
-            type: "Point",
-            coordinates: [coords.lng, coords.lat],
-          },
+      try {
+        const coords = await resolveSingleAddress(address);
+        if (coords) {
+          results.push({
+            originalText: address,
+            formattedAddress: address,
+            coordinates: coords,
+            geoJson: {
+              type: "Point",
+              coordinates: [coords.lng, coords.lat],
+            },
+          });
+        } else {
+          logger.warn("Failed to geocode address", { address });
+        }
+      } catch (error) {
+        logger.error("Error geocoding address", {
+          address,
+          error: error instanceof Error ? error.message : String(error),
         });
-      } else {
-        logger.warn("Failed to geocode address", { address });
       }
-    } catch (error) {
-      logger.error("Error geocoding address", {
-        address,
-        error: error instanceof Error ? error.message : String(error),
-      });
+
+      // Rate limiting
+      if (i < addresses.length - 1) {
+        await delay(OVERPASS_DELAY_MS);
+      }
     }
 
-    // Rate limiting
-    if (i < addresses.length - 1) {
-      await delay(OVERPASS_DELAY_MS);
-    }
-  }
-
-  return results;
+    return results;
+  });
 }

--- a/ingest/geocoding/overpass/service.ts
+++ b/ingest/geocoding/overpass/service.ts
@@ -52,10 +52,19 @@ function getStreetFeatureType(streetName: string): StreetGeometryFeatureType {
 
 // In-memory cache for street geometry lookups (keyed on type + normalized street name)
 const streetGeometryCache = new Map<string, Feature<MultiLineString> | null>();
+const deferredStreetGeometryKeys = new Set<string>();
+
+function getStreetGeometryCacheKey(streetName: string): string {
+  return makeStreetGeometryCacheKey(
+    getStreetFeatureType(streetName),
+    normalizeStreetName(streetName),
+  );
+}
 
 /** Clear the street geometry cache. Exported for test isolation. */
 export function clearStreetGeometryCache(): void {
   streetGeometryCache.clear();
+  deferredStreetGeometryKeys.clear();
 }
 
 /**
@@ -65,10 +74,7 @@ export function clearStreetGeometryCache(): void {
 export function getStreetGeometryCached(
   streetName: string,
 ): Feature<MultiLineString> | null {
-  const cacheKey = makeStreetGeometryCacheKey(
-    getStreetFeatureType(streetName),
-    normalizeStreetName(streetName),
-  );
+  const cacheKey = getStreetGeometryCacheKey(streetName);
   return streetGeometryCache.get(cacheKey) ?? null;
 }
 
@@ -78,12 +84,7 @@ export function getStreetGeometryCached(
  * delay is needed before a subsequent Overpass call.
  */
 export function hasStreetGeometryQueried(streetName: string): boolean {
-  return streetGeometryCache.has(
-    makeStreetGeometryCacheKey(
-      getStreetFeatureType(streetName),
-      normalizeStreetName(streetName),
-    ),
-  );
+  return streetGeometryCache.has(getStreetGeometryCacheKey(streetName));
 }
 
 /**
@@ -102,6 +103,29 @@ export function seedStreetGeometryCache(
       streetGeometryCache.set(cacheKey, geometry);
     }
   }
+}
+
+function isStreetGeometryDeferred(streetName: string): boolean {
+  return deferredStreetGeometryKeys.has(getStreetGeometryCacheKey(streetName));
+}
+
+function clearDeferredStreetGeometryKeys(): void {
+  deferredStreetGeometryKeys.clear();
+}
+
+function parseIntersectionStreetNames(intersection: string): [string, string] {
+  const [street1Name = "", street2Name = ""] = intersection
+    .split("\u2229")
+    .map((s) => s.trim());
+  return [street1Name, street2Name];
+}
+
+function shouldRetryIntersectionLater(intersection: string): boolean {
+  const [street1Name, street2Name] = parseIntersectionStreetNames(intersection);
+  return (
+    (Boolean(street1Name) && isStreetGeometryDeferred(street1Name)) ||
+    (Boolean(street2Name) && isStreetGeometryDeferred(street2Name))
+  );
 }
 
 /**
@@ -200,6 +224,13 @@ export function toOverpassRegex(normalizedName: string): string {
 export async function getStreetGeometryFromOverpass(
   streetName: string,
 ): Promise<Feature<MultiLineString> | null> {
+  const cacheKey = getStreetGeometryCacheKey(streetName);
+
+  if (deferredStreetGeometryKeys.has(cacheKey)) {
+    logger.debug("Street geometry deferred for retry", { streetName });
+    return null;
+  }
+
   try {
     // Normalize street name for better OSM matching
     const normalizedName = normalizeStreetName(streetName);
@@ -210,8 +241,6 @@ export async function getStreetGeometryFromOverpass(
     const featureType = getStreetFeatureType(streetName);
     const isSquare = featureType === "square";
     const isStreet = featureType === "street";
-    const cacheKey = makeStreetGeometryCacheKey(featureType, normalizedName);
-
     // Return cached result if available (includes null for streets not found in OSM)
     if (streetGeometryCache.has(cacheKey)) {
       logger.debug("Street geometry cache hit", { streetName, normalizedName });
@@ -354,6 +383,7 @@ export async function getStreetGeometryFromOverpass(
       // No OSM ways found - API request succeeded but no data for this street name
       logger.info("Could not find street in OSM", { streetName });
       streetGeometryCache.set(cacheKey, null);
+      deferredStreetGeometryKeys.delete(cacheKey);
       return null;
     }
 
@@ -397,6 +427,7 @@ export async function getStreetGeometryFromOverpass(
     if (lineStrings.length === 0) {
       logger.info("No valid geometries in response", { streetName });
       streetGeometryCache.set(cacheKey, null);
+      deferredStreetGeometryKeys.delete(cacheKey);
       return null;
     }
 
@@ -416,12 +447,24 @@ export async function getStreetGeometryFromOverpass(
     };
 
     streetGeometryCache.set(cacheKey, multiLineString);
+    deferredStreetGeometryKeys.delete(cacheKey);
     return multiLineString;
   } catch (error) {
+    const err = error instanceof Error ? error : new Error(String(error));
     logger.error("Error fetching from Overpass", {
       streetName,
-      error: error instanceof Error ? error.message : String(error),
+      error: err.message,
     });
+
+    if (shouldTryFallback(err)) {
+      deferredStreetGeometryKeys.add(cacheKey);
+      logger.info("Deferring street geometry after transient failure", {
+        streetName,
+      });
+      return null;
+    }
+
+    streetGeometryCache.set(cacheKey, null);
     return null;
   }
 }
@@ -559,9 +602,7 @@ function findGeometricIntersection(
 async function geocodeSingleIntersection(
   intersection: string,
 ): Promise<Address | null> {
-  const [street1Name, street2Name] = intersection
-    .split("∩")
-    .map((s) => s.trim());
+  const [street1Name, street2Name] = parseIntersectionStreetNames(intersection);
 
   if (!street1Name || !street2Name) {
     logger.error("Invalid intersection format", { intersection });
@@ -606,23 +647,45 @@ export async function overpassGeocodeIntersections(
   }
 
   const results: Address[] = [];
+  const retryIntersections: string[] = [];
 
-  for (let i = 0; i < intersections.length; i++) {
-    const intersection = intersections[i];
-    try {
-      const result = await geocodeSingleIntersection(intersection);
-      if (result) results.push(result);
-    } catch (error) {
-      logger.error("Error processing intersection", {
-        intersection,
-        error: error instanceof Error ? error.message : String(error),
-      });
-    }
+  async function processIntersections(
+    queue: string[],
+    collectRetryCandidates: boolean,
+  ): Promise<void> {
+    for (let i = 0; i < queue.length; i++) {
+      const intersection = queue[i];
+      try {
+        const result = await geocodeSingleIntersection(intersection);
+        if (result) {
+          results.push(result);
+        } else if (
+          collectRetryCandidates &&
+          shouldRetryIntersectionLater(intersection)
+        ) {
+          retryIntersections.push(intersection);
+        }
+      } catch (error) {
+        logger.error("Error processing intersection", {
+          intersection,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
 
-    // Rate limiting between requests
-    if (i < intersections.length - 1) {
-      await delay(OVERPASS_DELAY_MS);
+      if (i < queue.length - 1) {
+        await delay(OVERPASS_DELAY_MS);
+      }
     }
+  }
+
+  await processIntersections(intersections, true);
+
+  if (retryIntersections.length > 0) {
+    logger.info("Retrying deferred intersections", {
+      count: retryIntersections.length,
+    });
+    clearDeferredStreetGeometryKeys();
+    await processIntersections(retryIntersections, false);
   }
 
   return results;

--- a/ingest/geocoding/overpass/service.ts
+++ b/ingest/geocoding/overpass/service.ts
@@ -53,6 +53,7 @@ function getStreetFeatureType(streetName: string): StreetGeometryFeatureType {
 // In-memory cache for street geometry lookups (keyed on type + normalized street name)
 const streetGeometryCache = new Map<string, Feature<MultiLineString> | null>();
 const deferredStreetGeometryKeys = new Set<string>();
+let deferredScopeDepth = 0;
 
 function getStreetGeometryCacheKey(streetName: string): string {
   return makeStreetGeometryCacheKey(
@@ -84,7 +85,10 @@ export function getStreetGeometryCached(
  * delay is needed before a subsequent Overpass call.
  */
 export function hasStreetGeometryQueried(streetName: string): boolean {
-  return streetGeometryCache.has(getStreetGeometryCacheKey(streetName));
+  const cacheKey = getStreetGeometryCacheKey(streetName);
+  return (
+    streetGeometryCache.has(cacheKey) || deferredStreetGeometryKeys.has(cacheKey)
+  );
 }
 
 /**
@@ -111,6 +115,25 @@ function isStreetGeometryDeferred(streetName: string): boolean {
 
 function clearDeferredStreetGeometryKeys(): void {
   deferredStreetGeometryKeys.clear();
+}
+
+async function runWithDeferredRetryScope<T>(
+  work: () => Promise<T>,
+): Promise<T> {
+  const isRootScope = deferredScopeDepth === 0;
+  if (isRootScope) {
+    clearDeferredStreetGeometryKeys();
+  }
+
+  deferredScopeDepth += 1;
+  try {
+    return await work();
+  } finally {
+    deferredScopeDepth -= 1;
+    if (isRootScope) {
+      clearDeferredStreetGeometryKeys();
+    }
+  }
 }
 
 function parseIntersectionStreetNames(intersection: string): [string, string] {
@@ -226,7 +249,7 @@ export async function getStreetGeometryFromOverpass(
 ): Promise<Feature<MultiLineString> | null> {
   const cacheKey = getStreetGeometryCacheKey(streetName);
 
-  if (deferredStreetGeometryKeys.has(cacheKey)) {
+  if (deferredScopeDepth > 0 && deferredStreetGeometryKeys.has(cacheKey)) {
     logger.debug("Street geometry deferred for retry", { streetName });
     return null;
   }
@@ -457,10 +480,12 @@ export async function getStreetGeometryFromOverpass(
     });
 
     if (shouldTryFallback(err)) {
-      deferredStreetGeometryKeys.add(cacheKey);
-      logger.info("Deferring street geometry after transient failure", {
-        streetName,
-      });
+      if (deferredScopeDepth > 0) {
+        deferredStreetGeometryKeys.add(cacheKey);
+        logger.info("Deferring street geometry after transient failure", {
+          streetName,
+        });
+      }
       return null;
     }
 
@@ -646,49 +671,51 @@ export async function overpassGeocodeIntersections(
     return mockService.overpassGeocodeIntersections(intersections);
   }
 
-  const results: Address[] = [];
-  const retryIntersections: string[] = [];
+  return runWithDeferredRetryScope(async () => {
+    const results: Address[] = [];
+    const retryIntersections: string[] = [];
 
-  async function processIntersections(
-    queue: string[],
-    collectRetryCandidates: boolean,
-  ): Promise<void> {
-    for (let i = 0; i < queue.length; i++) {
-      const intersection = queue[i];
-      try {
-        const result = await geocodeSingleIntersection(intersection);
-        if (result) {
-          results.push(result);
-        } else if (
-          collectRetryCandidates &&
-          shouldRetryIntersectionLater(intersection)
-        ) {
-          retryIntersections.push(intersection);
+    async function processIntersections(
+      queue: string[],
+      collectRetryCandidates: boolean,
+    ): Promise<void> {
+      for (let i = 0; i < queue.length; i++) {
+        const intersection = queue[i];
+        try {
+          const result = await geocodeSingleIntersection(intersection);
+          if (result) {
+            results.push(result);
+          } else if (
+            collectRetryCandidates &&
+            shouldRetryIntersectionLater(intersection)
+          ) {
+            retryIntersections.push(intersection);
+          }
+        } catch (error) {
+          logger.error("Error processing intersection", {
+            intersection,
+            error: error instanceof Error ? error.message : String(error),
+          });
         }
-      } catch (error) {
-        logger.error("Error processing intersection", {
-          intersection,
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
 
-      if (i < queue.length - 1) {
-        await delay(OVERPASS_DELAY_MS);
+        if (i < queue.length - 1) {
+          await delay(OVERPASS_DELAY_MS);
+        }
       }
     }
-  }
 
-  await processIntersections(intersections, true);
+    await processIntersections(intersections, true);
 
-  if (retryIntersections.length > 0) {
-    logger.info("Retrying deferred intersections", {
-      count: retryIntersections.length,
-    });
-    clearDeferredStreetGeometryKeys();
-    await processIntersections(retryIntersections, false);
-  }
+    if (retryIntersections.length > 0) {
+      logger.info("Retrying deferred intersections", {
+        count: retryIntersections.length,
+      });
+      clearDeferredStreetGeometryKeys();
+      await processIntersections(retryIntersections, false);
+    }
 
-  return results;
+    return results;
+  });
 }
 
 /**

--- a/ingest/geocoding/overpass/service.ts
+++ b/ingest/geocoding/overpass/service.ts
@@ -193,6 +193,8 @@ function shouldTryFallback(error: Error, statusCode?: number): boolean {
   return true;
 }
 
+type ErrorWithStatusCode = Error & { statusCode?: number };
+
 // Multiple Overpass API instances for fallback
 const OVERPASS_INSTANCES = [
   "https://overpass.private.coffee/api/interpreter", // No rate limit
@@ -334,7 +336,10 @@ export async function getStreetGeometryFromOverpass(
           // Try to extract XML error message
           const text = await response.text();
           const errorMsg = parseOverpassError(text) || response.statusText;
-          const error = new Error(`HTTP ${response.status}: ${errorMsg}`);
+          const error: ErrorWithStatusCode = new Error(
+            `HTTP ${response.status}: ${errorMsg}`,
+          );
+          error.statusCode = response.status;
 
           if (!shouldTryFallback(error, response.status)) {
             // Client-side error - don't try other servers
@@ -374,10 +379,11 @@ export async function getStreetGeometryFromOverpass(
       } catch (error) {
         clearTimeout(timeoutId);
 
-        const err = error instanceof Error ? error : new Error(String(error));
+        const err: ErrorWithStatusCode =
+          error instanceof Error ? error : new Error(String(error));
 
         // Check if this is a client-side error
-        if (!shouldTryFallback(err)) {
+        if (!shouldTryFallback(err, err.statusCode)) {
           logger.error("Client error (query issue)", { error: err.message });
           throw err;
         }
@@ -473,13 +479,14 @@ export async function getStreetGeometryFromOverpass(
     deferredStreetGeometryKeys.delete(cacheKey);
     return multiLineString;
   } catch (error) {
-    const err = error instanceof Error ? error : new Error(String(error));
+    const err: ErrorWithStatusCode =
+      error instanceof Error ? error : new Error(String(error));
     logger.error("Error fetching from Overpass", {
       streetName,
       error: err.message,
     });
 
-    if (shouldTryFallback(err)) {
+    if (shouldTryFallback(err, err.statusCode)) {
       if (deferredScopeDepth > 0) {
         deferredStreetGeometryKeys.add(cacheKey);
         logger.info("Deferring street geometry after transient failure", {


### PR DESCRIPTION
## Summary\n- treat transient Overpass/network failures as deferred instead of not-found\n- add a deferred street queue and retry deferred intersections at the end of the run\n- keep null caching only for definitive not-found outcomes\n- add regression coverage for transient failure retry behavior\n\n## Testing\n- runTests: ingest/geocoding/overpass/service.test.ts (49 passed)\n- pnpm exec tsc --noEmit -p ingest/tsconfig.json

refs #348