### PR TITLE
fix(ingest): adaptive retry backoff and circuit breaker for Overpass saturation

### DIFF
--- a/ingest/geocoding/overpass/README.md
+++ b/ingest/geocoding/overpass/README.md
@@ -14,12 +14,41 @@ Retrieves street geometries and calculates intersection points from OpenStreetMa
 
 ## Multiple Servers
 
-Uses fallback chain with 4 OpenStreetMap Overpass servers for reliability:
+Uses a two-instance fallback chain for reliability:
 
 1. **Primary**: overpass.private.coffee (no rate limit applied)
-2. **Fallback servers**: Automatically retried on failure
+2. **Fallback**: overpass-api.de (main instance, ~10k queries/day)
 
-**Auto-Retry**: Requests failing on primary server automatically retry on fallback servers.
+Requests failing on the primary server automatically fall through to the fallback.
+
+## Adaptive Retry Policy
+
+For transient failures on a single instance (429 Too Many Requests or request timeouts), the service retries the **same instance** up to `OVERPASS_RETRY_MAX_ATTEMPTS = 3` times before falling back to the next instance.
+
+**Backoff**: exponential with ±25% jitter, starting at 1 s, capped at 30 s.
+
+```
+attempt 1 → fail → wait ~1s
+attempt 2 → fail → wait ~2s
+attempt 3 → fail → move to next instance
+```
+
+**`Retry-After` header**: honoured on 429 responses (supports both delta-seconds and HTTP-date formats, capped at 30 s).
+
+Other transient errors (5xx, network errors) skip per-instance retry and immediately try the next instance.
+
+## Run-Scoped Circuit Breaker
+
+To prevent a saturated run from hammering Overpass with hundreds of failing requests, each geocoding run tracks consecutive transient failures via `AsyncLocalStorage`.
+
+After **`CIRCUIT_BREAKER_THRESHOLD = 5`** consecutive transient failures:
+- The circuit opens for the current run.
+- Subsequent street geometry lookups are **deferred** (no network call) until the retry pass.
+- The circuit **resets** on the first successful response.
+
+The two-pass structure of `overpassGeocodeIntersections` naturally accommodates this: the first pass collects deferred streets, the circuit resets, and deferred streets are retried in the second pass.
+
+Cached streets (already in memory from a previous lookup) are **always served** regardless of circuit state — no network call needed.
 
 ## Street Name Normalization
 

--- a/ingest/geocoding/overpass/README.md
+++ b/ingest/geocoding/overpass/README.md
@@ -42,6 +42,7 @@ Other transient errors (5xx, network errors) skip per-instance retry and immedia
 To prevent a saturated run from hammering Overpass with hundreds of failing requests, each geocoding run tracks consecutive transient failures via `AsyncLocalStorage`.
 
 After **`CIRCUIT_BREAKER_THRESHOLD = 5`** consecutive transient failures:
+
 - The circuit opens for the current run.
 - Subsequent street geometry lookups are **deferred** (no network call) until the retry pass.
 - The circuit **resets** on the first successful response.

--- a/ingest/geocoding/overpass/service.test.ts
+++ b/ingest/geocoding/overpass/service.test.ts
@@ -5,7 +5,9 @@ import {
   toOverpassRegex,
   clearStreetGeometryCache,
   overpassGeocodeIntersections,
+  CIRCUIT_BREAKER_THRESHOLD,
 } from "./service";
+import { delay } from "../../lib/delay";
 
 // Prevent the 500ms inter-item delay from slowing down the test suite
 vi.mock("../../lib/delay", () => ({ delay: vi.fn().mockResolvedValue(undefined) }));
@@ -416,6 +418,149 @@ describe("overpass-geocoding-service", () => {
       // Both streets were cleared — should fetch them again
       await overpassGeocodeIntersections(["ул. Пример ∩ ул. Фоо"]);
       expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    describe("adaptive retry policy", () => {
+      const OVERPASS_INSTANCES_COUNT = 2; // number of instances in OVERPASS_INSTANCES
+
+      it("retries 429 on the same instance with backoff before falling back to the next", async () => {
+        // Instance 1 (private.coffee) always returns 429; instance 2 succeeds
+        let instance1Calls = 0;
+        let instance2Calls = 0;
+        vi.stubGlobal(
+          "fetch",
+          vi.fn(async (url: string | URL) => {
+            if (String(url).includes("private.coffee")) {
+              instance1Calls++;
+              return {
+                ok: false,
+                status: 429,
+                statusText: "Too Many Requests",
+                headers: { get: (_: string) => null },
+                text: () => Promise.resolve(""),
+              };
+            }
+            instance2Calls++;
+            return { ok: true, text: () => Promise.resolve(wayResponse) };
+          }),
+        );
+
+        const results = await overpassGeocodeIntersections(["ул. Пример ∩ ул. Фоо"]);
+
+        // 2 streets × OVERPASS_RETRY_MAX_ATTEMPTS retries on instance1 before fallback
+        expect(instance1Calls).toBeGreaterThan(OVERPASS_INSTANCES_COUNT);
+        // Instance 2 handles both streets after instance 1 exhausts its attempts
+        expect(instance2Calls).toBe(2);
+        expect(results).toHaveLength(1);
+      });
+
+      it("respects Retry-After header when backing off on 429", async () => {
+        vi.mocked(delay).mockClear();
+        let fetchCount = 0;
+        vi.stubGlobal(
+          "fetch",
+          vi.fn(async (url: string | URL) => {
+            if (String(url).includes("private.coffee") && fetchCount++ === 0) {
+              return {
+                ok: false,
+                status: 429,
+                statusText: "Too Many Requests",
+                headers: { get: (name: string) => (name === "Retry-After" ? "3" : null) },
+                text: () => Promise.resolve(""),
+              };
+            }
+            return { ok: true, text: () => Promise.resolve(wayResponse) };
+          }),
+        );
+
+        await overpassGeocodeIntersections(["ул. Пример ∩ ул. Фоо"]);
+
+        // delay must have been called with exactly 3000 ms for the Retry-After header
+        const delayCalls = vi.mocked(delay).mock.calls.map(([ms]) => ms);
+        expect(delayCalls).toContain(3000);
+      });
+
+      it("retries AbortError (timeout) on the same instance with backoff", async () => {
+        // Instance 1 always times out; instance 2 succeeds
+        let instance1Calls = 0;
+        let instance2Calls = 0;
+        vi.stubGlobal(
+          "fetch",
+          vi.fn(async (url: string | URL) => {
+            if (String(url).includes("private.coffee")) {
+              instance1Calls++;
+              const err = new Error("The operation was aborted");
+              err.name = "AbortError";
+              throw err;
+            }
+            instance2Calls++;
+            return { ok: true, text: () => Promise.resolve(wayResponse) };
+          }),
+        );
+
+        const results = await overpassGeocodeIntersections(["ул. Пример ∩ ул. Фоо"]);
+
+        expect(instance1Calls).toBeGreaterThan(OVERPASS_INSTANCES_COUNT);
+        expect(instance2Calls).toBe(2);
+        expect(results).toHaveLength(1);
+      });
+    });
+
+    describe("circuit breaker", () => {
+      it("opens after threshold consecutive transient failures and defers remaining streets", async () => {
+        vi.stubGlobal(
+          "fetch",
+          vi.fn().mockRejectedValue(new Error("Network request failed")),
+        );
+
+        // Enough unique intersections to exceed the threshold (each has 2 unique streets)
+        const intersections = Array.from(
+          { length: CIRCUIT_BREAKER_THRESHOLD + 2 },
+          (_, i) => `ул. А${i} ∩ ул. Б${i}`,
+        );
+
+        await overpassGeocodeIntersections(intersections);
+
+        // Without circuit breaker every street would be tried on all instances.
+        // With circuit breaker, only (threshold) failures fire before the circuit opens.
+        // Each failure = 1 street × 2 instances (no per-instance retry for plain network errors).
+        const maxExpectedCalls = CIRCUIT_BREAKER_THRESHOLD * 2; // × 2 passes
+        expect(vi.mocked(fetch).mock.calls.length).toBeLessThan(
+          intersections.length * 2 * 2,
+        );
+        expect(vi.mocked(fetch).mock.calls.length).toBeLessThanOrEqual(
+          maxExpectedCalls * 2, // retry pass also resets and can trip again
+        );
+      });
+
+      it("resets after a successful request so subsequent streets are attempted", async () => {
+        // All instances fail for the first street (circuit will open at threshold),
+        // then instance 2 starts succeeding — circuit should reset on first success.
+        let fetchCallCount = 0;
+        vi.stubGlobal(
+          "fetch",
+          vi.fn(async (url: string | URL) => {
+            fetchCallCount++;
+            // First CIRCUIT_BREAKER_THRESHOLD * 2 calls (threshold streets × 2 instances) fail
+            if (fetchCallCount <= CIRCUIT_BREAKER_THRESHOLD * 2) {
+              throw new Error("Network request failed");
+            }
+            return { ok: true, text: () => Promise.resolve(wayResponse) };
+          }),
+        );
+
+        // Provide threshold+2 intersections: first threshold streets fail (trip circuit),
+        // retry pass resets circuit — the retry streets should now succeed
+        const intersections = Array.from(
+          { length: CIRCUIT_BREAKER_THRESHOLD + 2 },
+          (_, i) => `ул. А${i} ∩ ул. Б${i}`,
+        );
+
+        const results = await overpassGeocodeIntersections(intersections);
+
+        // After the circuit resets, some intersections should be resolved
+        expect(results.length).toBeGreaterThan(0);
+      });
     });
   });
 });

--- a/ingest/geocoding/overpass/service.test.ts
+++ b/ingest/geocoding/overpass/service.test.ts
@@ -16,7 +16,9 @@ import {
 import { delay } from "../../lib/delay";
 
 // Prevent the 500ms inter-item delay from slowing down the test suite
-vi.mock("../../lib/delay", () => ({ delay: vi.fn().mockResolvedValue(undefined) }));
+vi.mock("../../lib/delay", () => ({
+  delay: vi.fn().mockResolvedValue(undefined),
+}));
 
 describe("overpass-geocoding-service", () => {
   describe("parseOverpassError", () => {
@@ -393,7 +395,9 @@ describe("overpass-geocoding-service", () => {
 
     it("caps at OVERPASS_RETRY_MAX_DELAY_MS for large attempt numbers", () => {
       for (let i = 0; i < 10; i++) {
-        expect(calculateRetryDelayMs(20, null)).toBe(OVERPASS_RETRY_MAX_DELAY_MS);
+        expect(calculateRetryDelayMs(20, null)).toBe(
+          OVERPASS_RETRY_MAX_DELAY_MS,
+        );
       }
     });
   });
@@ -429,22 +433,25 @@ describe("overpass-geocoding-service", () => {
 
     it("retries deferred intersections after transient network failures", async () => {
       const attemptsByInstanceAndQuery = new Map<string, number>();
-      const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
-        const instance = input instanceof URL ? input.toString() : String(input);
-        const query = typeof init?.body === "string" ? init.body : "";
-        const key = `${instance}|${query}`;
-        const attempts = attemptsByInstanceAndQuery.get(key) ?? 0;
-        attemptsByInstanceAndQuery.set(key, attempts + 1);
+      const fetchMock = vi.fn(
+        async (input: string | URL, init?: RequestInit) => {
+          const instance =
+            input instanceof URL ? input.toString() : String(input);
+          const query = typeof init?.body === "string" ? init.body : "";
+          const key = `${instance}|${query}`;
+          const attempts = attemptsByInstanceAndQuery.get(key) ?? 0;
+          attemptsByInstanceAndQuery.set(key, attempts + 1);
 
-        if (attempts === 0) {
-          throw new Error("Network request failed");
-        }
+          if (attempts === 0) {
+            throw new Error("Network request failed");
+          }
 
-        return {
-          ok: true,
-          text: () => Promise.resolve(wayResponse),
-        };
-      });
+          return {
+            ok: true,
+            text: () => Promise.resolve(wayResponse),
+          };
+        },
+      );
       vi.stubGlobal("fetch", fetchMock);
 
       const results = await overpassGeocodeIntersections([
@@ -536,7 +543,9 @@ describe("overpass-geocoding-service", () => {
           }),
         );
 
-        const results = await overpassGeocodeIntersections(["ул. Пример ∩ ул. Фоо"]);
+        const results = await overpassGeocodeIntersections([
+          "ул. Пример ∩ ул. Фоо",
+        ]);
 
         // 2 streets, each exhausts OVERPASS_RETRY_MAX_ATTEMPTS on instance 1 before falling back
         expect(instance1Calls).toBe(OVERPASS_RETRY_MAX_ATTEMPTS * 2);
@@ -556,7 +565,9 @@ describe("overpass-geocoding-service", () => {
                 ok: false,
                 status: 429,
                 statusText: "Too Many Requests",
-                headers: { get: (name: string) => (name === "Retry-After" ? "3" : null) },
+                headers: {
+                  get: (name: string) => (name === "Retry-After" ? "3" : null),
+                },
                 text: () => Promise.resolve(""),
               };
             }
@@ -589,7 +600,9 @@ describe("overpass-geocoding-service", () => {
           }),
         );
 
-        const results = await overpassGeocodeIntersections(["ул. Пример ∩ ул. Фоо"]);
+        const results = await overpassGeocodeIntersections([
+          "ул. Пример ∩ ул. Фоо",
+        ]);
 
         // 2 streets, each exhausts OVERPASS_RETRY_MAX_ATTEMPTS on instance 1 before falling back
         expect(instance1Calls).toBe(OVERPASS_RETRY_MAX_ATTEMPTS * 2);
@@ -616,7 +629,8 @@ describe("overpass-geocoding-service", () => {
         // Without circuit breaker every street would be tried on every instance in both passes.
         // With circuit breaker, at most threshold × instances calls occur per pass before it opens.
         const overpassInstanceCount = OVERPASS_INSTANCES.length;
-        const maxExpectedCallsPerPass = CIRCUIT_BREAKER_THRESHOLD * overpassInstanceCount;
+        const maxExpectedCallsPerPass =
+          CIRCUIT_BREAKER_THRESHOLD * overpassInstanceCount;
         expect(vi.mocked(fetch).mock.calls.length).toBeLessThan(
           intersections.length * 2 * overpassInstanceCount,
         );
@@ -635,7 +649,10 @@ describe("overpass-geocoding-service", () => {
           vi.fn(async (url: string | URL) => {
             fetchCallCount++;
             // First threshold × instances calls fail (enough to open the circuit)
-            if (fetchCallCount <= CIRCUIT_BREAKER_THRESHOLD * overpassInstanceCount) {
+            if (
+              fetchCallCount <=
+              CIRCUIT_BREAKER_THRESHOLD * overpassInstanceCount
+            ) {
               throw new Error("Network request failed");
             }
             return { ok: true, text: () => Promise.resolve(wayResponse) };

--- a/ingest/geocoding/overpass/service.test.ts
+++ b/ingest/geocoding/overpass/service.test.ts
@@ -8,6 +8,10 @@ import {
   CIRCUIT_BREAKER_THRESHOLD,
   OVERPASS_INSTANCES,
   OVERPASS_RETRY_MAX_ATTEMPTS,
+  OVERPASS_RETRY_BASE_DELAY_MS,
+  OVERPASS_RETRY_MAX_DELAY_MS,
+  parseRetryAfterMs,
+  calculateRetryDelayMs,
 } from "./service";
 import { delay } from "../../lib/delay";
 
@@ -304,6 +308,93 @@ describe("overpass-geocoding-service", () => {
       expect(normalizeAddressForNominatim("бл. 12, ж.к. Младост")).toBe(
         "бл. 12, ж.к. Младост",
       );
+    });
+  });
+
+  describe("parseRetryAfterMs", () => {
+    it("returns null for null header", () => {
+      expect(parseRetryAfterMs(null)).toBeNull();
+    });
+
+    it("returns null for empty string", () => {
+      expect(parseRetryAfterMs("")).toBeNull();
+      expect(parseRetryAfterMs("   ")).toBeNull();
+    });
+
+    it("parses delta-seconds correctly", () => {
+      expect(parseRetryAfterMs("3")).toBe(3_000);
+      expect(parseRetryAfterMs("0")).toBe(0);
+    });
+
+    it("caps delta-seconds at OVERPASS_RETRY_MAX_DELAY_MS", () => {
+      expect(parseRetryAfterMs("9999")).toBe(OVERPASS_RETRY_MAX_DELAY_MS);
+    });
+
+    it("returns 0 for a past HTTP-date", () => {
+      const pastDate = new Date(Date.now() - 60_000).toUTCString();
+      expect(parseRetryAfterMs(pastDate)).toBe(0);
+    });
+
+    it("returns a positive delta for a future HTTP-date, capped at max", () => {
+      const farFuture = new Date(Date.now() + 999_999_999).toUTCString();
+      expect(parseRetryAfterMs(farFuture)).toBe(OVERPASS_RETRY_MAX_DELAY_MS);
+    });
+
+    it("returns the correct delta for a near-future HTTP-date", () => {
+      const targetDelayMs = 10_000;
+      const futureDate = new Date(Date.now() + targetDelayMs).toUTCString();
+      const result = parseRetryAfterMs(futureDate);
+      // Allow ±500ms tolerance for execution time
+      expect(result).toBeGreaterThanOrEqual(targetDelayMs - 500);
+      expect(result).toBeLessThanOrEqual(targetDelayMs);
+    });
+
+    it("returns null for a malformed string", () => {
+      expect(parseRetryAfterMs("not-a-date")).toBeNull();
+    });
+
+    it("returns 0 for a string that parses as an epoch/past date", () => {
+      // "-1" is treated as a past HTTP-date (epoch minus 1ms) → clamped to 0
+      expect(parseRetryAfterMs("-1")).toBe(0);
+    });
+  });
+
+  describe("calculateRetryDelayMs", () => {
+    it("returns retryAfterMs directly when provided", () => {
+      expect(calculateRetryDelayMs(1, 5_000)).toBe(5_000);
+      expect(calculateRetryDelayMs(2, 0)).toBe(0);
+    });
+
+    it("caps retryAfterMs at OVERPASS_RETRY_MAX_DELAY_MS", () => {
+      expect(calculateRetryDelayMs(1, OVERPASS_RETRY_MAX_DELAY_MS + 1)).toBe(
+        OVERPASS_RETRY_MAX_DELAY_MS,
+      );
+    });
+
+    it("attempt 1 falls within [BASE * 0.75, BASE * 1.25]", () => {
+      for (let i = 0; i < 20; i++) {
+        const result = calculateRetryDelayMs(1, null);
+        expect(result).toBeGreaterThanOrEqual(
+          Math.round(OVERPASS_RETRY_BASE_DELAY_MS * 0.75),
+        );
+        expect(result).toBeLessThanOrEqual(
+          Math.round(OVERPASS_RETRY_BASE_DELAY_MS * 1.25),
+        );
+      }
+    });
+
+    it("attempt 2 has a larger base than attempt 1 (exponential growth)", () => {
+      // With ±25% jitter: attempt1 max = BASE*1.25 = 1250, attempt2 min = BASE*2*0.75 = 1500
+      // Ranges do not overlap, so a single sample suffices for a range check
+      const attempt1Max = Math.round(OVERPASS_RETRY_BASE_DELAY_MS * 1.25);
+      const attempt2Min = Math.round(OVERPASS_RETRY_BASE_DELAY_MS * 2 * 0.75);
+      expect(attempt2Min).toBeGreaterThan(attempt1Max);
+    });
+
+    it("caps at OVERPASS_RETRY_MAX_DELAY_MS for large attempt numbers", () => {
+      for (let i = 0; i < 10; i++) {
+        expect(calculateRetryDelayMs(20, null)).toBe(OVERPASS_RETRY_MAX_DELAY_MS);
+      }
     });
   });
 

--- a/ingest/geocoding/overpass/service.test.ts
+++ b/ingest/geocoding/overpass/service.test.ts
@@ -355,9 +355,11 @@ describe("overpass-geocoding-service", () => {
       expect(parseRetryAfterMs("not-a-date")).toBeNull();
     });
 
-    it("returns 0 for a string that parses as an epoch/past date", () => {
-      // "-1" is treated as a past HTTP-date (epoch minus 1ms) → clamped to 0
-      expect(parseRetryAfterMs("-1")).toBe(0);
+    it("returns null for strings that are not IMF-fixdate (strict RFC 7231 format)", () => {
+      // ISO 8601 — accepted by Date.parse but not a valid Retry-After HTTP-date
+      expect(parseRetryAfterMs("2026-04-05T12:34:56Z")).toBeNull();
+      // Raw number with sign — not delta-seconds, not IMF-fixdate
+      expect(parseRetryAfterMs("-1")).toBeNull();
     });
   });
 

--- a/ingest/geocoding/overpass/service.test.ts
+++ b/ingest/geocoding/overpass/service.test.ts
@@ -344,8 +344,8 @@ describe("overpass-geocoding-service", () => {
       const targetDelayMs = 10_000;
       const futureDate = new Date(Date.now() + targetDelayMs).toUTCString();
       const result = parseRetryAfterMs(futureDate);
-      // Allow ±500ms tolerance for execution time
-      expect(result).toBeGreaterThanOrEqual(targetDelayMs - 500);
+      // toUTCString() truncates to second precision; allow up to 1500ms tolerance
+      expect(result).toBeGreaterThanOrEqual(targetDelayMs - 1500);
       expect(result).toBeLessThanOrEqual(targetDelayMs);
     });
 
@@ -613,10 +613,9 @@ describe("overpass-geocoding-service", () => {
 
         await overpassGeocodeIntersections(intersections);
 
-        // This test assumes the current production configuration uses 2 Overpass instances.
-        const overpassInstanceCount = 2;
         // Without circuit breaker every street would be tried on every instance in both passes.
         // With circuit breaker, at most threshold × instances calls occur per pass before it opens.
+        const overpassInstanceCount = OVERPASS_INSTANCES.length;
         const maxExpectedCallsPerPass = CIRCUIT_BREAKER_THRESHOLD * overpassInstanceCount;
         expect(vi.mocked(fetch).mock.calls.length).toBeLessThan(
           intersections.length * 2 * overpassInstanceCount,
@@ -629,7 +628,7 @@ describe("overpass-geocoding-service", () => {
       it("resets after a successful request so subsequent streets are attempted", async () => {
         // All instances fail for the first threshold streets, then requests start succeeding
         // — the circuit should reset on the first successful response.
-        const overpassInstanceCount = 2;
+        const overpassInstanceCount = OVERPASS_INSTANCES.length;
         let fetchCallCount = 0;
         vi.stubGlobal(
           "fetch",

--- a/ingest/geocoding/overpass/service.test.ts
+++ b/ingest/geocoding/overpass/service.test.ts
@@ -584,6 +584,32 @@ describe("overpass-geocoding-service", () => {
         expect(delayCalls).toContain(3000);
       });
 
+      it("falls back to the next instance after all 429 retries are exhausted on the first", async () => {
+        // All instances always return 429 — retries exhaust on each instance,
+        // then fall back, then exhaust again → all instances fail → null result.
+        vi.stubGlobal(
+          "fetch",
+          vi.fn(async () => ({
+            ok: false,
+            status: 429,
+            statusText: "Too Many Requests",
+            headers: { get: (_: string) => null },
+            text: () => Promise.resolve(""),
+          })),
+        );
+
+        const results = await overpassGeocodeIntersections(["ул. Пример ∩ ул. Фоо"]);
+
+        // Each of the 2 streets has 2 unique street names. In pass 1 every instance is
+        // tried with OVERPASS_RETRY_MAX_ATTEMPTS before moving on. All streets are deferred.
+        // In pass 2 the deferred streets are retried with the same exhaustion pattern.
+        const expectedCalls =
+          2 * OVERPASS_INSTANCES.length * OVERPASS_RETRY_MAX_ATTEMPTS * 2; // ×2 passes
+        expect(vi.mocked(fetch).mock.calls.length).toBe(expectedCalls);
+        // No intersection resolved — both streets have null geometry
+        expect(results).toHaveLength(0);
+      });
+
       it("retries AbortError (timeout) on the same instance with backoff", async () => {
         // First instance always times out; second instance succeeds
         let instance1Calls = 0;

--- a/ingest/geocoding/overpass/service.test.ts
+++ b/ingest/geocoding/overpass/service.test.ts
@@ -521,36 +521,38 @@ describe("overpass-geocoding-service", () => {
 
         await overpassGeocodeIntersections(intersections);
 
-        // Without circuit breaker every street would be tried on all instances.
-        // With circuit breaker, only (threshold) failures fire before the circuit opens.
-        // Each failure = 1 street × 2 instances (no per-instance retry for plain network errors).
-        const maxExpectedCalls = CIRCUIT_BREAKER_THRESHOLD * 2; // × 2 passes
+        // This test assumes the current production configuration uses 2 Overpass instances.
+        const overpassInstanceCount = 2;
+        // Without circuit breaker every street would be tried on every instance in both passes.
+        // With circuit breaker, at most threshold × instances calls occur per pass before it opens.
+        const maxExpectedCallsPerPass = CIRCUIT_BREAKER_THRESHOLD * overpassInstanceCount;
         expect(vi.mocked(fetch).mock.calls.length).toBeLessThan(
-          intersections.length * 2 * 2,
+          intersections.length * 2 * overpassInstanceCount,
         );
         expect(vi.mocked(fetch).mock.calls.length).toBeLessThanOrEqual(
-          maxExpectedCalls * 2, // retry pass also resets and can trip again
+          maxExpectedCallsPerPass * 2, // retry pass also resets and can trip again
         );
       });
 
       it("resets after a successful request so subsequent streets are attempted", async () => {
-        // All instances fail for the first street (circuit will open at threshold),
-        // then instance 2 starts succeeding — circuit should reset on first success.
+        // All instances fail for the first threshold streets, then requests start succeeding
+        // — the circuit should reset on the first successful response.
+        const overpassInstanceCount = 2;
         let fetchCallCount = 0;
         vi.stubGlobal(
           "fetch",
           vi.fn(async (url: string | URL) => {
             fetchCallCount++;
-            // First CIRCUIT_BREAKER_THRESHOLD * 2 calls (threshold streets × 2 instances) fail
-            if (fetchCallCount <= CIRCUIT_BREAKER_THRESHOLD * 2) {
+            // First threshold × instances calls fail (enough to open the circuit)
+            if (fetchCallCount <= CIRCUIT_BREAKER_THRESHOLD * overpassInstanceCount) {
               throw new Error("Network request failed");
             }
             return { ok: true, text: () => Promise.resolve(wayResponse) };
           }),
         );
 
-        // Provide threshold+2 intersections: first threshold streets fail (trip circuit),
-        // retry pass resets circuit — the retry streets should now succeed
+        // Provide threshold+2 intersections: after threshold × instances failures the
+        // circuit opens, then the retry pass resets it once requests start succeeding.
         const intersections = Array.from(
           { length: CIRCUIT_BREAKER_THRESHOLD + 2 },
           (_, i) => `ул. А${i} ∩ ул. Б${i}`,

--- a/ingest/geocoding/overpass/service.test.ts
+++ b/ingest/geocoding/overpass/service.test.ts
@@ -6,6 +6,8 @@ import {
   clearStreetGeometryCache,
   overpassGeocodeIntersections,
   CIRCUIT_BREAKER_THRESHOLD,
+  OVERPASS_INSTANCES,
+  OVERPASS_RETRY_MAX_ATTEMPTS,
 } from "./service";
 import { delay } from "../../lib/delay";
 
@@ -421,16 +423,14 @@ describe("overpass-geocoding-service", () => {
     });
 
     describe("adaptive retry policy", () => {
-      const OVERPASS_INSTANCES_COUNT = 2; // number of instances in OVERPASS_INSTANCES
-
       it("retries 429 on the same instance with backoff before falling back to the next", async () => {
-        // Instance 1 (private.coffee) always returns 429; instance 2 succeeds
+        // First instance always returns 429; second instance succeeds
         let instance1Calls = 0;
         let instance2Calls = 0;
         vi.stubGlobal(
           "fetch",
           vi.fn(async (url: string | URL) => {
-            if (String(url).includes("private.coffee")) {
+            if (String(url) === OVERPASS_INSTANCES[0]) {
               instance1Calls++;
               return {
                 ok: false,
@@ -447,9 +447,9 @@ describe("overpass-geocoding-service", () => {
 
         const results = await overpassGeocodeIntersections(["ул. Пример ∩ ул. Фоо"]);
 
-        // 2 streets × OVERPASS_RETRY_MAX_ATTEMPTS retries on instance1 before fallback
-        expect(instance1Calls).toBeGreaterThan(OVERPASS_INSTANCES_COUNT);
-        // Instance 2 handles both streets after instance 1 exhausts its attempts
+        // 2 streets, each exhausts OVERPASS_RETRY_MAX_ATTEMPTS on instance 1 before falling back
+        expect(instance1Calls).toBe(OVERPASS_RETRY_MAX_ATTEMPTS * 2);
+        // Instance 2 then handles both streets successfully on the first try
         expect(instance2Calls).toBe(2);
         expect(results).toHaveLength(1);
       });
@@ -460,7 +460,7 @@ describe("overpass-geocoding-service", () => {
         vi.stubGlobal(
           "fetch",
           vi.fn(async (url: string | URL) => {
-            if (String(url).includes("private.coffee") && fetchCount++ === 0) {
+            if (String(url) === OVERPASS_INSTANCES[0] && fetchCount++ === 0) {
               return {
                 ok: false,
                 status: 429,
@@ -481,13 +481,13 @@ describe("overpass-geocoding-service", () => {
       });
 
       it("retries AbortError (timeout) on the same instance with backoff", async () => {
-        // Instance 1 always times out; instance 2 succeeds
+        // First instance always times out; second instance succeeds
         let instance1Calls = 0;
         let instance2Calls = 0;
         vi.stubGlobal(
           "fetch",
           vi.fn(async (url: string | URL) => {
-            if (String(url).includes("private.coffee")) {
+            if (String(url) === OVERPASS_INSTANCES[0]) {
               instance1Calls++;
               const err = new Error("The operation was aborted");
               err.name = "AbortError";
@@ -500,7 +500,8 @@ describe("overpass-geocoding-service", () => {
 
         const results = await overpassGeocodeIntersections(["ул. Пример ∩ ул. Фоо"]);
 
-        expect(instance1Calls).toBeGreaterThan(OVERPASS_INSTANCES_COUNT);
+        // 2 streets, each exhausts OVERPASS_RETRY_MAX_ATTEMPTS on instance 1 before falling back
+        expect(instance1Calls).toBe(OVERPASS_RETRY_MAX_ATTEMPTS * 2);
         expect(instance2Calls).toBe(2);
         expect(results).toHaveLength(1);
       });

--- a/ingest/geocoding/overpass/service.ts
+++ b/ingest/geocoding/overpass/service.ts
@@ -330,7 +330,7 @@ export async function getStreetGeometryFromOverpass(
   // Circuit breaker — stop hammering Overpass when saturated
   if (runCtx?.circuitOpen) {
     deferredKeys?.add(cacheKey);
-    logger.warn("Overpass circuit open, deferring street without network attempt", {
+    logger.debug("Overpass circuit open, deferring street without network attempt", {
       streetName,
     });
     return null;

--- a/ingest/geocoding/overpass/service.ts
+++ b/ingest/geocoding/overpass/service.ts
@@ -78,11 +78,17 @@ function getRunContext(): OverpassRunContext | undefined {
 
 function recordTransientFailure(ctx: OverpassRunContext): void {
   ctx.consecutiveTransientFailures++;
-  if (ctx.consecutiveTransientFailures >= CIRCUIT_BREAKER_THRESHOLD && !ctx.circuitOpen) {
+  if (
+    ctx.consecutiveTransientFailures >= CIRCUIT_BREAKER_THRESHOLD &&
+    !ctx.circuitOpen
+  ) {
     ctx.circuitOpen = true;
-    logger.warn("Overpass circuit breaker opened after consecutive transient failures", {
-      threshold: CIRCUIT_BREAKER_THRESHOLD,
-    });
+    logger.warn(
+      "Overpass circuit breaker opened after consecutive transient failures",
+      {
+        threshold: CIRCUIT_BREAKER_THRESHOLD,
+      },
+    );
   }
 }
 
@@ -110,13 +116,21 @@ export function parseRetryAfterMs(header: string | null): number | null {
   // HTTP-date format: "Sat, 05 Apr 2026 12:34:56 GMT"
   const retryAtMs = Date.parse(trimmed);
   if (Number.isNaN(retryAtMs)) return null;
-  return Math.min(Math.max(retryAtMs - Date.now(), 0), OVERPASS_RETRY_MAX_DELAY_MS);
+  return Math.min(
+    Math.max(retryAtMs - Date.now(), 0),
+    OVERPASS_RETRY_MAX_DELAY_MS,
+  );
 }
 
-export function calculateRetryDelayMs(attempt: number, retryAfterMs: number | null): number {
-  if (retryAfterMs !== null) return Math.min(retryAfterMs, OVERPASS_RETRY_MAX_DELAY_MS);
+export function calculateRetryDelayMs(
+  attempt: number,
+  retryAfterMs: number | null,
+): number {
+  if (retryAfterMs !== null)
+    return Math.min(retryAfterMs, OVERPASS_RETRY_MAX_DELAY_MS);
   const base =
-    OVERPASS_RETRY_BASE_DELAY_MS * Math.pow(OVERPASS_RETRY_BACKOFF_FACTOR, attempt - 1);
+    OVERPASS_RETRY_BASE_DELAY_MS *
+    Math.pow(OVERPASS_RETRY_BACKOFF_FACTOR, attempt - 1);
   const jitter = base * OVERPASS_RETRY_JITTER_FACTOR * (Math.random() * 2 - 1);
   return Math.min(Math.round(base + jitter), OVERPASS_RETRY_MAX_DELAY_MS);
 }
@@ -341,9 +355,12 @@ export async function getStreetGeometryFromOverpass(
   // Circuit breaker — stop hammering Overpass when saturated
   if (runCtx?.circuitOpen) {
     deferredKeys?.add(cacheKey);
-    logger.debug("Overpass circuit open, deferring street without network attempt", {
-      streetName,
-    });
+    logger.debug(
+      "Overpass circuit open, deferring street without network attempt",
+      {
+        streetName,
+      },
+    );
     return null;
   }
 
@@ -434,16 +451,22 @@ export async function getStreetGeometryFromOverpass(
             }
 
             // 429: retry this instance with backoff
-            if (response.status === 429 && attempt < OVERPASS_RETRY_MAX_ATTEMPTS) {
+            if (
+              response.status === 429 &&
+              attempt < OVERPASS_RETRY_MAX_ATTEMPTS
+            ) {
               const retryAfterMs = parseRetryAfterMs(
                 response.headers.get("Retry-After"),
               );
               const waitMs = calculateRetryDelayMs(attempt, retryAfterMs);
-              logger.info("Rate limited by Overpass instance, retrying with backoff", {
-                hostname: new URL(instance).hostname,
-                attempt,
-                waitMs,
-              });
+              logger.info(
+                "Rate limited by Overpass instance, retrying with backoff",
+                {
+                  hostname: new URL(instance).hostname,
+                  attempt,
+                  waitMs,
+                },
+              );
               await delay(waitMs);
               continue; // retry this instance
             }
@@ -486,17 +509,22 @@ export async function getStreetGeometryFromOverpass(
           const isAbort = err.name === "AbortError";
           if (isAbort && attempt < OVERPASS_RETRY_MAX_ATTEMPTS) {
             const waitMs = calculateRetryDelayMs(attempt, null);
-            logger.info("Timeout from Overpass instance, retrying with backoff", {
-              hostname: new URL(instance).hostname,
-              attempt,
-              waitMs,
-            });
+            logger.info(
+              "Timeout from Overpass instance, retrying with backoff",
+              {
+                hostname: new URL(instance).hostname,
+                attempt,
+                waitMs,
+              },
+            );
             await delay(waitMs);
             continue; // retry this instance
           }
 
           logger.info(
-            isAbort ? "Timeout with Overpass instance" : "Failed with Overpass instance",
+            isAbort
+              ? "Timeout with Overpass instance"
+              : "Failed with Overpass instance",
             {
               hostname: new URL(instance).hostname,
               ...(isAbort ? {} : { error: err.message }),
@@ -880,47 +908,49 @@ export async function getStreetSectionGeometry(
 
       // Try each segment as a potential section
       for (const segment of allSegments) {
-      if (segment.length < 2) continue;
+        if (segment.length < 2) continue;
 
-      const line = turf.lineString(segment);
+        const line = turf.lineString(segment);
 
-      // Check if both points are close to this segment
-      const startSnapped = turf.nearestPointOnLine(line, startPoint);
-      const endSnapped = turf.nearestPointOnLine(line, endPoint);
+        // Check if both points are close to this segment
+        const startSnapped = turf.nearestPointOnLine(line, startPoint);
+        const endSnapped = turf.nearestPointOnLine(line, endPoint);
 
-      const startDist = turf.distance(startPoint, startSnapped, {
-        units: "meters",
-      });
-      const endDist = turf.distance(endPoint, endSnapped, { units: "meters" });
+        const startDist = turf.distance(startPoint, startSnapped, {
+          units: "meters",
+        });
+        const endDist = turf.distance(endPoint, endSnapped, {
+          units: "meters",
+        });
 
-      // If both points are within 50m of this segment, it might be our section
-      if (startDist < 50 && endDist < 50) {
-        const totalDist = startDist + endDist;
+        // If both points are within 50m of this segment, it might be our section
+        if (startDist < 50 && endDist < 50) {
+          const totalDist = startDist + endDist;
 
-        if (totalDist < minTotalDistance) {
-          minTotalDistance = totalDist;
+          if (totalDist < minTotalDistance) {
+            minTotalDistance = totalDist;
 
-          // Extract the subsection between the two snapped points
-          const startIndex = startSnapped.properties.index || 0;
-          const endIndex = endSnapped.properties.index || segment.length - 1;
+            // Extract the subsection between the two snapped points
+            const startIndex = startSnapped.properties.index || 0;
+            const endIndex = endSnapped.properties.index || segment.length - 1;
 
-          const minIndex = Math.min(startIndex, endIndex);
-          const maxIndex = Math.max(startIndex, endIndex);
+            const minIndex = Math.min(startIndex, endIndex);
+            const maxIndex = Math.max(startIndex, endIndex);
 
-          // Extract coordinates between the indices
-          let section = segment.slice(minIndex, maxIndex + 2);
+            // Extract coordinates between the indices
+            let section = segment.slice(minIndex, maxIndex + 2);
 
-          // CRITICAL: Preserve directionality from start→end
-          // If startIndex > endIndex, we need to reverse the section
-          // to maintain the semantic order (from start coords to end coords)
-          if (startIndex > endIndex) {
-            section = section.slice().reverse();
+            // CRITICAL: Preserve directionality from start→end
+            // If startIndex > endIndex, we need to reverse the section
+            // to maintain the semantic order (from start coords to end coords)
+            if (startIndex > endIndex) {
+              section = section.slice().reverse();
+            }
+
+            bestSection = section;
           }
-
-          bestSection = section;
         }
       }
-    }
 
       if (bestSection && bestSection.length >= 2) {
         logger.info("Found street section", { points: bestSection.length });
@@ -936,77 +966,79 @@ export async function getStreetSectionGeometry(
       const usedSegments = new Set<number>();
 
       while (
-      connectedPath.length === 0 ||
-      turf.distance(
-        turf.point(connectedPath[connectedPath.length - 1]),
-        endPoint,
-        { units: "meters" },
-      ) > 10
-    ) {
-      // Find nearest unused segment to current point
-      let nearestSegmentIdx = -1;
-      let nearestDist = Infinity;
+        connectedPath.length === 0 ||
+        turf.distance(
+          turf.point(connectedPath[connectedPath.length - 1]),
+          endPoint,
+          { units: "meters" },
+        ) > 10
+      ) {
+        // Find nearest unused segment to current point
+        let nearestSegmentIdx = -1;
+        let nearestDist = Infinity;
 
-      for (let i = 0; i < allSegments.length; i++) {
-        if (usedSegments.has(i)) continue;
+        for (let i = 0; i < allSegments.length; i++) {
+          if (usedSegments.has(i)) continue;
 
-        const segment = allSegments[i];
-        if (segment.length < 2) continue;
+          const segment = allSegments[i];
+          if (segment.length < 2) continue;
 
-        const line = turf.lineString(segment);
-        const snapped = turf.nearestPointOnLine(line, currentPoint);
-        const dist = turf.distance(currentPoint, snapped, { units: "meters" });
+          const line = turf.lineString(segment);
+          const snapped = turf.nearestPointOnLine(line, currentPoint);
+          const dist = turf.distance(currentPoint, snapped, {
+            units: "meters",
+          });
 
-        if (dist < nearestDist) {
-          nearestDist = dist;
-          nearestSegmentIdx = i;
-          // nearestSnap = snapped; // unused but kept for potential debugging
+          if (dist < nearestDist) {
+            nearestDist = dist;
+            nearestSegmentIdx = i;
+            // nearestSnap = snapped; // unused but kept for potential debugging
+          }
         }
-      }
 
-      if (nearestSegmentIdx === -1 || nearestDist > 50) {
-        logger.info("Cannot connect segments", {
-          minDistanceMeters: nearestDist,
-        });
-        break;
-      }
+        if (nearestSegmentIdx === -1 || nearestDist > 50) {
+          logger.info("Cannot connect segments", {
+            minDistanceMeters: nearestDist,
+          });
+          break;
+        }
 
-      // Add this segment
-      usedSegments.add(nearestSegmentIdx);
-      const segment = allSegments[nearestSegmentIdx];
+        // Add this segment
+        usedSegments.add(nearestSegmentIdx);
+        const segment = allSegments[nearestSegmentIdx];
 
-      // Determine direction and add coordinates
-      if (connectedPath.length === 0) {
-        connectedPath.push(...segment);
-      } else {
-        // Check if we need to reverse
-        const lastPoint = turf.point(connectedPath[connectedPath.length - 1]);
-        const segmentStart = turf.point(segment[0]);
-        const segmentEnd = turf.point(segment[segment.length - 1]);
-
-        const distToStart = turf.distance(lastPoint, segmentStart, {
-          units: "meters",
-        });
-        const distToEnd = turf.distance(lastPoint, segmentEnd, {
-          units: "meters",
-        });
-
-        if (distToEnd < distToStart) {
-          // Reverse and add
-          connectedPath.push(...segment.slice().reverse());
-        } else {
+        // Determine direction and add coordinates
+        if (connectedPath.length === 0) {
           connectedPath.push(...segment);
+        } else {
+          // Check if we need to reverse
+          const lastPoint = turf.point(connectedPath[connectedPath.length - 1]);
+          const segmentStart = turf.point(segment[0]);
+          const segmentEnd = turf.point(segment[segment.length - 1]);
+
+          const distToStart = turf.distance(lastPoint, segmentStart, {
+            units: "meters",
+          });
+          const distToEnd = turf.distance(lastPoint, segmentEnd, {
+            units: "meters",
+          });
+
+          if (distToEnd < distToStart) {
+            // Reverse and add
+            connectedPath.push(...segment.slice().reverse());
+          } else {
+            connectedPath.push(...segment);
+          }
+        }
+
+        currentPoint = turf.point(connectedPath[connectedPath.length - 1]);
+
+        // Safety check
+        if (usedSegments.size > 10) {
+          logger.info("Too many segments, giving up");
+          break;
         }
       }
-
-      currentPoint = turf.point(connectedPath[connectedPath.length - 1]);
-
-      // Safety check
-      if (usedSegments.size > 10) {
-        logger.info("Too many segments, giving up");
-        break;
-      }
-    }
 
       if (connectedPath.length >= 2) {
         logger.info("Connected segments into path", {

--- a/ingest/geocoding/overpass/service.ts
+++ b/ingest/geocoding/overpass/service.ts
@@ -113,7 +113,13 @@ export function parseRetryAfterMs(header: string | null): number | null {
     return Math.min(seconds * 1_000, OVERPASS_RETRY_MAX_DELAY_MS);
   }
 
-  // HTTP-date format: "Sat, 05 Apr 2026 12:34:56 GMT"
+  // HTTP-date format (RFC 7231 IMF-fixdate only): "Sat, 05 Apr 2026 12:34:56 GMT"
+  // Reject anything that isn't a strict IMF-fixdate to avoid accepting ISO 8601 or
+  // other Date.parse-parseable strings that aren't valid Retry-After values.
+  if (
+    !/^[A-Za-z]{3}, \d{2} [A-Za-z]{3} \d{4} \d{2}:\d{2}:\d{2} GMT$/.test(trimmed)
+  )
+    return null;
   const retryAtMs = Date.parse(trimmed);
   if (Number.isNaN(retryAtMs)) return null;
   return Math.min(
@@ -483,11 +489,16 @@ export async function getStreetGeometryFromOverpass(
           const text = await response.text();
           try {
             responseData = JSON.parse(text);
-          } catch (parseError) {
-            // Failed to parse JSON - might be XML error with HTTP 200
+          } catch {
+            // Failed to parse JSON — might be an upstream HTML/XML error page with HTTP 200.
+            // Re-throw with a transient/server-oriented message so fallback/deferred retry
+            // can apply. parseOverpassError handles real Overpass XML errors (e.g. query
+            // syntax errors) which remain non-retryable via shouldTryFallback.
             const errorMsg = parseOverpassError(text);
             if (errorMsg) throw new Error(errorMsg);
-            throw parseError;
+            throw new Error(
+              "Overpass instance returned a non-JSON success response; treating as transient upstream failure",
+            );
           }
 
           logger.info("Response from Overpass instance", {

--- a/ingest/geocoding/overpass/service.ts
+++ b/ingest/geocoding/overpass/service.ts
@@ -103,7 +103,7 @@ function parseRetryAfterMs(header: string | null): number | null {
 }
 
 function calculateRetryDelayMs(attempt: number, retryAfterMs: number | null): number {
-  if (retryAfterMs !== null) return retryAfterMs;
+  if (retryAfterMs !== null) return Math.min(retryAfterMs, OVERPASS_RETRY_MAX_DELAY_MS);
   const base =
     OVERPASS_RETRY_BASE_DELAY_MS * Math.pow(OVERPASS_RETRY_BACKOFF_FACTOR, attempt - 1);
   const jitter = base * OVERPASS_RETRY_JITTER_FACTOR * (Math.random() * 2 - 1);
@@ -310,6 +310,15 @@ export async function getStreetGeometryFromOverpass(
   streetName: string,
 ): Promise<Feature<MultiLineString> | null> {
   const cacheKey = getStreetGeometryCacheKey(streetName);
+
+  // Check the in-memory cache first — cached results are always usable regardless
+  // of circuit-breaker or deferred-retry state (no network call needed).
+  if (streetGeometryCache.has(cacheKey)) {
+    const normalizedName = normalizeStreetName(streetName);
+    logger.debug("Street geometry cache hit", { streetName, normalizedName });
+    return streetGeometryCache.get(cacheKey)!;
+  }
+
   const runCtx = getRunContext();
   const deferredKeys = runCtx?.deferredKeys;
 
@@ -337,11 +346,6 @@ export async function getStreetGeometryFromOverpass(
     const featureType = getStreetFeatureType(streetName);
     const isSquare = featureType === "square";
     const isStreet = featureType === "street";
-    // Return cached result if available (includes null for streets not found in OSM)
-    if (streetGeometryCache.has(cacheKey)) {
-      logger.debug("Street geometry cache hit", { streetName, normalizedName });
-      return streetGeometryCache.get(cacheKey)!;
-    }
 
     const queryRegex = toOverpassRegex(normalizedName);
 
@@ -414,7 +418,7 @@ export async function getStreetGeometryFromOverpass(
             err.statusCode = response.status;
 
             if (!shouldTryFallback(err, response.status)) {
-              logger.error("Client error (query issue)", { errorMsg });
+              logger.debug("Client error (query issue)", { errorMsg });
               throw err;
             }
 
@@ -463,7 +467,7 @@ export async function getStreetGeometryFromOverpass(
             error instanceof Error ? error : new Error(String(error));
 
           if (!shouldTryFallback(err, err.statusCode)) {
-            logger.error("Client error (query issue)", { error: err.message });
+            logger.debug("Client error (query issue)", { error: err.message });
             throw err;
           }
 

--- a/ingest/geocoding/overpass/service.ts
+++ b/ingest/geocoding/overpass/service.ts
@@ -28,6 +28,16 @@ const OVERPASS_DELAY_MS = 500; // 500ms for Overpass API (generous limits)
 const OVERPASS_TIMEOUT_MS = 25000; // 25 seconds timeout for HTTP requests
 const BUFFER_DISTANCE_METERS = 30; // Buffer distance for street geometries
 
+// Adaptive retry policy for per-instance 429 / AbortError retries
+const OVERPASS_RETRY_MAX_ATTEMPTS = 3; // Total attempts per instance (including first)
+const OVERPASS_RETRY_BASE_DELAY_MS = 1_000;
+const OVERPASS_RETRY_MAX_DELAY_MS = 30_000;
+const OVERPASS_RETRY_BACKOFF_FACTOR = 2;
+const OVERPASS_RETRY_JITTER_FACTOR = 0.25;
+
+// Number of consecutive transient failures in a run needed to open the circuit
+export const CIRCUIT_BREAKER_THRESHOLD = 5;
+
 type StreetGeometryFeatureType = "street" | "boulevard" | "square";
 
 /**
@@ -53,7 +63,52 @@ function getStreetFeatureType(streetName: string): StreetGeometryFeatureType {
 
 // In-memory cache for street geometry lookups (keyed on type + normalized street name)
 const streetGeometryCache = new Map<string, Feature<MultiLineString> | null>();
-const deferredScopeStorage = new AsyncLocalStorage<Set<string>>();
+
+interface OverpassRunContext {
+  deferredKeys: Set<string>;
+  consecutiveTransientFailures: number;
+  circuitOpen: boolean;
+}
+
+const runContextStorage = new AsyncLocalStorage<OverpassRunContext>();
+
+function getRunContext(): OverpassRunContext | undefined {
+  return runContextStorage.getStore();
+}
+
+function recordTransientFailure(ctx: OverpassRunContext): void {
+  ctx.consecutiveTransientFailures++;
+  if (ctx.consecutiveTransientFailures >= CIRCUIT_BREAKER_THRESHOLD && !ctx.circuitOpen) {
+    ctx.circuitOpen = true;
+    logger.warn("Overpass circuit breaker opened after consecutive transient failures", {
+      threshold: CIRCUIT_BREAKER_THRESHOLD,
+    });
+  }
+}
+
+function recordSuccess(ctx: OverpassRunContext): void {
+  if (ctx.consecutiveTransientFailures > 0 || ctx.circuitOpen) {
+    if (ctx.circuitOpen) {
+      logger.info("Overpass circuit breaker closed after successful request");
+    }
+    ctx.consecutiveTransientFailures = 0;
+    ctx.circuitOpen = false;
+  }
+}
+
+function parseRetryAfterMs(header: string | null): number | null {
+  if (header === null) return null;
+  const seconds = parseInt(header, 10);
+  return isNaN(seconds) ? null : seconds * 1_000;
+}
+
+function calculateRetryDelayMs(attempt: number, retryAfterMs: number | null): number {
+  if (retryAfterMs !== null) return retryAfterMs;
+  const base =
+    OVERPASS_RETRY_BASE_DELAY_MS * Math.pow(OVERPASS_RETRY_BACKOFF_FACTOR, attempt - 1);
+  const jitter = base * OVERPASS_RETRY_JITTER_FACTOR * (Math.random() * 2 - 1);
+  return Math.min(Math.round(base + jitter), OVERPASS_RETRY_MAX_DELAY_MS);
+}
 
 function getStreetGeometryCacheKey(streetName: string): string {
   return makeStreetGeometryCacheKey(
@@ -85,10 +140,10 @@ export function getStreetGeometryCached(
  */
 export function hasStreetGeometryQueried(streetName: string): boolean {
   const cacheKey = getStreetGeometryCacheKey(streetName);
-  const deferredKeys = getCurrentDeferredStreetGeometryKeys();
+  const ctx = getRunContext();
   return (
     streetGeometryCache.has(cacheKey) ||
-    Boolean(deferredKeys?.has(cacheKey))
+    Boolean(ctx?.deferredKeys.has(cacheKey))
   );
 }
 
@@ -111,29 +166,34 @@ export function seedStreetGeometryCache(
 }
 
 function isStreetGeometryDeferred(streetName: string): boolean {
-  const deferredKeys = getCurrentDeferredStreetGeometryKeys();
-  return Boolean(deferredKeys?.has(getStreetGeometryCacheKey(streetName)));
+  const ctx = getRunContext();
+  return Boolean(ctx?.deferredKeys.has(getStreetGeometryCacheKey(streetName)));
 }
 
 function clearDeferredStreetGeometryKeys(): void {
-  const deferredKeys = getCurrentDeferredStreetGeometryKeys();
-  deferredKeys?.clear();
-}
-
-function getCurrentDeferredStreetGeometryKeys(): Set<string> | undefined {
-  return deferredScopeStorage.getStore();
+  const ctx = getRunContext();
+  if (ctx) {
+    ctx.deferredKeys.clear();
+    // Reset circuit breaker for the retry pass so deferred streets get a fair attempt
+    ctx.consecutiveTransientFailures = 0;
+    ctx.circuitOpen = false;
+  }
 }
 
 async function runWithDeferredRetryScope<T>(
   work: () => Promise<T>,
 ): Promise<T> {
-  const existingScope = deferredScopeStorage.getStore();
+  const existingScope = runContextStorage.getStore();
   if (existingScope !== undefined) {
     return work();
   }
 
-  const deferredKeys = new Set<string>();
-  return deferredScopeStorage.run(deferredKeys, work);
+  const ctx: OverpassRunContext = {
+    deferredKeys: new Set<string>(),
+    consecutiveTransientFailures: 0,
+    circuitOpen: false,
+  };
+  return runContextStorage.run(ctx, work);
 }
 
 function parseIntersectionStreetNames(intersection: string): [string, string] {
@@ -250,10 +310,20 @@ export async function getStreetGeometryFromOverpass(
   streetName: string,
 ): Promise<Feature<MultiLineString> | null> {
   const cacheKey = getStreetGeometryCacheKey(streetName);
-  const deferredKeys = getCurrentDeferredStreetGeometryKeys();
+  const runCtx = getRunContext();
+  const deferredKeys = runCtx?.deferredKeys;
 
   if (deferredKeys?.has(cacheKey)) {
     logger.debug("Street geometry deferred for retry", { streetName });
+    return null;
+  }
+
+  // Circuit breaker — stop hammering Overpass when saturated
+  if (runCtx?.circuitOpen) {
+    deferredKeys?.add(cacheKey);
+    logger.warn("Overpass circuit open, deferring street without network attempt", {
+      streetName,
+    });
     return null;
   }
 
@@ -312,102 +382,123 @@ export async function getStreetGeometryFromOverpass(
       `;
     }
 
-    // Try each Overpass instance until one works
+    // Try each Overpass instance; retry within the same instance for 429 and AbortError (timeout)
     let responseData: OverpassResponse | null = null;
     let lastError: Error | null = null;
 
-    for (const instance of OVERPASS_INSTANCES) {
-      const controller = new AbortController();
-      const timeoutId = setTimeout(
-        () => controller.abort(),
-        OVERPASS_TIMEOUT_MS,
-      );
+    outerLoop: for (const instance of OVERPASS_INSTANCES) {
+      for (let attempt = 1; attempt <= OVERPASS_RETRY_MAX_ATTEMPTS; attempt++) {
+        const controller = new AbortController();
+        const timeoutId = setTimeout(
+          () => controller.abort(),
+          OVERPASS_TIMEOUT_MS,
+        );
 
-      try {
-        const response = await fetch(instance, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/x-www-form-urlencoded",
-          },
-          body: `data=${encodeURIComponent(query)}`,
-          signal: controller.signal,
-        });
+        try {
+          const response = await fetch(instance, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/x-www-form-urlencoded",
+            },
+            body: `data=${encodeURIComponent(query)}`,
+            signal: controller.signal,
+          });
+          clearTimeout(timeoutId);
 
-        if (!response.ok) {
-          // Try to extract XML error message
-          const text = await response.text();
-          const errorMsg = parseOverpassError(text) || response.statusText;
-          const error: ErrorWithStatusCode = new Error(
-            `HTTP ${response.status}: ${errorMsg}`,
-          );
-          error.statusCode = response.status;
+          if (!response.ok) {
+            const text = await response.text();
+            const errorMsg = parseOverpassError(text) || response.statusText;
+            const err: ErrorWithStatusCode = new Error(
+              `HTTP ${response.status}: ${errorMsg}`,
+            );
+            err.statusCode = response.status;
 
-          if (!shouldTryFallback(error, response.status)) {
-            // Client-side error - don't try other servers
-            clearTimeout(timeoutId);
-            logger.error("Client error (query issue)", { errorMsg });
-            throw error;
+            if (!shouldTryFallback(err, response.status)) {
+              logger.error("Client error (query issue)", { errorMsg });
+              throw err;
+            }
+
+            // 429: retry this instance with backoff
+            if (response.status === 429 && attempt < OVERPASS_RETRY_MAX_ATTEMPTS) {
+              const retryAfterMs = parseRetryAfterMs(
+                response.headers.get("Retry-After"),
+              );
+              const waitMs = calculateRetryDelayMs(attempt, retryAfterMs);
+              logger.info("Rate limited by Overpass instance, retrying with backoff", {
+                hostname: new URL(instance).hostname,
+                attempt,
+                waitMs,
+              });
+              await delay(waitMs);
+              continue; // retry this instance
+            }
+
+            logger.info("Server error from Overpass instance", {
+              hostname: new URL(instance).hostname,
+              errorMsg,
+            });
+            lastError = err;
+            continue outerLoop; // try next instance
           }
 
-          logger.info("Server error from Overpass instance", {
-            hostname: new URL(instance).hostname,
-            errorMsg,
-          });
-          lastError = error;
-          clearTimeout(timeoutId);
-          continue;
-        }
+          // Parse JSON defensively - buffer as text first
+          const text = await response.text();
+          try {
+            responseData = JSON.parse(text);
+          } catch (parseError) {
+            // Failed to parse JSON - might be XML error with HTTP 200
+            const errorMsg = parseOverpassError(text);
+            if (errorMsg) throw new Error(errorMsg);
+            throw parseError;
+          }
 
-        // Parse JSON defensively - buffer as text first
-        const text = await response.text();
-        try {
-          responseData = JSON.parse(text);
           logger.info("Response from Overpass instance", {
             hostname: new URL(instance).hostname,
           });
-        } catch (parseError) {
-          // Failed to parse JSON - might be XML error with HTTP 200
-          const errorMsg = parseOverpassError(text);
-          if (errorMsg) {
-            throw new Error(errorMsg);
+          break outerLoop; // success
+        } catch (error) {
+          clearTimeout(timeoutId);
+
+          const err: ErrorWithStatusCode =
+            error instanceof Error ? error : new Error(String(error));
+
+          if (!shouldTryFallback(err, err.statusCode)) {
+            logger.error("Client error (query issue)", { error: err.message });
+            throw err;
           }
-          // Re-throw the original parse error
-          throw parseError;
+
+          // AbortError (timeout): retry this instance with backoff
+          const isAbort = err.name === "AbortError";
+          if (isAbort && attempt < OVERPASS_RETRY_MAX_ATTEMPTS) {
+            const waitMs = calculateRetryDelayMs(attempt, null);
+            logger.info("Timeout from Overpass instance, retrying with backoff", {
+              hostname: new URL(instance).hostname,
+              attempt,
+              waitMs,
+            });
+            await delay(waitMs);
+            continue; // retry this instance
+          }
+
+          logger.info(
+            isAbort ? "Timeout with Overpass instance" : "Failed with Overpass instance",
+            {
+              hostname: new URL(instance).hostname,
+              ...(isAbort ? {} : { error: err.message }),
+            },
+          );
+          lastError = err;
+          continue outerLoop; // try next instance
         }
-
-        clearTimeout(timeoutId);
-        break; // Success, exit loop
-      } catch (error) {
-        clearTimeout(timeoutId);
-
-        const err: ErrorWithStatusCode =
-          error instanceof Error ? error : new Error(String(error));
-
-        // Check if this is a client-side error
-        if (!shouldTryFallback(err, err.statusCode)) {
-          logger.error("Client error (query issue)", { error: err.message });
-          throw err;
-        }
-
-        // Server-side error or timeout - try next instance
-        if (err.name === "AbortError") {
-          logger.info("Timeout with Overpass instance", {
-            hostname: new URL(instance).hostname,
-          });
-        } else {
-          logger.info("Failed with Overpass instance", {
-            hostname: new URL(instance).hostname,
-            error: err.message,
-          });
-        }
-        lastError = err;
-        continue; // Try next instance
       }
     }
 
     if (!responseData) {
       throw lastError || new Error("All Overpass instances failed");
     }
+
+    // API responded — count as success to reset the circuit breaker
+    if (runCtx) recordSuccess(runCtx);
 
     if (!responseData.elements || responseData.elements.length === 0) {
       // No OSM ways found - API request succeeded but no data for this street name
@@ -490,10 +581,11 @@ export async function getStreetGeometryFromOverpass(
     if (shouldTryFallback(err, err.statusCode)) {
       if (deferredKeys) {
         deferredKeys.add(cacheKey);
-        logger.info("Deferring street geometry after transient failure", {
-          streetName,
-        });
       }
+      if (runCtx) recordTransientFailure(runCtx);
+      logger.info("Deferring street geometry after transient failure", {
+        streetName,
+      });
       return null;
     }
     logger.error("Non-retryable Overpass error while resolving street", {

--- a/ingest/geocoding/overpass/service.ts
+++ b/ingest/geocoding/overpass/service.ts
@@ -35,7 +35,8 @@ export const OVERPASS_RETRY_MAX_DELAY_MS = 30_000;
 const OVERPASS_RETRY_BACKOFF_FACTOR = 2;
 const OVERPASS_RETRY_JITTER_FACTOR = 0.25;
 
-// Number of consecutive transient failures in a run needed to open the circuit
+// Number of consecutive per-street transient failures (i.e. streets that exhausted every
+// instance) needed to open the circuit. One increment per street, not per individual request.
 export const CIRCUIT_BREAKER_THRESHOLD = 5;
 
 type StreetGeometryFeatureType = "street" | "boulevard" | "square";

--- a/ingest/geocoding/overpass/service.ts
+++ b/ingest/geocoding/overpass/service.ts
@@ -29,7 +29,7 @@ const OVERPASS_TIMEOUT_MS = 25000; // 25 seconds timeout for HTTP requests
 const BUFFER_DISTANCE_METERS = 30; // Buffer distance for street geometries
 
 // Adaptive retry policy for per-instance 429 / AbortError retries
-const OVERPASS_RETRY_MAX_ATTEMPTS = 3; // Total attempts per instance (including first)
+export const OVERPASS_RETRY_MAX_ATTEMPTS = 3; // Total attempts per instance (including first)
 const OVERPASS_RETRY_BASE_DELAY_MS = 1_000;
 const OVERPASS_RETRY_MAX_DELAY_MS = 30_000;
 const OVERPASS_RETRY_BACKOFF_FACTOR = 2;
@@ -98,8 +98,19 @@ function recordSuccess(ctx: OverpassRunContext): void {
 
 function parseRetryAfterMs(header: string | null): number | null {
   if (header === null) return null;
-  const seconds = parseInt(header, 10);
-  return isNaN(seconds) ? null : seconds * 1_000;
+  const trimmed = header.trim();
+  if (trimmed.length === 0) return null;
+
+  // Delta-seconds format: "42"
+  if (/^\d+$/.test(trimmed)) {
+    const seconds = Number.parseInt(trimmed, 10);
+    return Math.min(seconds * 1_000, OVERPASS_RETRY_MAX_DELAY_MS);
+  }
+
+  // HTTP-date format: "Sat, 05 Apr 2026 12:34:56 GMT"
+  const retryAtMs = Date.parse(trimmed);
+  if (Number.isNaN(retryAtMs)) return null;
+  return Math.min(Math.max(retryAtMs - Date.now(), 0), OVERPASS_RETRY_MAX_DELAY_MS);
 }
 
 function calculateRetryDelayMs(attempt: number, retryAfterMs: number | null): number {
@@ -256,7 +267,7 @@ function shouldTryFallback(error: Error, statusCode?: number): boolean {
 type ErrorWithStatusCode = Error & { statusCode?: number };
 
 // Multiple Overpass API instances for fallback
-const OVERPASS_INSTANCES = [
+export const OVERPASS_INSTANCES = [
   "https://overpass.private.coffee/api/interpreter", // No rate limit
   "https://overpass-api.de/api/interpreter", // Main instance (10k queries/day)
 ];

--- a/ingest/geocoding/overpass/service.ts
+++ b/ingest/geocoding/overpass/service.ts
@@ -30,8 +30,8 @@ const BUFFER_DISTANCE_METERS = 30; // Buffer distance for street geometries
 
 // Adaptive retry policy for per-instance 429 / AbortError retries
 export const OVERPASS_RETRY_MAX_ATTEMPTS = 3; // Total attempts per instance (including first)
-const OVERPASS_RETRY_BASE_DELAY_MS = 1_000;
-const OVERPASS_RETRY_MAX_DELAY_MS = 30_000;
+export const OVERPASS_RETRY_BASE_DELAY_MS = 1_000;
+export const OVERPASS_RETRY_MAX_DELAY_MS = 30_000;
 const OVERPASS_RETRY_BACKOFF_FACTOR = 2;
 const OVERPASS_RETRY_JITTER_FACTOR = 0.25;
 
@@ -96,7 +96,7 @@ function recordSuccess(ctx: OverpassRunContext): void {
   }
 }
 
-function parseRetryAfterMs(header: string | null): number | null {
+export function parseRetryAfterMs(header: string | null): number | null {
   if (header === null) return null;
   const trimmed = header.trim();
   if (trimmed.length === 0) return null;
@@ -113,7 +113,7 @@ function parseRetryAfterMs(header: string | null): number | null {
   return Math.min(Math.max(retryAtMs - Date.now(), 0), OVERPASS_RETRY_MAX_DELAY_MS);
 }
 
-function calculateRetryDelayMs(attempt: number, retryAfterMs: number | null): number {
+export function calculateRetryDelayMs(attempt: number, retryAfterMs: number | null): number {
   if (retryAfterMs !== null) return Math.min(retryAfterMs, OVERPASS_RETRY_MAX_DELAY_MS);
   const base =
     OVERPASS_RETRY_BASE_DELAY_MS * Math.pow(OVERPASS_RETRY_BACKOFF_FACTOR, attempt - 1);


### PR DESCRIPTION
## Phase 2 — Adaptive Overpass Retry Policy

Follows Phase 1 (#351 — deferred retry for transient failures). Addresses the saturation scenario where repeated Overpass failures cause the pipeline to thrash without any back-pressure.

### Changes

**Per-instance retry with exponential backoff** (`getStreetGeometryFromOverpass`):
- **429 Too Many Requests**: retried on the **same** instance (up to `OVERPASS_RETRY_MAX_ATTEMPTS = 3` total attempts) with exponential backoff + ±25% jitter. Respects `Retry-After` header when present.
- **AbortError / timeout**: same per-instance retry with backoff.
- Other server errors (5xx, network): immediate fallback to the next instance (existing behavior).
- Backoff: 1 s base, ×2 factor, 30 s cap.

**Run-scoped circuit breaker** (stored in `AsyncLocalStorage` via `OverpassRunContext`):
- After `CIRCUIT_BREAKER_THRESHOLD = 5` consecutive transient failures in a run, the circuit opens.
- While open, new street geometry requests are **deferred immediately** — no network calls, no thrashing.
- Circuit **resets on the first successful response** (closes).
- Circuit also **resets between the two passes** of `overpassGeocodeIntersections` (`clearDeferredStreetGeometryKeys`) so deferred streets get a fair retry in pass 2.

**`OverpassRunContext`** replaces the raw `Set<string>` stored in `AsyncLocalStorage`:
```ts
interface OverpassRunContext {
  deferredKeys: Set<string>;
  consecutiveTransientFailures: number;
  circuitOpen: boolean;
}
```
All deferred-key helpers updated accordingly; `CIRCUIT_BREAKER_THRESHOLD` is exported for testing.

### Tests added (5 new, 54 total)

| Test | Verifies |
|---|---|
| Retries 429 on same instance before falling back | Per-instance retry loop for 429 |
| Respects `Retry-After` header | `delay` called with header value |
| Retries AbortError on same instance | Per-instance retry loop for timeouts |
| Circuit opens after threshold failures, defers remaining | Circuit breaker activation |
| Circuit resets after success, allowing subsequent streets | Circuit breaker reset |

### Pre-PR checklist
- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm lint` — clean
- [x] 54/54 tests pass