### PR TITLE
feat(ingest): Phase 3 — pre-fetch unique street geometries before intersection geocoding

### DIFF
--- a/ingest/geocoding/overpass/README.md
+++ b/ingest/geocoding/overpass/README.md
@@ -21,6 +21,31 @@ Uses a two-instance fallback chain for reliability:
 
 Requests failing on the primary server automatically fall through to the fallback.
 
+## Pre-Fetch Deduplication (Phase 3)
+
+Before per-section intersection geocoding begins, all unique street names in the batch are
+collected and fetched in one pass. This bounds Overpass call volume to the number of unique
+normalised street names rather than the number of street sections.
+
+**How it works** (`preFetchStreetGeometries`):
+
+1. **Deduplicate by normalised cache key** — identical streets (e.g. `"ул. Оборище"` and
+   `"ул.Оборище"`) resolve to the same key; only one request is issued.
+2. **Cache-skip** — streets already in the in-memory geometry cache generate no request at all.
+3. **Two-pass deferred retry** — streets that fail transiently in the first pass are retried once
+   (same circuit-breaker and deferred-key logic as `overpassGeocodeIntersections`).
+4. **Null-cache after retry exhaustion** — streets still unresolvable after retry are written as
+   `null` into the cache. All subsequent per-section `getStreetGeometryFromOverpass` calls for
+   those streets become immediate cache hits, preventing O(sections) retries for a single
+   unavailable street.
+
+**Interaction with the circuit breaker**: pre-fetch runs in its own
+`AsyncLocalStorage` scope. The per-section intersection calls each run in their own scope too,
+so a circuit opened during pre-fetch does not carry over into per-section processing.
+
+**Precondition**: `preFetchStreetGeometries` must not be called from within an existing retry
+scope (it guards against this at runtime and logs a warning if violated).
+
 ## Adaptive Retry Policy
 
 For transient failures on a single instance (429 Too Many Requests or request timeouts), the service retries the **same instance** up to `OVERPASS_RETRY_MAX_ATTEMPTS = 3` times before falling back to the next instance.

--- a/ingest/geocoding/overpass/service.test.ts
+++ b/ingest/geocoding/overpass/service.test.ts
@@ -5,6 +5,8 @@ import {
   toOverpassRegex,
   clearStreetGeometryCache,
   overpassGeocodeIntersections,
+  getStreetGeometryFromOverpass,
+  preFetchStreetGeometries,
   CIRCUIT_BREAKER_THRESHOLD,
   OVERPASS_INSTANCES,
   OVERPASS_RETRY_MAX_ATTEMPTS,
@@ -699,6 +701,108 @@ describe("overpass-geocoding-service", () => {
         // After the circuit resets, some intersections should be resolved
         expect(results.length).toBeGreaterThan(0);
       });
+    });
+  });
+
+  describe("preFetchStreetGeometries", () => {
+    const wayResponse = JSON.stringify({
+      elements: [
+        {
+          type: "way",
+          geometry: [
+            { lat: 42.6977, lon: 23.3219 },
+            { lat: 42.698, lon: 23.3225 },
+          ],
+        },
+      ],
+    });
+
+    function mockFetch(responseBody: string) {
+      return vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(responseBody),
+      });
+    }
+
+    beforeEach(() => {
+      clearStreetGeometryCache();
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it("deduplicates by normalized cache key: three names → two Overpass calls", async () => {
+      vi.stubGlobal("fetch", mockFetch(wayResponse));
+
+      // "ул. Оборище" and "ул.Оборище" normalize to the same key
+      await preFetchStreetGeometries([
+        "ул. Оборище",
+        "ул.Оборище",
+        "ул. Раковски",
+      ]);
+
+      expect(fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("skips names already present in the geometry cache", async () => {
+      vi.stubGlobal("fetch", mockFetch(wayResponse));
+
+      // Warm up the cache for "ул. Оборище"
+      await preFetchStreetGeometries(["ул. Оборище"]);
+      expect(fetch).toHaveBeenCalledTimes(1);
+      vi.mocked(fetch).mockClear();
+
+      // Second call: already cached → no new fetch
+      await preFetchStreetGeometries(["ул. Оборище", "ул. Оборище"]);
+      expect(fetch).toHaveBeenCalledTimes(0);
+    });
+
+    it("retries deferred streets in a second pass", async () => {
+      // First call per unique name fails (transient); second call succeeds
+      const callsPerKey = new Map<string, number>();
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (_url: string | URL, init?: RequestInit) => {
+          const body = typeof init?.body === "string" ? init.body : "";
+          const calls = (callsPerKey.get(body) ?? 0) + 1;
+          callsPerKey.set(body, calls);
+          if (calls === 1) throw new Error("Network request failed");
+          return { ok: true, text: () => Promise.resolve(wayResponse) };
+        }),
+      );
+
+      await preFetchStreetGeometries(["ул. Пример"]);
+
+      // 2 total calls: 1 (fail) + 1 (retry)
+      expect(vi.mocked(fetch).mock.calls.length).toBe(2);
+    });
+
+    it("caches persistently unavailable streets as null after retry exhaustion", async () => {
+      // All instances always fail → passes through both passes → cached as null
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockRejectedValue(new Error("Network request failed")),
+      );
+
+      await preFetchStreetGeometries(["ул. Пример"]);
+      const fetchCallsDuringPreFetch = vi.mocked(fetch).mock.calls.length;
+      vi.mocked(fetch).mockClear();
+
+      // getStreetGeometryFromOverpass should now return null from cache — no new fetch
+      const geometry = await getStreetGeometryFromOverpass("ул. Пример");
+      expect(geometry).toBeNull();
+      expect(vi.mocked(fetch).mock.calls.length).toBe(0);
+      expect(fetchCallsDuringPreFetch).toBeGreaterThan(0);
+    });
+
+    it("is a no-op for empty input and blank strings", async () => {
+      vi.stubGlobal("fetch", mockFetch(wayResponse));
+
+      await preFetchStreetGeometries([]);
+      await preFetchStreetGeometries(["", "  "]);
+
+      expect(fetch).not.toHaveBeenCalled();
     });
   });
 });

--- a/ingest/geocoding/overpass/service.test.ts
+++ b/ingest/geocoding/overpass/service.test.ts
@@ -774,8 +774,13 @@ describe("overpass-geocoding-service", () => {
 
       await preFetchStreetGeometries(["ул. Пример"]);
 
-      // 2 total calls: 1 (fail) + 1 (retry)
+      // 2 total calls: 1 (fail in pass 1) + 1 (succeed in pass 2)
       expect(vi.mocked(fetch).mock.calls.length).toBe(2);
+      // The second-pass result must have been cached — no further fetch needed
+      vi.mocked(fetch).mockClear();
+      const cached = await getStreetGeometryFromOverpass("ул. Пример");
+      expect(cached).not.toBeNull();
+      expect(vi.mocked(fetch).mock.calls.length).toBe(0);
     });
 
     it("caches persistently unavailable streets as null after retry exhaustion", async () => {

--- a/ingest/geocoding/overpass/service.test.ts
+++ b/ingest/geocoding/overpass/service.test.ts
@@ -759,28 +759,34 @@ describe("overpass-geocoding-service", () => {
     });
 
     it("retries deferred streets in a second pass", async () => {
-      // First call per unique name fails (transient); second call succeeds
-      const callsPerKey = new Map<string, number>();
+      // Fail on ALL instances in pass 1 so the street is actually deferred (not satisfied
+      // by the fallback instance), then succeed in pass 2 (after clearDeferredStreetGeometryKeys).
+      // The inter-pass delay mock is overridden to flip the pass1Done flag.
+      let pass1Done = false;
       vi.stubGlobal(
         "fetch",
-        vi.fn(async (_url: string | URL, init?: RequestInit) => {
-          const body = typeof init?.body === "string" ? init.body : "";
-          const calls = (callsPerKey.get(body) ?? 0) + 1;
-          callsPerKey.set(body, calls);
-          if (calls === 1) throw new Error("Network request failed");
+        vi.fn(async () => {
+          if (!pass1Done) throw new Error("Network request failed");
           return { ok: true, text: () => Promise.resolve(wayResponse) };
         }),
       );
+      vi.mocked(delay).mockImplementation(async () => {
+        pass1Done = true;
+      });
 
       await preFetchStreetGeometries(["ул. Пример"]);
 
-      // 2 total calls: 1 (fail in pass 1) + 1 (succeed in pass 2)
-      expect(vi.mocked(fetch).mock.calls.length).toBe(2);
+      // Pass 1: OVERPASS_INSTANCES.length calls all fail → street deferred
+      // Pass 2: 1 call succeeds on the first instance
+      expect(vi.mocked(fetch).mock.calls.length).toBe(OVERPASS_INSTANCES.length + 1);
       // The second-pass result must have been cached — no further fetch needed
       vi.mocked(fetch).mockClear();
       const cached = await getStreetGeometryFromOverpass("ул. Пример");
       expect(cached).not.toBeNull();
       expect(vi.mocked(fetch).mock.calls.length).toBe(0);
+
+      // Restore default delay mock
+      vi.mocked(delay).mockResolvedValue(undefined);
     });
 
     it("caches persistently unavailable streets as null after retry exhaustion", async () => {

--- a/ingest/geocoding/overpass/service.ts
+++ b/ingest/geocoding/overpass/service.ts
@@ -244,9 +244,21 @@ export async function preFetchStreetGeometries(
 
     clearDeferredStreetGeometryKeys();
 
+    const unknownDeferredCount =
+      [...ctx.deferredKeys].filter((k) => !keyToName.has(k)).length;
+    if (unknownDeferredCount > 0) {
+      logger.warn(
+        "preFetchStreetGeometries: deferred keys with no matching name — streets will not be retried",
+        { count: unknownDeferredCount },
+      );
+    }
+
     logger.debug("Retrying deferred street geometry pre-fetches", {
       count: deferredNames.length,
     });
+
+    // Respect rate limiting between the last request of pass 1 and the first of pass 2
+    if (deferredNames.length > 0) await delay(OVERPASS_DELAY_MS);
 
     for (let i = 0; i < deferredNames.length; i++) {
       if (i > 0) await delay(OVERPASS_DELAY_MS);

--- a/ingest/geocoding/overpass/service.ts
+++ b/ingest/geocoding/overpass/service.ts
@@ -201,7 +201,9 @@ export function seedStreetGeometryCache(
  * Pre-fetch street geometries for a batch of names, populating the in-memory cache
  * before intersection geocoding begins.
  *
- * Deduplicates by normalized cache key so each unique street is fetched at most once.
+ * Deduplicates by full cache key (inferred feature type + normalised street name) so
+ * each unique query variant is fetched at most once — e.g. "\u0443\u043b. \u041e\u0431\u043e\u0440\u0438\u0449\u0435" (street) and
+ * "\u0431\u0443\u043b. \u041e\u0431\u043e\u0440\u0438\u0449\u0435" (boulevard) produce different keys and are each fetched once.
  * Runs an internal two-pass retry (identical in structure to overpassGeocodeIntersections):
  * streets that fail transiently in the first pass are retried once.  Streets still
  * deferred after the retry pass are written into the cache as null, which converts

--- a/ingest/geocoding/overpass/service.ts
+++ b/ingest/geocoding/overpass/service.ts
@@ -197,6 +197,78 @@ export function seedStreetGeometryCache(
   }
 }
 
+/**
+ * Pre-fetch street geometries for a batch of names, populating the in-memory cache
+ * before intersection geocoding begins.
+ *
+ * Deduplicates by normalized cache key so each unique street is fetched at most once.
+ * Runs an internal two-pass retry (identical in structure to overpassGeocodeIntersections):
+ * streets that fail transiently in the first pass are retried once.  Streets still
+ * deferred after the retry pass are written into the cache as null, which converts
+ * future lookups into immediate cache hits and prevents repeated Overpass calls for the
+ * same unavailable street across multiple sections.
+ *
+ * Includes OVERPASS_DELAY_MS between requests (Overpass rate-limiting constraint).
+ */
+export async function preFetchStreetGeometries(
+  streetNames: string[],
+): Promise<void> {
+  // Deduplicate by cache key; skip names already resolved (success, null, or pending dedup)
+  const keyToName = new Map<string, string>();
+  for (const name of streetNames) {
+    if (!name.trim()) continue;
+    const key = getStreetGeometryCacheKey(name);
+    if (keyToName.has(key) || streetGeometryCache.has(key)) continue;
+    keyToName.set(key, name);
+  }
+
+  if (keyToName.size === 0) return;
+
+  const toFetch = [...keyToName.values()];
+  logger.debug("Pre-fetching street geometries", { count: toFetch.length });
+
+  await runWithDeferredRetryScope(async () => {
+    // First pass: fetch each unique name
+    for (let i = 0; i < toFetch.length; i++) {
+      if (i > 0) await delay(OVERPASS_DELAY_MS);
+      await getStreetGeometryFromOverpass(toFetch[i]);
+    }
+
+    // Second pass: retry names that were deferred by transient failures
+    const ctx = getRunContext();
+    if (!ctx || ctx.deferredKeys.size === 0) return;
+
+    const deferredNames = [...ctx.deferredKeys]
+      .map((k) => keyToName.get(k))
+      .filter((n): n is string => n !== undefined);
+
+    clearDeferredStreetGeometryKeys();
+
+    logger.debug("Retrying deferred street geometry pre-fetches", {
+      count: deferredNames.length,
+    });
+
+    for (let i = 0; i < deferredNames.length; i++) {
+      if (i > 0) await delay(OVERPASS_DELAY_MS);
+      await getStreetGeometryFromOverpass(deferredNames[i]);
+    }
+
+    // Any streets still deferred after retry are unlikely to succeed in the current run.
+    // Cache them as null so that subsequent intersection processing gets an immediate
+    // cache hit instead of issuing another Overpass request per section.
+    const ctxAfterRetry = getRunContext();
+    if (ctxAfterRetry && ctxAfterRetry.deferredKeys.size > 0) {
+      logger.debug("Marking persistently unavailable streets in cache", {
+        count: ctxAfterRetry.deferredKeys.size,
+      });
+      for (const key of ctxAfterRetry.deferredKeys) {
+        streetGeometryCache.set(key, null);
+      }
+      ctxAfterRetry.deferredKeys.clear();
+    }
+  });
+}
+
 function isStreetGeometryDeferred(streetName: string): boolean {
   const ctx = getRunContext();
   return Boolean(ctx?.deferredKeys.has(getStreetGeometryCacheKey(streetName)));

--- a/ingest/geocoding/overpass/service.ts
+++ b/ingest/geocoding/overpass/service.ts
@@ -210,9 +210,22 @@ export function seedStreetGeometryCache(
  *
  * Includes OVERPASS_DELAY_MS between requests (Overpass rate-limiting constraint).
  */
+/**
+ * PRECONDITION: must not be called from within an existing runWithDeferredRetryScope.
+ * The function creates its own isolated scope and calls clearDeferredStreetGeometryKeys()
+ * internally; if an outer scope exists those calls would corrupt its deferred-key state,
+ * breaking the outer retry logic. A defensive guard is applied at runtime.
+ */
 export async function preFetchStreetGeometries(
   streetNames: string[],
 ): Promise<void> {
+  if (getRunContext() !== undefined) {
+    logger.warn(
+      "preFetchStreetGeometries called inside an existing retry scope — skipping pre-fetch",
+    );
+    return;
+  }
+
   // Deduplicate by cache key; skip names already resolved (success, null, or pending dedup)
   const keyToName = new Map<string, string>();
   for (const name of streetNames) {
@@ -238,14 +251,17 @@ export async function preFetchStreetGeometries(
     const ctx = getRunContext();
     if (!ctx || ctx.deferredKeys.size === 0) return;
 
-    const deferredNames = [...ctx.deferredKeys]
+    // Snapshot before clearing — clearDeferredStreetGeometryKeys empties the Set
+    const deferredKeys = [...ctx.deferredKeys];
+    const deferredNames = deferredKeys
       .map((k) => keyToName.get(k))
       .filter((n): n is string => n !== undefined);
+    const unknownDeferredCount = deferredKeys.filter(
+      (k) => !keyToName.has(k),
+    ).length;
 
     clearDeferredStreetGeometryKeys();
 
-    const unknownDeferredCount =
-      [...ctx.deferredKeys].filter((k) => !keyToName.has(k)).length;
     if (unknownDeferredCount > 0) {
       logger.warn(
         "preFetchStreetGeometries: deferred keys with no matching name — streets will not be retried",

--- a/ingest/messageIngest/geocode-addresses.test.ts
+++ b/ingest/messageIngest/geocode-addresses.test.ts
@@ -35,6 +35,7 @@ vi.mock("@/geocoding/router", () => ({
     .fn()
     .mockResolvedValue(new Map()),
   geocodeBusStops: vi.fn().mockResolvedValue([]),
+  hasHouseNumber: vi.fn().mockReturnValue(false),
 }));
 
 vi.mock("@/geocoding/overpass/service", () => ({
@@ -42,6 +43,7 @@ vi.mock("@/geocoding/overpass/service", () => ({
   getStreetGeometryCached: vi.fn().mockReturnValue(null),
   getStreetGeometryFromOverpass: vi.fn().mockResolvedValue(null),
   hasStreetGeometryQueried: vi.fn().mockReturnValue(false),
+  preFetchStreetGeometries: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("@/lib/delay", () => ({

--- a/ingest/messageIngest/geocode-addresses.test.ts
+++ b/ingest/messageIngest/geocode-addresses.test.ts
@@ -360,6 +360,46 @@ describe("geocodeAddressesFromExtractedData", () => {
     // geocodeAddresses should be called only for the pin without coordinates
     expect(geocodeAddresses).toHaveBeenCalledWith(["Without coordinates"]);
   });
+
+  it("excludes house-number endpoints from preFetchStreetGeometries", async () => {
+    const { hasHouseNumber } = await import("@/geocoding/router");
+    const { preFetchStreetGeometries } = await import(
+      "@/geocoding/overpass/service"
+    );
+
+    // Make hasHouseNumber return true only for the "№15" endpoint
+    vi.mocked(hasHouseNumber).mockImplementation((ep) => ep === "№15");
+
+    const extractedData: ExtractedLocations = {
+      withSpecificAddress: true,
+      cityWide: false,
+      busStops: [],
+      pins: [],
+      streets: [
+        {
+          street: "ул. Оборище",
+          from: "ул. Г. С. Раковски",
+          to: "№15",
+          timespans: [{ start: "01.02.2026 00:00", end: "02.02.2026 00:00" }],
+        },
+      ],
+      cadastralProperties: [],
+    };
+
+    await geocodeAddressesFromExtractedData(extractedData);
+
+    // preFetchStreetGeometries must receive the main street and the cross-street endpoint,
+    // but NOT the house-number endpoint "№15"
+    expect(preFetchStreetGeometries).toHaveBeenCalledWith(
+      expect.not.arrayContaining(["№15"]),
+    );
+    expect(preFetchStreetGeometries).toHaveBeenCalledWith(
+      expect.arrayContaining(["ул. Оборище", "ул. Г. С. Раковски"]),
+    );
+
+    // Restore default mock
+    vi.mocked(hasHouseNumber).mockReturnValue(false);
+  });
 });
 
 describe("getValidPreResolvedCoordinates", () => {

--- a/ingest/messageIngest/geocode-addresses.ts
+++ b/ingest/messageIngest/geocode-addresses.ts
@@ -138,7 +138,12 @@ function collectUniqueStreetNames(
 ): string[] {
   const names: string[] = [];
   for (const street of streets) {
+    // street.street is the canonical street name (e.g. "ул. Оборище"), never a
+    // house-number string, so no hasHouseNumber guard is needed here.
     names.push(street.street);
+    // Include both endpoints even for sections where only one needs Overpass — any
+    // already-geocoded or house-number endpoint is excluded by the guards below.
+    // The cache-skip inside preFetchStreetGeometries makes the extra names free.
     if (!preGeocodedMap.has(street.from) && !hasHouseNumber(street.from)) {
       names.push(street.from);
     }

--- a/ingest/messageIngest/geocode-addresses.ts
+++ b/ingest/messageIngest/geocode-addresses.ts
@@ -4,8 +4,12 @@ import {
   geocodeCadastralPropertiesFromIdentifiers,
   geocodeBusStops,
   geocodeEducationalFacilities,
+  hasHouseNumber,
 } from "@/geocoding/router";
-import { overpassGeocodeAddresses } from "@/geocoding/overpass/service";
+import {
+  overpassGeocodeAddresses,
+  preFetchStreetGeometries,
+} from "@/geocoding/overpass/service";
 import {
   Address,
   ExtractedLocations,
@@ -120,6 +124,29 @@ function haversineDistance(
       Math.sin(dLng / 2);
   const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
   return R * c;
+}
+
+/**
+ * Collect all unique street names referenced across a batch of sections.
+ * Includes the main street name and any cross-street endpoints (non-house-number).
+ * Pre-geocoded endpoints are excluded because they never need an Overpass lookup.
+ * Deduplication by normalized cache key happens inside preFetchStreetGeometries.
+ */
+function collectUniqueStreetNames(
+  streets: StreetSection[],
+  preGeocodedMap: Map<string, Coordinates>,
+): string[] {
+  const names: string[] = [];
+  for (const street of streets) {
+    names.push(street.street);
+    if (!preGeocodedMap.has(street.from) && !hasHouseNumber(street.from)) {
+      names.push(street.from);
+    }
+    if (!preGeocodedMap.has(street.to) && !hasHouseNumber(street.to)) {
+      names.push(street.to);
+    }
+  }
+  return names;
 }
 
 /**
@@ -398,6 +425,17 @@ async function geocodeStreetIntersections(
   );
 
   if (streetsNeedingGeocoding.length > 0) {
+    // Phase 3: Pre-fetch all unique street geometries into the cache before processing
+    // intersections. Each unique normalized street name is fetched at most once (with a
+    // built-in two-pass deferred retry). Streets that still fail after retry are cached
+    // as null, so subsequent per-section intersection calls get immediate cache hits
+    // instead of repeating Overpass requests for the same unavailable street.
+    const uniqueStreetNames = collectUniqueStreetNames(
+      streetsNeedingGeocoding,
+      preGeocodedMap,
+    );
+    await preFetchStreetGeometries(uniqueStreetNames);
+
     logger.debug("Geocoding streets via Overpass (per-street)", {
       total: streetsNeedingGeocoding.length,
       trackerActive: !!tracker,


### PR DESCRIPTION
## Summary

Part of the geocoding stability plan for issue #348. Reduces total Overpass calls per run so that **each unique normalised street name is fetched at most once**, regardless of how many street sections reference it.

---

## Problem

Before this change, `geocodeStreetIntersections` processed sections one at a time. Each call to `geocodeSingleIntersection` independently called `getStreetGeometryFromOverpass` for its two street names. If `"ул. Оборище"` appeared in 10 sections, it triggered up to 10 Overpass requests (or 10 deferred-retry entries) — one per section.

---

## Solution

### New export: `preFetchStreetGeometries(streetNames: string[])` in `overpass/service.ts`

Before the per-section intersection loop, all unique street tokens are collected and pre-fetched in one pass:

1. **Deduplication by normalised cache key** — `"ул. Оборище"` and `"ул.Оборище"` normalise to the same key; only one Overpass request is made.
2. **Cache-skip** — names already present in the in-memory geometry cache are excluded entirely (no network call).
3. **Internal two-pass deferred retry** — mirrors the structure of `overpassGeocodeIntersections`: streets that fail transiently in the first pass are retried once, within the same `AsyncLocalStorage` run scope, so the circuit breaker and deferred-key sets are shared.
4. **Persistent-failure null caching** — streets still deferred after the retry pass are written into the geometry cache as `null`. All subsequent per-section lookups for those streets become immediate cache hits instead of new Overpass requests.

### New helper: `collectUniqueStreetNames()` in `geocode-addresses.ts`

Collects the main street name and any cross-street endpoints (skipping house-number endpoints and already-geocoded endpoints) across all sections needing geocoding. Called once before the section loop; the result is passed to `preFetchStreetGeometries`.

---

## Acceptance criterion

> Unique Overpass call count ≤ unique normalised street name count.

This is now guaranteed structurally: `preFetchStreetGeometries` deduplicates before issuing any request, and caches null for persistently unavailable streets so the subsequent `getStreetGeometryFromOverpass` calls inside intersection resolution always hit the cache.

---

## Tests

5 new unit tests for `preFetchStreetGeometries`:

| Test | What it verifies |
|---|---|
| Dedup by normalised key | 3 names → 2 calls |
| Cache-skip | Already-cached names generate 0 new fetches |
| Deferred retry | Transient failure on pass 1 → retried on pass 2 |
| Persistent-failure null caching | After retry exhaustion, subsequent `getStreetGeometryFromOverpass` is a cache hit |
| No-op for empty / blank input | No fetches made |

Total test count: **1181** (all passing).
