### PR TITLE
Message detail: AI-processed notice with conditional source link

### DIFF
--- a/web/components/MessageDetailView/AiProcessedNotice.tsx
+++ b/web/components/MessageDetailView/AiProcessedNotice.tsx
@@ -1,0 +1,51 @@
+interface AiProcessedNoticeProps {
+  readonly sourceId?: string;
+  readonly sourceUrl?: string;
+}
+
+export function hasValidSourceUrl(sourceUrl?: string): boolean {
+  return sourceUrl?.startsWith("https://") ?? false;
+}
+
+export default function AiProcessedNotice({
+  sourceId,
+  sourceUrl,
+}: Readonly<AiProcessedNoticeProps>) {
+  const showSourceHint = hasValidSourceUrl(sourceUrl) && Boolean(sourceId);
+
+  return (
+    <p className="rounded-md border border-info-border bg-info-light p-3 text-sm text-neutral">
+      Съдържанието е обработено от AI и може да съдържа неточности.
+      {showSourceHint && sourceUrl && sourceId && (
+        <>
+          {" "}
+          За пълен контекст виж{" "}
+          <a
+            href={sourceUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 underline underline-offset-2"
+          >
+            <span>оригиналния източник</span>
+            <svg
+              className="h-3.5 w-3.5 text-neutral"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+              data-testid="external-link-icon"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+              />
+            </svg>
+          </a>
+          .
+        </>
+      )}
+    </p>
+  );
+}

--- a/web/components/MessageDetailView/AiProcessedNotice.tsx
+++ b/web/components/MessageDetailView/AiProcessedNotice.tsx
@@ -1,3 +1,5 @@
+import ExternalLinkIcon from "@/components/icons/ExternalLinkIcon";
+
 interface AiProcessedNoticeProps {
   readonly sourceUrl?: string;
 }
@@ -35,21 +37,10 @@ export default function AiProcessedNotice({
             className="inline-flex items-center gap-1 underline underline-offset-2"
           >
             <span>оригиналния източник</span>
-            <svg
+            <ExternalLinkIcon
               className="h-3.5 w-3.5 text-neutral"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
               data-testid="external-link-icon"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
-              />
-            </svg>
+            />
           </a>
           .
         </>

--- a/web/components/MessageDetailView/AiProcessedNotice.tsx
+++ b/web/components/MessageDetailView/AiProcessedNotice.tsx
@@ -1,14 +1,21 @@
 interface AiProcessedNoticeProps {
-  readonly sourceId?: string;
   readonly sourceUrl?: string;
 }
 
 export function hasValidSourceUrl(sourceUrl?: string): boolean {
-  return sourceUrl?.startsWith("https://") ?? false;
+  if (!sourceUrl) {
+    return false;
+  }
+
+  try {
+    const url = new URL(sourceUrl);
+    return url.protocol === "https:";
+  } catch {
+    return false;
+  }
 }
 
 export default function AiProcessedNotice({
-  sourceId,
   sourceUrl,
 }: Readonly<AiProcessedNoticeProps>) {
   const showSourceHint = hasValidSourceUrl(sourceUrl);

--- a/web/components/MessageDetailView/AiProcessedNotice.tsx
+++ b/web/components/MessageDetailView/AiProcessedNotice.tsx
@@ -1,20 +1,10 @@
 import ExternalLinkIcon from "@/components/icons/ExternalLinkIcon";
+import { hasValidSourceUrl } from "@/lib/url-utils";
+
+export { hasValidSourceUrl };
 
 interface AiProcessedNoticeProps {
   readonly sourceUrl?: string;
-}
-
-export function hasValidSourceUrl(sourceUrl?: string): boolean {
-  if (!sourceUrl) {
-    return false;
-  }
-
-  try {
-    const url = new URL(sourceUrl);
-    return url.protocol === "https:";
-  } catch {
-    return false;
-  }
 }
 
 export default function AiProcessedNotice({

--- a/web/components/MessageDetailView/AiProcessedNotice.tsx
+++ b/web/components/MessageDetailView/AiProcessedNotice.tsx
@@ -11,12 +11,12 @@ export default function AiProcessedNotice({
   sourceId,
   sourceUrl,
 }: Readonly<AiProcessedNoticeProps>) {
-  const showSourceHint = hasValidSourceUrl(sourceUrl) && Boolean(sourceId);
+  const showSourceHint = hasValidSourceUrl(sourceUrl);
 
   return (
     <p className="rounded-md border border-info-border bg-info-light p-3 text-sm text-neutral">
       Съдържанието е обработено от AI и може да съдържа неточности.
-      {showSourceHint && sourceUrl && sourceId && (
+      {showSourceHint && sourceUrl && (
         <>
           {" "}
           За пълен контекст виж{" "}
@@ -24,6 +24,7 @@ export default function AiProcessedNotice({
             href={sourceUrl}
             target="_blank"
             rel="noopener noreferrer"
+            aria-label="оригиналния източник (отваря се в нов таб)"
             className="inline-flex items-center gap-1 underline underline-offset-2"
           >
             <span>оригиналния източник</span>

--- a/web/components/MessageDetailView/MessageDetailView.test.tsx
+++ b/web/components/MessageDetailView/MessageDetailView.test.tsx
@@ -151,4 +151,27 @@ describe("MessageDetailView AI notice", () => {
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
   });
+
+  it("renders notice for message with markdownText", () => {
+    render(
+      <MessageDetailView
+        message={{
+          ...baseMessage,
+          markdownText: "**Тестово** съобщение",
+          sourceUrl: "https://example.com/msg",
+        }}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        /Съдържанието е обработено от AI и може да съдържа неточности\./,
+      ),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("link", { name: /оригиналния източник/i }),
+    ).toBeInTheDocument();
+  });
 });

--- a/web/components/MessageDetailView/MessageDetailView.test.tsx
+++ b/web/components/MessageDetailView/MessageDetailView.test.tsx
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { within } from "@testing-library/react";
+import type { Message } from "@/lib/types";
+import MessageDetailView from "./MessageDetailView";
+
+vi.mock("@/lib/analytics", () => ({
+  trackEvent: vi.fn(),
+}));
+
+vi.mock("@/lib/message-classification", () => ({
+  classifyMessage: () => "active",
+}));
+
+vi.mock("@/lib/hooks/useDragPanel", () => ({
+  useDragPanel: () => ({
+    isDragging: false,
+    dragOffset: 0,
+    handlers: {
+      onTouchStart: vi.fn(),
+      onTouchMove: vi.fn(),
+      onTouchEnd: vi.fn(),
+      onMouseDown: vi.fn(),
+    },
+  }),
+}));
+
+vi.mock("@/lib/hooks/useMessageAnimation", () => ({
+  useMessageAnimation: () => true,
+}));
+
+vi.mock("@/lib/hooks/useEscapeKey", () => ({
+  useEscapeKey: vi.fn(),
+}));
+
+vi.mock("@/lib/geometry-utils", () => ({
+  getFeaturesCentroid: () => null,
+}));
+
+vi.mock("@/components/CategoryChips", () => ({
+  default: () => <div data-testid="category-chips" />,
+}));
+
+vi.mock("./Header", () => ({
+  default: () => <div data-testid="message-detail-header" />,
+}));
+
+vi.mock("./Source", () => ({
+  default: () => <div data-testid="message-detail-source" />,
+}));
+
+vi.mock("./Locations", () => ({
+  default: () => <div data-testid="message-detail-locations" />,
+}));
+
+const baseMessage: Message = {
+  id: "m1",
+  text: "Тестово съобщение",
+  createdAt: "2026-04-07T00:00:00.000Z",
+  locality: "София",
+  source: "sofiatraffic",
+  responsibleEntity: "Столична община",
+};
+
+describe("MessageDetailView AI notice", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("matchMedia", () => ({
+      matches: false,
+      media: "(max-width: 639px)",
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+  });
+
+  it("shows source-aware notice when sourceUrl is valid https", () => {
+    render(
+      <MessageDetailView
+        message={{ ...baseMessage, sourceUrl: "https://example.com/msg" }}
+        onClose={vi.fn()}
+      />,
+    );
+
+    const sourceLink = screen.getByRole("link", {
+      name: /оригиналния източник/i,
+    });
+    expect(sourceLink).toHaveAttribute("href", "https://example.com/msg");
+    expect(
+      within(sourceLink).getByTestId("external-link-icon"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows source-neutral notice when sourceUrl is missing", () => {
+    render(<MessageDetailView message={baseMessage} onClose={vi.fn()} />);
+
+    expect(
+      screen.getByText(
+        "Съдържанието е обработено от AI и може да съдържа неточности.",
+      ),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByText(/За пълен контекст виж оригиналния източник\./),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows source-neutral notice when sourceUrl is not https", () => {
+    render(
+      <MessageDetailView
+        message={{ ...baseMessage, sourceUrl: "http://example.com/msg" }}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        "Съдържанието е обработено от AI и може да съдържа неточности.",
+      ),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole("link", { name: /оригиналния източник/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders notice below responsible entity", () => {
+    render(
+      <MessageDetailView
+        message={{ ...baseMessage, sourceUrl: "https://example.com/msg" }}
+        onClose={vi.fn()}
+      />,
+    );
+
+    const responsibleEntity = screen.getByText("Столична община");
+    const notice = screen.getByText(
+      /Съдържанието е обработено от AI и може да съдържа неточности\./,
+    );
+
+    expect(
+      responsibleEntity.compareDocumentPosition(notice) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+});

--- a/web/components/MessageDetailView/MessageDetailView.test.tsx
+++ b/web/components/MessageDetailView/MessageDetailView.test.tsx
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { within } from "@testing-library/react";
 import type { Message } from "@/lib/types";
@@ -65,6 +65,7 @@ const baseMessage: Message = {
 describe("MessageDetailView AI notice", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllGlobals();
     vi.stubGlobal("matchMedia", () => ({
       matches: false,
       media: "(max-width: 639px)",
@@ -75,6 +76,10 @@ describe("MessageDetailView AI notice", () => {
       removeListener: vi.fn(),
       dispatchEvent: vi.fn(),
     }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it("shows source-aware notice when sourceUrl is valid https", () => {

--- a/web/components/MessageDetailView/MessageDetailView.test.tsx
+++ b/web/components/MessageDetailView/MessageDetailView.test.tsx
@@ -56,6 +56,7 @@ vi.mock("./Locations", () => ({
 const baseMessage: Message = {
   id: "m1",
   text: "Тестово съобщение",
+  plainText: "Тестово съобщение",
   createdAt: "2026-04-07T00:00:00.000Z",
   locality: "София",
   source: "sofiatraffic",

--- a/web/components/MessageDetailView/MessageDetailView.tsx
+++ b/web/components/MessageDetailView/MessageDetailView.tsx
@@ -13,6 +13,7 @@ import SourceDisplay from "./Source";
 import Locations from "./Locations";
 import DetailItem from "./DetailItem";
 import MessageText from "./MessageText";
+import AiProcessedNotice from "./AiProcessedNotice";
 import CategoryChips from "@/components/CategoryChips";
 import { getFeaturesCentroid } from "@/lib/geometry-utils";
 
@@ -297,6 +298,11 @@ export default function MessageDetailView({
             </p>
           </DetailItem>
         )}
+
+        <AiProcessedNotice
+          sourceId={message.source}
+          sourceUrl={message.sourceUrl}
+        />
 
         <Locations
           pins={message.pins}

--- a/web/components/MessageDetailView/MessageDetailView.tsx
+++ b/web/components/MessageDetailView/MessageDetailView.tsx
@@ -299,10 +299,9 @@ export default function MessageDetailView({
           </DetailItem>
         )}
 
-        <AiProcessedNotice
-          sourceId={message.source}
-          sourceUrl={message.sourceUrl}
-        />
+        {"plainText" in message && (
+          <AiProcessedNotice sourceUrl={message.sourceUrl} />
+        )}
 
         <Locations
           pins={message.pins}

--- a/web/components/MessageDetailView/Source.tsx
+++ b/web/components/MessageDetailView/Source.tsx
@@ -3,6 +3,7 @@ import Image from "next/image";
 import { trackEvent } from "@/lib/analytics";
 import sources from "@/lib/sources";
 import DetailItem from "./DetailItem";
+import ExternalLinkIcon from "@/components/icons/ExternalLinkIcon";
 
 interface SourceProps {
   readonly sourceId: string;
@@ -98,20 +99,7 @@ export default function SourceDisplay({ sourceId, sourceUrl }: SourceProps) {
             }}
           >
             {content}
-            <svg
-              className="w-3.5 h-3.5 text-gray-400 flex-shrink-0"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
-              />
-            </svg>
+            <ExternalLinkIcon className="w-3.5 h-3.5 text-gray-400 flex-shrink-0" />
           </a>
         ) : (
           content

--- a/web/components/MessageDetailView/Source.tsx
+++ b/web/components/MessageDetailView/Source.tsx
@@ -4,6 +4,7 @@ import { trackEvent } from "@/lib/analytics";
 import sources from "@/lib/sources";
 import DetailItem from "./DetailItem";
 import ExternalLinkIcon from "@/components/icons/ExternalLinkIcon";
+import { hasValidSourceUrl } from "@/lib/url-utils";
 
 interface SourceProps {
   readonly sourceId: string;
@@ -64,7 +65,7 @@ export default function SourceDisplay({ sourceId, sourceUrl }: SourceProps) {
   const [logoError, setLogoError] = useState(false);
   const source = sources.find((s) => s.id === sourceId);
   const logoPath = `/sources/${sourceId}.png`;
-  const isValidUrl = sourceUrl?.startsWith("https://");
+  const isValidUrl = hasValidSourceUrl(sourceUrl);
 
   const content = (
     <SourceContent

--- a/web/components/icons/ExternalLinkIcon.tsx
+++ b/web/components/icons/ExternalLinkIcon.tsx
@@ -1,0 +1,28 @@
+import { SVGProps } from "react";
+
+interface ExternalLinkIconProps extends SVGProps<SVGSVGElement> {
+  readonly className?: string;
+}
+
+export default function ExternalLinkIcon({
+  className,
+  ...props
+}: ExternalLinkIconProps) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      {...props}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+      />
+    </svg>
+  );
+}

--- a/web/lib/url-utils.test.ts
+++ b/web/lib/url-utils.test.ts
@@ -3,6 +3,7 @@ import {
   extractHostname,
   createMessageUrl,
   createMessageUrlFromId,
+  hasValidSourceUrl,
 } from "./url-utils";
 import type { Message } from "./types";
 
@@ -101,5 +102,35 @@ describe("createMessageUrlFromId", () => {
     expect(createMessageUrlFromId("test/id?value")).toBe(
       "/?messageId=test%2Fid%3Fvalue",
     );
+  });
+});
+
+describe("hasValidSourceUrl", () => {
+  it("returns true for valid https URL", () => {
+    expect(hasValidSourceUrl("https://example.com/path")).toBe(true);
+  });
+
+  it("returns false for http URL", () => {
+    expect(hasValidSourceUrl("http://example.com/path")).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(hasValidSourceUrl(undefined)).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(hasValidSourceUrl("")).toBe(false);
+  });
+
+  it("returns false for invalid URL string", () => {
+    expect(hasValidSourceUrl("not a url")).toBe(false);
+  });
+
+  it("returns false for https:// with no host", () => {
+    expect(hasValidSourceUrl("https://")).toBe(false);
+  });
+
+  it("returns true for https URL with query params", () => {
+    expect(hasValidSourceUrl("https://example.com/path?foo=bar")).toBe(true);
   });
 });

--- a/web/lib/url-utils.ts
+++ b/web/lib/url-utils.ts
@@ -49,3 +49,16 @@ export function createMessageUrl(message: Message): string {
 export function createMessageUrlFromId(messageId: string): string {
   return `/?messageId=${encodeURIComponent(messageId)}`;
 }
+
+export function hasValidSourceUrl(sourceUrl?: string): boolean {
+  if (!sourceUrl) {
+    return false;
+  }
+
+  try {
+    const url = new URL(sourceUrl);
+    return url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
﻿## Summary
- add an AI-processed notice in message details
- place the notice below responsible entity
- render original source text as a target=_blank link only when source URL is valid HTTPS
- use external-link icon after link text (matching existing source link pattern)
- hide source mention when source URL is missing/invalid
- add MessageDetailView tests for link rendering and ordering

## Validation
- lint 
- tsc
- build
- test:run

Closes #365
