### PR TITLE
feat(api): add public API v2, deprecate v1

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -3,6 +3,10 @@ import { sourcesRoute } from "./routes/sources";
 import { messagesRoute } from "./routes/messages";
 import { messageByIdRoute } from "./routes/messages-by-id";
 import { openapiRoute } from "./routes/openapi";
+import { sourcesRouteV2 } from "./routes/v2/sources";
+import { messagesRouteV2 } from "./routes/v2/messages";
+import { messageByIdRouteV2 } from "./routes/v2/messages-by-id";
+import { openapiRouteV2 } from "./routes/v2/openapi";
 import { initSentry, captureException } from "./lib/sentry";
 
 initSentry();
@@ -12,11 +16,17 @@ const app = new Hono();
 // Health check
 app.get("/health", (c) => c.json({ status: "ok" }));
 
-// Public API routes (v1)
+// Public API routes (v1 — deprecated, sunset Oct 14 2026)
 app.route("/v1", sourcesRoute);
 app.route("/v1", messagesRoute);
 app.route("/v1", messageByIdRoute);
 app.route("/v1", openapiRoute);
+
+// Public API routes (v2)
+app.route("/v2", sourcesRouteV2);
+app.route("/v2", messagesRouteV2);
+app.route("/v2", messageByIdRouteV2);
+app.route("/v2", openapiRouteV2);
 
 // Global error handler
 app.onError((err, c) => {

--- a/api/src/lib/doc-to-message.v2.ts
+++ b/api/src/lib/doc-to-message.v2.ts
@@ -1,0 +1,34 @@
+import type { MessageV2 } from "../schema/contract.v2";
+import { toOptionalISOString, toRequiredISOString } from "./date-serialization";
+import { getCategories, getFeatureCollection } from "./typed-arrays";
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+/**
+ * Convert a database record to a public v2 Message object.
+ *
+ * Compared to v1, omits pipeline-internal fields that are derivable from
+ * geoJson: addresses, pins, streets, cadastralProperties, busStops.
+ */
+export function recordToMessageV2(record: Record<string, unknown>): MessageV2 {
+  return {
+    id: typeof record._id === "string" ? record._id : undefined,
+    text: typeof record.text === "string" ? record.text : "",
+    locality: typeof record.locality === "string" ? record.locality : "",
+    plainText: optionalString(record.plainText),
+    markdownText: optionalString(record.markdownText),
+    source: optionalString(record.source),
+    sourceUrl: optionalString(record.sourceUrl),
+    categories: getCategories(record.categories),
+    geoJson: getFeatureCollection(record.geoJson),
+    crawledAt: toOptionalISOString(record.crawledAt, "crawledAt"),
+    createdAt: toRequiredISOString(record.createdAt, "createdAt"),
+    finalizedAt: toOptionalISOString(record.finalizedAt, "finalizedAt"),
+    timespanStart: toOptionalISOString(record.timespanStart, "timespanStart"),
+    timespanEnd: toOptionalISOString(record.timespanEnd, "timespanEnd"),
+    cityWide: record.cityWide === true,
+    responsibleEntity: optionalString(record.responsibleEntity),
+  };
+}

--- a/api/src/lib/messages-query.ts
+++ b/api/src/lib/messages-query.ts
@@ -1,0 +1,215 @@
+/**
+ * Shared DB query utilities for message route handlers.
+ *
+ * These functions operate on raw MessageRecord (Record<string, unknown>) and
+ * have no dependency on the versioned Message type. They are shared between
+ * v1 and v2 route handlers to avoid duplicating DB/geo query logic.
+ */
+
+import type { OboDb } from "@oboapp/db";
+import type { WhereClause } from "@oboapp/db";
+import { clampBounds, addBuffer, type ViewportBounds } from "./bounds-utils";
+
+export type MessageRecord = Record<string, unknown>;
+
+const DEFAULT_RELEVANCE_DAYS = 7;
+const FIRESTORE_IN_OPERATOR_LIMIT = 10;
+
+export function isUncategorizedDoc(doc: MessageRecord): boolean {
+  const categories = Array.isArray(doc.categories) ? doc.categories : undefined;
+  return !categories || categories.length === 0;
+}
+
+export function toViewportBounds(params: {
+  north?: number;
+  south?: number;
+  east?: number;
+  west?: number;
+}): ViewportBounds | null {
+  const { north, south, east, west } = params;
+  if (
+    north === undefined ||
+    south === undefined ||
+    east === undefined ||
+    west === undefined
+  ) {
+    return null;
+  }
+
+  const rawBounds: ViewportBounds = { north, south, east, west };
+  const clampedBounds = clampBounds(rawBounds);
+  return addBuffer(clampedBounds, 0.2);
+}
+
+export function getCutoffDate(override?: Date): Date {
+  if (override) {
+    return override;
+  }
+
+  const parsed = process.env.MESSAGE_RELEVANCE_DAYS
+    ? Number.parseInt(process.env.MESSAGE_RELEVANCE_DAYS, 10)
+    : DEFAULT_RELEVANCE_DAYS;
+  const relevanceDays = Number.isNaN(parsed) ? DEFAULT_RELEVANCE_DAYS : parsed;
+
+  const cutoffDate = new Date();
+  cutoffDate.setDate(cutoffDate.getDate() - relevanceDays);
+  return cutoffDate;
+}
+
+export async function findRecentMessageDocs(
+  db: OboDb,
+  cutoffDate: Date,
+  locality?: string,
+): Promise<MessageRecord[]> {
+  const where: WhereClause[] = [
+    { field: "timespanEnd", op: ">=", value: cutoffDate },
+  ];
+  if (locality) {
+    where.push({ field: "locality", op: "==", value: locality });
+  }
+  return db.messages.findMany({
+    where,
+    orderBy: [{ field: "timespanEnd", direction: "desc" }],
+  });
+}
+
+export function chunkArray<T>(items: T[], chunkSize: number): T[][] {
+  const chunks: T[][] = [];
+  for (let index = 0; index < items.length; index += chunkSize) {
+    chunks.push(items.slice(index, index + chunkSize));
+  }
+  return chunks;
+}
+
+export async function findRecentMessageDocsBySources(
+  db: OboDb,
+  cutoffDate: Date,
+  sources: string[],
+  locality?: string,
+): Promise<MessageRecord[]> {
+  if (sources.length === 0) {
+    return [];
+  }
+
+  const sourceChunks = chunkArray(sources, FIRESTORE_IN_OPERATOR_LIMIT);
+  const chunkQueries = sourceChunks.map((sourceChunk) => {
+    const where: WhereClause[] = [
+      { field: "source", op: "in", value: sourceChunk },
+      { field: "timespanEnd", op: ">=", value: cutoffDate },
+    ];
+    if (locality) {
+      where.push({ field: "locality", op: "==", value: locality });
+    }
+    return db.messages.findMany({
+      where,
+      orderBy: [{ field: "timespanEnd", direction: "desc" }],
+    });
+  });
+
+  const chunkResults = await Promise.all(chunkQueries);
+  return chunkResults.flat();
+}
+
+function toSourceList(sourceSet?: Set<string>): string[] {
+  return sourceSet ? Array.from(sourceSet) : [];
+}
+
+export async function findUncategorizedDocs(
+  db: OboDb,
+  cutoffDate: Date,
+  sourceSet?: Set<string>,
+  locality?: string,
+): Promise<MessageRecord[]> {
+  const sourceList = toSourceList(sourceSet);
+  const docs = sourceList.length
+    ? await findRecentMessageDocsBySources(db, cutoffDate, sourceList, locality)
+    : await findRecentMessageDocs(db, cutoffDate, locality);
+
+  return docs.filter((doc) => isUncategorizedDoc(doc));
+}
+
+export function applyOptionalSourceSet(
+  docs: MessageRecord[],
+  sourceSet?: Set<string>,
+): MessageRecord[] {
+  if (!sourceSet) {
+    return docs;
+  }
+
+  return docs.filter(
+    (doc) => typeof doc.source === "string" && sourceSet.has(doc.source),
+  );
+}
+
+export function isInvalidSourceForFilter(
+  doc: MessageRecord,
+  sourceSet?: Set<string>,
+): boolean {
+  if (!sourceSet) {
+    return false;
+  }
+
+  return (
+    !doc.source || typeof doc.source !== "string" || !sourceSet.has(doc.source)
+  );
+}
+
+export async function buildCategoryQueryPlans(
+  db: OboDb,
+  cutoffDate: Date,
+  realCategories: string[],
+  includeUncategorized: boolean,
+  sourceSet?: Set<string>,
+  locality?: string,
+): Promise<Array<{ uncategorizedOnly: boolean; docs: MessageRecord[] }>> {
+  const plans: Array<
+    Promise<{ uncategorizedOnly: boolean; docs: MessageRecord[] }>
+  > = [];
+
+  if (realCategories.length > 0) {
+    const where: WhereClause[] = [
+      {
+        field: "categories",
+        op: "array-contains-any",
+        value: realCategories,
+      },
+      { field: "timespanEnd", op: ">=", value: cutoffDate },
+    ];
+    if (locality) {
+      where.push({ field: "locality", op: "==", value: locality });
+    }
+    plans.push(
+      db.messages
+        .findMany({
+          where,
+          orderBy: [{ field: "timespanEnd", direction: "desc" }],
+        })
+        .then((docs) => ({ uncategorizedOnly: false, docs })),
+    );
+  }
+
+  if (includeUncategorized) {
+    plans.push(
+      findUncategorizedDocs(db, cutoffDate, sourceSet, locality).then(
+        (docs) => ({
+          uncategorizedOnly: true,
+          docs,
+        }),
+      ),
+    );
+  }
+
+  return Promise.all(plans);
+}
+
+export function getValidatedSources(
+  selectedSources: string[] | undefined,
+  allSourceIds: Set<string>,
+): string[] | undefined {
+  if (!selectedSources || selectedSources.length === 0) {
+    return undefined;
+  }
+
+  const uniqueSources = Array.from(new Set(selectedSources));
+  return uniqueSources.filter((sourceId) => allSourceIds.has(sourceId));
+}

--- a/api/src/middleware/deprecation.ts
+++ b/api/src/middleware/deprecation.ts
@@ -1,0 +1,18 @@
+import type { MiddlewareHandler } from "hono";
+
+const SUNSET_DATE = "Tue, 14 Oct 2026 00:00:00 GMT";
+const SUCCESSOR_URL = "https://api.oboapp.online/v2/messages";
+
+/**
+ * Adds standard HTTP deprecation headers to v1 responses.
+ *
+ * Deprecation: true          — signals the endpoint is deprecated
+ * Sunset: <date>             — when it will be removed
+ * Link: <url>; rel="successor-version"  — points to the v2 equivalent
+ */
+export const v1DeprecationHeaders: MiddlewareHandler = async (c, next) => {
+  await next();
+  c.header("Deprecation", "true");
+  c.header("Sunset", SUNSET_DATE);
+  c.header("Link", `<${SUCCESSOR_URL}>; rel="successor-version"`);
+};

--- a/api/src/routes/messages-by-id.ts
+++ b/api/src/routes/messages-by-id.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { getDb } from "../lib/db";
 import { recordToMessage } from "../lib/doc-to-message";
 import { apiKeyAuth } from "../middleware/api-key";
+import { v1DeprecationHeaders } from "../middleware/deprecation";
 import { isValidMessageId } from "@oboapp/shared";
 
 /**
@@ -14,36 +15,41 @@ function stripSplitSuffix(id: string): string {
 
 export const messageByIdRoute = new Hono();
 
-messageByIdRoute.get("/messages/by-id", apiKeyAuth, async (c) => {
-  try {
-    const id = c.req.query("id");
+messageByIdRoute.get(
+  "/messages/by-id",
+  apiKeyAuth,
+  v1DeprecationHeaders,
+  async (c) => {
+    try {
+      const id = c.req.query("id");
 
-    if (!id) {
-      return c.json({ error: "Missing id parameter" }, 400);
-    }
-
-    const db = await getDb();
-
-    // Primary: look up by 8-char message ID
-    if (isValidMessageId(id)) {
-      const doc = await db.messages.findById(id);
-      if (doc) {
-        return c.json({ message: recordToMessage(doc) });
+      if (!id) {
+        return c.json({ error: "Missing id parameter" }, 400);
       }
+
+      const db = await getDb();
+
+      // Primary: look up by 8-char message ID
+      if (isValidMessageId(id)) {
+        const doc = await db.messages.findById(id);
+        if (doc) {
+          return c.json({ message: recordToMessage(doc) });
+        }
+        return c.json({ error: "Message not found" }, 404);
+      }
+
+      // Fallback: treat the id as a sourceDocumentId (strip optional "-N" suffix)
+      const sourceDocId = stripSplitSuffix(id);
+      const docs = await db.messages.findBySourceDocumentIds([sourceDocId]);
+
+      if (docs.length > 0) {
+        return c.json({ message: recordToMessage(docs[0]) });
+      }
+
       return c.json({ error: "Message not found" }, 404);
+    } catch (error) {
+      console.error("Error fetching message by id:", error);
+      return c.json({ error: "Failed to fetch message" }, 500);
     }
-
-    // Fallback: treat the id as a sourceDocumentId (strip optional "-N" suffix)
-    const sourceDocId = stripSplitSuffix(id);
-    const docs = await db.messages.findBySourceDocumentIds([sourceDocId]);
-
-    if (docs.length > 0) {
-      return c.json({ message: recordToMessage(docs[0]) });
-    }
-
-    return c.json({ error: "Message not found" }, 404);
-  } catch (error) {
-    console.error("Error fetching message by id:", error);
-    return c.json({ error: "Failed to fetch message" }, 500);
-  }
-});
+  },
+);

--- a/api/src/routes/messages.ts
+++ b/api/src/routes/messages.ts
@@ -1,25 +1,32 @@
 import { Hono } from "hono";
 import { SOURCES } from "@oboapp/shared";
 import { getDb } from "../lib/db";
-import type { WhereClause } from "@oboapp/db";
+import type { OboDb } from "@oboapp/db";
 import { recordToMessage } from "../lib/doc-to-message";
 import { apiKeyAuth } from "../middleware/api-key";
+import { v1DeprecationHeaders } from "../middleware/deprecation";
 import { messagesQuerySchema } from "../schema/query";
 import type { Message, GeoJsonFeature } from "../schema/contract";
 import {
-  clampBounds,
-  addBuffer,
   featureIntersectsBounds,
   type ViewportBounds,
 } from "../lib/bounds-utils";
 import { getCentroid } from "../lib/geometry-utils";
+import {
+  type MessageRecord,
+  isUncategorizedDoc,
+  toViewportBounds,
+  getCutoffDate,
+  findRecentMessageDocs,
+  findRecentMessageDocsBySources,
+  findUncategorizedDocs,
+  applyOptionalSourceSet,
+  isInvalidSourceForFilter,
+  buildCategoryQueryPlans,
+  getValidatedSources,
+} from "../lib/messages-query";
 
-const DEFAULT_RELEVANCE_DAYS = 7;
 const CLUSTER_ZOOM_THRESHOLD = 15;
-const FIRESTORE_IN_OPERATOR_LIMIT = 10;
-
-type DbClient = Awaited<ReturnType<typeof getDb>>;
-type MessageRecord = Record<string, unknown>;
 
 function sortMessagesByRelevance(messages: Message[]): Message[] {
   return [...messages].sort((a, b) => {
@@ -35,108 +42,18 @@ function sortMessagesByRelevance(messages: Message[]): Message[] {
   });
 }
 
-function isUncategorizedDoc(doc: MessageRecord): boolean {
-  const categories = Array.isArray(doc.categories) ? doc.categories : undefined;
-  return !categories || categories.length === 0;
-}
-
-function toViewportBounds(params: {
-  north?: number;
-  south?: number;
-  east?: number;
-  west?: number;
-}): ViewportBounds | null {
-  const { north, south, east, west } = params;
-  if (
-    north === undefined ||
-    south === undefined ||
-    east === undefined ||
-    west === undefined
-  ) {
-    return null;
-  }
-
-  const rawBounds: ViewportBounds = { north, south, east, west };
-  const clampedBounds = clampBounds(rawBounds);
-  return addBuffer(clampedBounds, 0.2);
-}
-
-function getCutoffDate(override?: Date): Date {
-  if (override) {
-    return override;
-  }
-
-  const parsed = process.env.MESSAGE_RELEVANCE_DAYS
-    ? Number.parseInt(process.env.MESSAGE_RELEVANCE_DAYS, 10)
-    : DEFAULT_RELEVANCE_DAYS;
-  const relevanceDays = Number.isNaN(parsed) ? DEFAULT_RELEVANCE_DAYS : parsed;
-
-  const cutoffDate = new Date();
-  cutoffDate.setDate(cutoffDate.getDate() - relevanceDays);
-  return cutoffDate;
-}
-
-async function findRecentMessageDocs(
-  db: DbClient,
-  cutoffDate: Date,
-  locality?: string,
-): Promise<MessageRecord[]> {
-  const where: WhereClause[] = [
-    { field: "timespanEnd", op: ">=", value: cutoffDate },
-  ];
-  if (locality) {
-    where.push({ field: "locality", op: "==", value: locality });
-  }
-  return db.messages.findMany({
-    where,
-    orderBy: [{ field: "timespanEnd", direction: "desc" }],
-  });
-}
-
-function chunkArray<T>(items: T[], chunkSize: number): T[][] {
-  const chunks: T[][] = [];
-  for (let index = 0; index < items.length; index += chunkSize) {
-    chunks.push(items.slice(index, index + chunkSize));
-  }
-  return chunks;
-}
-
-async function findRecentMessageDocsBySources(
-  db: DbClient,
-  cutoffDate: Date,
-  sources: string[],
-  locality?: string,
-): Promise<MessageRecord[]> {
-  if (sources.length === 0) {
-    return [];
-  }
-
-  const sourceChunks = chunkArray(sources, FIRESTORE_IN_OPERATOR_LIMIT);
-  const chunkQueries = sourceChunks.map((sourceChunk) => {
-    const where: WhereClause[] = [
-      { field: "source", op: "in", value: sourceChunk },
-      { field: "timespanEnd", op: ">=", value: cutoffDate },
-    ];
-    if (locality) {
-      where.push({ field: "locality", op: "==", value: locality });
-    }
-    return db.messages.findMany({
-      where,
-      orderBy: [{ field: "timespanEnd", direction: "desc" }],
-    });
-  });
-
-  const chunkResults = await Promise.all(chunkQueries);
-  return chunkResults.flat();
-}
-
 async function findMessagesBySources(
-  db: DbClient,
+  db: OboDb,
   cutoffDate: Date,
   sources: string[],
   locality?: string,
 ): Promise<Message[]> {
-  const results = await findRecentMessageDocsBySources(db, cutoffDate, sources, locality);
+  const results = await findRecentMessageDocsBySources(
+    db,
+    cutoffDate,
+    sources,
+    locality,
+  );
   const messagesMap = new Map<string, Message>();
 
   for (const doc of results) {
@@ -147,24 +64,6 @@ async function findMessagesBySources(
   }
 
   return sortMessagesByRelevance(Array.from(messagesMap.values()));
-}
-
-function toSourceList(sourceSet?: Set<string>): string[] {
-  return sourceSet ? Array.from(sourceSet) : [];
-}
-
-async function findUncategorizedDocs(
-  db: DbClient,
-  cutoffDate: Date,
-  sourceSet?: Set<string>,
-  locality?: string,
-): Promise<MessageRecord[]> {
-  const sourceList = toSourceList(sourceSet);
-  const docs = sourceList.length
-    ? await findRecentMessageDocsBySources(db, cutoffDate, sourceList, locality)
-    : await findRecentMessageDocs(db, cutoffDate, locality);
-
-  return docs.filter((doc) => isUncategorizedDoc(doc));
 }
 
 function dedupeAndMapMessages(docs: MessageRecord[]): Message[] {
@@ -180,80 +79,8 @@ function dedupeAndMapMessages(docs: MessageRecord[]): Message[] {
   return Array.from(messagesMap.values());
 }
 
-function applyOptionalSourceSet(
-  docs: MessageRecord[],
-  sourceSet?: Set<string>,
-): MessageRecord[] {
-  if (!sourceSet) {
-    return docs;
-  }
-
-  return docs.filter(
-    (doc) => typeof doc.source === "string" && sourceSet.has(doc.source),
-  );
-}
-
-function isInvalidSourceForFilter(
-  doc: MessageRecord,
-  sourceSet?: Set<string>,
-): boolean {
-  if (!sourceSet) {
-    return false;
-  }
-
-  return (
-    !doc.source || typeof doc.source !== "string" || !sourceSet.has(doc.source)
-  );
-}
-
-async function buildCategoryQueryPlans(
-  db: DbClient,
-  cutoffDate: Date,
-  realCategories: string[],
-  includeUncategorized: boolean,
-  sourceSet?: Set<string>,
-  locality?: string,
-): Promise<Array<{ uncategorizedOnly: boolean; docs: MessageRecord[] }>> {
-  const plans: Array<
-    Promise<{ uncategorizedOnly: boolean; docs: MessageRecord[] }>
-  > = [];
-
-  if (realCategories.length > 0) {
-    const where: WhereClause[] = [
-      {
-        field: "categories",
-        op: "array-contains-any",
-        value: realCategories,
-      },
-      { field: "timespanEnd", op: ">=", value: cutoffDate },
-    ];
-    if (locality) {
-      where.push({ field: "locality", op: "==", value: locality });
-    }
-    plans.push(
-      db.messages
-        .findMany({
-          where,
-          orderBy: [{ field: "timespanEnd", direction: "desc" }],
-        })
-        .then((docs) => ({ uncategorizedOnly: false, docs })),
-    );
-  }
-
-  if (includeUncategorized) {
-    plans.push(
-      findUncategorizedDocs(db, cutoffDate, sourceSet, locality).then((docs) => ({
-        uncategorizedOnly: true,
-        docs,
-      })),
-    );
-  }
-
-  return Promise.all(plans);
-}
-
 async function findMessagesByCategoryFilters(
-  db: DbClient,
+  db: OboDb,
   cutoffDate: Date,
   selectedCategories: string[],
   sourceSet?: Set<string>,
@@ -381,21 +208,9 @@ function simplifyMessagesForClusterZoom(
   });
 }
 
-function getValidatedSources(
-  selectedSources: string[] | undefined,
-  allSourceIds: Set<string>,
-): string[] | undefined {
-  if (!selectedSources || selectedSources.length === 0) {
-    return undefined;
-  }
-
-  const uniqueSources = Array.from(new Set(selectedSources));
-  return uniqueSources.filter((sourceId) => allSourceIds.has(sourceId));
-}
-
 export const messagesRoute = new Hono();
 
-messagesRoute.get("/messages", apiKeyAuth, async (c) => {
+messagesRoute.get("/messages", apiKeyAuth, v1DeprecationHeaders, async (c) => {
   try {
     const db = await getDb();
 
@@ -463,15 +278,7 @@ messagesRoute.get("/messages", apiKeyAuth, async (c) => {
         locality,
       );
     } else {
-      const where: WhereClause[] = [
-        { field: "timespanEnd", op: ">=", value: cutoffDate },
-      ];
-      where.push({ field: "locality", op: "==", value: locality });
-      const docs = await db.messages.findMany({
-        where,
-        orderBy: [{ field: "timespanEnd", direction: "desc" }],
-      });
-
+      const docs = await findRecentMessageDocs(db, cutoffDate, locality);
       allMessages = docs.map(recordToMessage);
     }
 

--- a/api/src/routes/openapi.ts
+++ b/api/src/routes/openapi.ts
@@ -166,7 +166,7 @@ function buildOpenApiSpec(): OpenAPIObject {
       title: "OboApp Public API",
       version: "1.0.0",
       description:
-        "Read-only public API for external consumption of OboApp city-infrastructure data. All data endpoints require a registered API key sent via the X-Api-Key header. You can create and manage API keys from the OboApp Settings page.",
+        "⚠️ **API v1 is deprecated** and will be removed on **October 14, 2026**. Please migrate to [API v2](/v2/docs).\n\nRead-only public API for external consumption of OboApp city-infrastructure data. All data endpoints require a registered API key sent via the X-Api-Key header. You can create and manage API keys from the OboApp Settings page.",
     },
     security: [{ ApiKeyAuth: [] }],
   });
@@ -189,11 +189,15 @@ openapiRoute.get("/docs", (c) => {
   const html = `<!DOCTYPE html>
 <html>
 <head>
-  <title>OboApp API Reference</title>
+  <title>OboApp API Reference v1 (Deprecated)</title>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
 </head>
 <body>
+  <div style="background:#fff3cd;border:1px solid #ffc107;border-radius:4px;padding:12px 16px;margin:16px;font-family:sans-serif;font-size:14px">
+    ⚠️ <strong>API v1 is deprecated</strong> and will be removed on <strong>October 14, 2026</strong>.
+    Please migrate to <a href="/v2/docs">API v2</a>.
+  </div>
   <script id="api-reference" data-url="/v1/openapi"></script>
   <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.25.59"></script>
 </body>

--- a/api/src/routes/routes.test.ts
+++ b/api/src/routes/routes.test.ts
@@ -42,10 +42,15 @@ describe("GET /v1/sources", () => {
     expect(source).toHaveProperty("url");
     expect(source).toHaveProperty("logoUrl");
   });
+
+  it("includes Deprecation header", async () => {
+    const res = await app.request("/v1/sources", { headers: API_KEY_HEADER });
+    expect(res.headers.get("Deprecation")).toBe("true");
+    expect(res.headers.get("Sunset")).toBeTruthy();
+  });
 });
 
 describe("GET /v1/messages", () => {
-
   it("returns 401 without API key", async () => {
     const res = await app.request("/v1/messages");
     expect(res.status).toBe(401);
@@ -197,6 +202,211 @@ describe("GET /v1/docs", () => {
     const html = await res.text();
     expect(html).toContain("<!DOCTYPE html>");
     expect(html).toContain("api-reference");
+  });
+
+  it("contains deprecation banner linking to /v2/docs", async () => {
+    const res = await app.request("/v1/docs");
+    const html = await res.text();
+    expect(html).toContain("/v2/docs");
+    expect(html).toContain("deprecated");
+  });
+});
+
+describe("GET /v2/sources", () => {
+  it("returns 401 without API key", async () => {
+    const res = await app.request("/v2/sources");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns sources with valid API key", async () => {
+    const res = await app.request("/v2/sources", {
+      headers: API_KEY_HEADER,
+    });
+    expect(res.status).toBe(200);
+    const body: any = await res.json();
+    expect(body).toHaveProperty("sources");
+    expect(Array.isArray(body.sources)).toBe(true);
+    expect(body.sources.length).toBeGreaterThan(0);
+    const source = body.sources[0];
+    expect(source).toHaveProperty("id");
+    expect(source).toHaveProperty("name");
+    expect(source).toHaveProperty("url");
+    expect(source).toHaveProperty("logoUrl");
+  });
+
+  it("does NOT include Deprecation header", async () => {
+    const res = await app.request("/v2/sources", {
+      headers: API_KEY_HEADER,
+    });
+    expect(res.headers.get("Deprecation")).toBeNull();
+  });
+});
+
+describe("GET /v2/messages", () => {
+  it("returns 401 without API key", async () => {
+    const res = await app.request("/v2/messages");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns messages without pipeline-internal fields", async () => {
+    const { getDb } = await import("@/lib/db");
+    const mockedGetDb = vi.mocked(getDb);
+    mockedGetDb.mockResolvedValue({
+      messages: {
+        findMany: vi.fn().mockResolvedValue([
+          {
+            _id: "msg2",
+            text: "Test v2 message",
+            createdAt: new Date("2025-01-01"),
+            locality: "bg.sofia",
+            source: "sofia-bg",
+            geoJson: {
+              type: "FeatureCollection",
+              features: [
+                {
+                  type: "Feature",
+                  geometry: { type: "Point", coordinates: [23.32, 42.69] },
+                  properties: {},
+                },
+              ],
+            },
+            timespanEnd: new Date("2099-12-31"),
+            addresses: [
+              {
+                originalText: "some street",
+                formattedAddress: "Some Street 1",
+                coordinates: { lat: 42.69, lng: 23.32 },
+              },
+            ],
+            pins: [{ address: "pin", timespans: [] }],
+            streets: [{ street: "Main St", from: "A", to: "B", timespans: [] }],
+            cadastralProperties: [{ identifier: "12345", timespans: [] }],
+            busStops: ["Stop 1"],
+          },
+        ]),
+        findById: vi.fn(),
+        findBySourceDocumentIds: vi.fn(),
+      },
+      apiClients: { findByApiKey: vi.fn() },
+    } as any);
+
+    const res = await app.request("/v2/messages", { headers: API_KEY_HEADER });
+    expect(res.status).toBe(200);
+    const body: any = await res.json();
+    expect(body).toHaveProperty("messages");
+    const msg = body.messages[0];
+    expect(msg).toHaveProperty("id", "msg2");
+    expect(msg).toHaveProperty("text", "Test v2 message");
+    expect(msg).toHaveProperty("geoJson");
+    // Pipeline-internal fields must be absent
+    expect(msg).not.toHaveProperty("addresses");
+    expect(msg).not.toHaveProperty("pins");
+    expect(msg).not.toHaveProperty("streets");
+    expect(msg).not.toHaveProperty("cadastralProperties");
+    expect(msg).not.toHaveProperty("busStops");
+  });
+
+  it("does NOT include Deprecation header", async () => {
+    const { getDb } = await import("@/lib/db");
+    vi.mocked(getDb).mockResolvedValue({
+      messages: { findMany: vi.fn().mockResolvedValue([]) },
+      apiClients: { findByApiKey: vi.fn() },
+    } as any);
+
+    const res = await app.request("/v2/messages", { headers: API_KEY_HEADER });
+    expect(res.headers.get("Deprecation")).toBeNull();
+  });
+});
+
+describe("GET /v2/messages/by-id", () => {
+  it("returns 401 without API key", async () => {
+    const res = await app.request("/v2/messages/by-id?id=abc123");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 without id parameter", async () => {
+    const res = await app.request("/v2/messages/by-id", {
+      headers: API_KEY_HEADER,
+    });
+    expect(res.status).toBe(400);
+    const body: any = await res.json();
+    expect(body.error).toMatch(/Missing id/i);
+  });
+
+  it("returns v2 message without pipeline-internal fields", async () => {
+    const { getDb } = await import("@/lib/db");
+    vi.mocked(getDb).mockResolvedValue({
+      messages: {
+        findById: vi.fn().mockResolvedValue({
+          _id: "abcd1234",
+          text: "Found v2 message",
+          createdAt: new Date("2025-01-01"),
+          locality: "bg.sofia",
+          addresses: [
+            {
+              originalText: "addr",
+              formattedAddress: "Addr 1",
+              coordinates: { lat: 42, lng: 23 },
+            },
+          ],
+          pins: [{ address: "pin", timespans: [] }],
+        }),
+        findMany: vi.fn(),
+        findBySourceDocumentIds: vi.fn(),
+      },
+      apiClients: { findByApiKey: vi.fn() },
+    } as any);
+
+    const res = await app.request("/v2/messages/by-id?id=abcd1234", {
+      headers: API_KEY_HEADER,
+    });
+    expect(res.status).toBe(200);
+    const body: any = await res.json();
+    expect(body.message).toHaveProperty("id", "abcd1234");
+    expect(body.message).not.toHaveProperty("addresses");
+    expect(body.message).not.toHaveProperty("pins");
+    expect(body.message).not.toHaveProperty("streets");
+    expect(body.message).not.toHaveProperty("cadastralProperties");
+    expect(body.message).not.toHaveProperty("busStops");
+  });
+});
+
+describe("GET /v2/openapi", () => {
+  it("returns OpenAPI spec without auth", async () => {
+    const res = await app.request("/v2/openapi");
+    expect(res.status).toBe(200);
+    const body: any = await res.json();
+    expect(body).toHaveProperty("openapi", "3.0.0");
+    expect(body?.info?.version).toBe("2.0.0");
+    expect(body?.info?.title).toContain("OboApp");
+    expect(body).toHaveProperty("paths");
+    expect(body.paths).toHaveProperty("/v2/sources");
+    expect(body.paths).toHaveProperty("/v2/messages");
+    expect(body.paths).toHaveProperty("/v2/messages/by-id");
+  });
+
+  it("does not contain v1 paths", async () => {
+    const res = await app.request("/v2/openapi");
+    const body: any = await res.json();
+    expect(body.paths).not.toHaveProperty("/v1/sources");
+    expect(body.paths).not.toHaveProperty("/v1/messages");
+  });
+});
+
+describe("GET /v2/docs", () => {
+  it("returns HTML page without auth", async () => {
+    const res = await app.request("/v2/docs");
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("<!DOCTYPE html>");
+    expect(html).toContain("api-reference");
+    expect(html).toContain("/v2/openapi");
+  });
+
+  it("does NOT contain a deprecation banner", async () => {
+    const res = await app.request("/v2/docs");
+    const html = await res.text();
+    expect(html).not.toContain("deprecated");
   });
 });
 

--- a/api/src/routes/sources.ts
+++ b/api/src/routes/sources.ts
@@ -1,10 +1,11 @@
 import { Hono } from "hono";
 import { SOURCES } from "@oboapp/shared";
 import { apiKeyAuth } from "../middleware/api-key";
+import { v1DeprecationHeaders } from "../middleware/deprecation";
 
 export const sourcesRoute = new Hono();
 
-sourcesRoute.get("/sources", apiKeyAuth, (c) => {
+sourcesRoute.get("/sources", apiKeyAuth, v1DeprecationHeaders, (c) => {
   const baseUrl =
     process.env.NEXT_PUBLIC_BASE_URL ||
     process.env.BASE_URL ||

--- a/api/src/routes/v2/messages-by-id.ts
+++ b/api/src/routes/v2/messages-by-id.ts
@@ -1,0 +1,49 @@
+import { Hono } from "hono";
+import { getDb } from "../../lib/db";
+import { recordToMessageV2 } from "../../lib/doc-to-message.v2";
+import { apiKeyAuth } from "../../middleware/api-key";
+import { isValidMessageId } from "@oboapp/shared";
+
+/**
+ * Strip a trailing split-index suffix (e.g. "-1", "-2") from a
+ * source-document-style ID so we can query by sourceDocumentId.
+ */
+function stripSplitSuffix(id: string): string {
+  return id.replace(/-\d+$/, "");
+}
+
+export const messageByIdRouteV2 = new Hono();
+
+messageByIdRouteV2.get("/messages/by-id", apiKeyAuth, async (c) => {
+  try {
+    const id = c.req.query("id");
+
+    if (!id) {
+      return c.json({ error: "Missing id parameter" }, 400);
+    }
+
+    const db = await getDb();
+
+    // Primary: look up by 8-char message ID
+    if (isValidMessageId(id)) {
+      const doc = await db.messages.findById(id);
+      if (doc) {
+        return c.json({ message: recordToMessageV2(doc) });
+      }
+      return c.json({ error: "Message not found" }, 404);
+    }
+
+    // Fallback: treat the id as a sourceDocumentId (strip optional "-N" suffix)
+    const sourceDocId = stripSplitSuffix(id);
+    const docs = await db.messages.findBySourceDocumentIds([sourceDocId]);
+
+    if (docs.length > 0) {
+      return c.json({ message: recordToMessageV2(docs[0]) });
+    }
+
+    return c.json({ error: "Message not found" }, 404);
+  } catch (error) {
+    console.error("Error fetching message by id:", error);
+    return c.json({ error: "Failed to fetch message" }, 500);
+  }
+});

--- a/api/src/routes/v2/messages.ts
+++ b/api/src/routes/v2/messages.ts
@@ -1,0 +1,292 @@
+import { Hono } from "hono";
+import { SOURCES } from "@oboapp/shared";
+import { getDb } from "../../lib/db";
+import type { OboDb } from "@oboapp/db";
+import { recordToMessageV2 } from "../../lib/doc-to-message.v2";
+import { apiKeyAuth } from "../../middleware/api-key";
+import { messagesQuerySchema } from "../../schema/query";
+import type { MessageV2, GeoJsonFeature } from "../../schema/contract.v2";
+import {
+  featureIntersectsBounds,
+  type ViewportBounds,
+} from "../../lib/bounds-utils";
+import { getCentroid } from "../../lib/geometry-utils";
+import {
+  type MessageRecord,
+  isUncategorizedDoc,
+  toViewportBounds,
+  getCutoffDate,
+  findRecentMessageDocs,
+  findRecentMessageDocsBySources,
+  findUncategorizedDocs,
+  applyOptionalSourceSet,
+  isInvalidSourceForFilter,
+  buildCategoryQueryPlans,
+  getValidatedSources,
+} from "../../lib/messages-query";
+
+const CLUSTER_ZOOM_THRESHOLD = 15;
+
+function sortMessagesByRelevance(messages: MessageV2[]): MessageV2[] {
+  return [...messages].sort((a, b) => {
+    const aFinalizedAt = a.finalizedAt ?? "";
+    const bFinalizedAt = b.finalizedAt ?? "";
+    if (aFinalizedAt !== bFinalizedAt) {
+      return bFinalizedAt.localeCompare(aFinalizedAt);
+    }
+
+    const aEnd = a.timespanEnd ?? "";
+    const bEnd = b.timespanEnd ?? "";
+    return bEnd.localeCompare(aEnd);
+  });
+}
+
+function dedupeAndMapMessages(docs: MessageRecord[]): MessageV2[] {
+  const messagesMap = new Map<string, MessageV2>();
+
+  for (const doc of docs) {
+    const docId = typeof doc._id === "string" ? doc._id : "";
+    if (docId && !messagesMap.has(docId)) {
+      messagesMap.set(docId, recordToMessageV2(doc));
+    }
+  }
+
+  return Array.from(messagesMap.values());
+}
+
+async function findMessagesBySources(
+  db: OboDb,
+  cutoffDate: Date,
+  sources: string[],
+  locality?: string,
+): Promise<MessageV2[]> {
+  const results = await findRecentMessageDocsBySources(
+    db,
+    cutoffDate,
+    sources,
+    locality,
+  );
+  const messagesMap = new Map<string, MessageV2>();
+
+  for (const doc of results) {
+    const docId = typeof doc._id === "string" ? doc._id : "";
+    if (docId && !messagesMap.has(docId)) {
+      messagesMap.set(docId, recordToMessageV2(doc));
+    }
+  }
+
+  return sortMessagesByRelevance(Array.from(messagesMap.values()));
+}
+
+async function findMessagesByCategoryFilters(
+  db: OboDb,
+  cutoffDate: Date,
+  selectedCategories: string[],
+  sourceSet?: Set<string>,
+  locality?: string,
+): Promise<MessageV2[]> {
+  const realCategories = selectedCategories.filter(
+    (c) => c !== "uncategorized",
+  );
+  const includeUncategorized = selectedCategories.includes("uncategorized");
+
+  if (includeUncategorized && realCategories.length === 0) {
+    const uncategorizedDocs = await findUncategorizedDocs(
+      db,
+      cutoffDate,
+      sourceSet,
+      locality,
+    );
+    return dedupeAndMapMessages(uncategorizedDocs);
+  }
+
+  const queryPlans = await buildCategoryQueryPlans(
+    db,
+    cutoffDate,
+    realCategories,
+    includeUncategorized,
+    sourceSet,
+    locality,
+  );
+  const messagesMap = new Map<string, MessageV2>();
+
+  for (const plan of queryPlans) {
+    const docs = applyOptionalSourceSet(plan.docs, sourceSet);
+    const { uncategorizedOnly } = plan;
+
+    for (const doc of docs) {
+      if (uncategorizedOnly && !isUncategorizedDoc(doc)) {
+        continue;
+      }
+
+      if (isInvalidSourceForFilter(doc, sourceSet)) {
+        continue;
+      }
+
+      const docId = typeof doc._id === "string" ? doc._id : "";
+      if (docId && !messagesMap.has(docId)) {
+        messagesMap.set(docId, recordToMessageV2(doc));
+      }
+    }
+  }
+
+  return sortMessagesByRelevance(Array.from(messagesMap.values()));
+}
+
+function filterMessagesByGeoAndViewport(
+  messages: MessageV2[],
+  viewportBounds: ViewportBounds | null,
+): MessageV2[] {
+  let filtered = messages.filter(
+    (message) =>
+      message.cityWide ||
+      (message.geoJson !== null && message.geoJson !== undefined),
+  );
+
+  if (!viewportBounds) {
+    return filtered;
+  }
+
+  filtered = filtered.filter((message) => {
+    if (message.cityWide) return true;
+    if (!message.geoJson?.features) return false;
+
+    return message.geoJson.features.some((feature) =>
+      featureIntersectsBounds(feature, viewportBounds),
+    );
+  });
+
+  return filtered;
+}
+
+function simplifyMessagesForClusterZoom(
+  messages: MessageV2[],
+  zoom?: number,
+): MessageV2[] {
+  if (zoom === undefined || zoom >= CLUSTER_ZOOM_THRESHOLD) {
+    return messages;
+  }
+
+  return messages.map((message) => {
+    if (!message.geoJson?.features) return message;
+
+    const simplifiedFeatures: GeoJsonFeature[] = message.geoJson.features.map(
+      (feature) => {
+        if (
+          feature.geometry.type === "LineString" ||
+          feature.geometry.type === "Polygon"
+        ) {
+          const centroid = getCentroid(feature.geometry);
+          if (!centroid) return feature;
+
+          const simplified: GeoJsonFeature = {
+            type: "Feature",
+            geometry: {
+              type: "Point",
+              coordinates: [centroid.lng, centroid.lat],
+            },
+            properties: {
+              ...feature.properties,
+              _originalGeometryType: feature.geometry.type,
+            },
+          };
+          return simplified;
+        }
+
+        return feature;
+      },
+    );
+
+    return {
+      ...message,
+      geoJson: {
+        ...message.geoJson,
+        features: simplifiedFeatures,
+      },
+    };
+  });
+}
+
+export const messagesRouteV2 = new Hono();
+
+messagesRouteV2.get("/messages", apiKeyAuth, async (c) => {
+  try {
+    const db = await getDb();
+
+    const parsed = messagesQuerySchema.safeParse(
+      Object.fromEntries(new URL(c.req.url).searchParams.entries()),
+    );
+
+    if (!parsed.success) {
+      return c.json({ error: "Invalid query parameters" }, 400);
+    }
+
+    const {
+      north,
+      south,
+      east,
+      west,
+      zoom,
+      categories: selectedCategories,
+      sources: selectedSources,
+      timespanEndGte,
+    } = parsed.data;
+
+    const viewportBounds = toViewportBounds({ north, south, east, west });
+    const cutoffDate = getCutoffDate(timespanEndGte);
+
+    if (selectedCategories && selectedCategories.length === 0) {
+      return c.json({ messages: [] });
+    }
+
+    const locality = process.env.LOCALITY || "bg.sofia";
+    const allSourceIds = new Set(
+      SOURCES.filter((s) => s.localities.includes(locality)).map((s) => s.id),
+    );
+
+    const validatedSources = getValidatedSources(selectedSources, allSourceIds);
+
+    if (
+      selectedSources &&
+      selectedSources.length > 0 &&
+      validatedSources?.length === 0
+    ) {
+      return c.json({ messages: [] });
+    }
+
+    let allMessages: MessageV2[];
+    const hasSourceFilter = validatedSources && validatedSources.length > 0;
+    const hasCategoryFilter =
+      selectedCategories && selectedCategories.length > 0;
+
+    if (hasCategoryFilter) {
+      const sourceSet = hasSourceFilter ? new Set(validatedSources) : undefined;
+      allMessages = await findMessagesByCategoryFilters(
+        db,
+        cutoffDate,
+        selectedCategories,
+        sourceSet,
+        locality,
+      );
+    } else if (hasSourceFilter) {
+      allMessages = await findMessagesBySources(
+        db,
+        cutoffDate,
+        validatedSources,
+        locality,
+      );
+    } else {
+      const docs = await findRecentMessageDocs(db, cutoffDate, locality);
+      allMessages = docs.map(recordToMessageV2);
+    }
+
+    let messages = filterMessagesByGeoAndViewport(allMessages, viewportBounds);
+    messages = simplifyMessagesForClusterZoom(messages, zoom);
+    messages = sortMessagesByRelevance(messages);
+
+    return c.json({ messages });
+  } catch (error) {
+    console.error("Error fetching messages:", error);
+    return c.json({ error: "Failed to fetch messages" }, 500);
+  }
+});

--- a/api/src/routes/v2/openapi.ts
+++ b/api/src/routes/v2/openapi.ts
@@ -1,0 +1,202 @@
+import { Hono } from "hono";
+import { z } from "../../lib/zod-openapi";
+import {
+  OpenAPIRegistry,
+  OpenApiGeneratorV3,
+} from "@asteasolutions/zod-to-openapi";
+import type { OpenAPIObject } from "openapi3-ts/oas30";
+import {
+  MessageV2Schema,
+  SourceV2Schema,
+  V2SourcesResponseSchema,
+  V2MessagesResponseSchema,
+  V2MessageResponseSchema,
+  ErrorResponseSchema,
+} from "../../schema/index";
+
+const sortRecord = <T>(record: Record<string, T>): Record<string, T> =>
+  Object.keys(record)
+    .sort()
+    .reduce<Record<string, T>>((acc, key) => {
+      acc[key] = record[key];
+      return acc;
+    }, {});
+
+const sortOpenApiDocument = (document: OpenAPIObject): OpenAPIObject => ({
+  ...document,
+  paths: document.paths ? sortRecord(document.paths) : document.paths,
+  components: document.components
+    ? {
+        ...document.components,
+        schemas: document.components.schemas
+          ? sortRecord(document.components.schemas)
+          : document.components.schemas,
+      }
+    : document.components,
+});
+
+function buildV2OpenApiSpec(): OpenAPIObject {
+  const registry = new OpenAPIRegistry();
+
+  registry.registerComponent("securitySchemes", "ApiKeyAuth", {
+    type: "apiKey",
+    in: "header",
+    name: "X-Api-Key",
+    description:
+      "API key created and managed in OboApp Settings. Create an API key in Settings and include it in the X-Api-Key header.",
+  });
+
+  const errorResponse = registry.register(
+    "V2ErrorResponse",
+    ErrorResponseSchema,
+  );
+  registry.register("V2Message", MessageV2Schema);
+  registry.register("V2Source", SourceV2Schema);
+  const sourcesResponse = registry.register(
+    "V2SourcesResponse",
+    V2SourcesResponseSchema,
+  );
+  const messagesResponse = registry.register(
+    "V2MessagesResponse",
+    V2MessagesResponseSchema,
+  );
+  const messageResponse = registry.register(
+    "V2MessageResponse",
+    V2MessageResponseSchema,
+  );
+
+  registry.registerPath({
+    method: "get",
+    path: "/v2/sources",
+    description: "List all sources with logo URLs.",
+    security: [{ ApiKeyAuth: [] }],
+    responses: {
+      200: {
+        description: "Sources response",
+        content: { "application/json": { schema: sourcesResponse } },
+      },
+      401: {
+        description: "Invalid or missing API key",
+        content: { "application/json": { schema: errorResponse } },
+      },
+      500: {
+        description: "Server error",
+        content: { "application/json": { schema: errorResponse } },
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/v2/messages",
+    description:
+      "Fetch messages, optionally filtered by bounds and categories.",
+    security: [{ ApiKeyAuth: [] }],
+    request: {
+      query: z.object({
+        north: z.string().optional(),
+        south: z.string().optional(),
+        east: z.string().optional(),
+        west: z.string().optional(),
+        zoom: z.string().optional(),
+        categories: z.string().optional(),
+        sources: z.string().optional(),
+        timespanEndGte: z.string().optional(),
+      }),
+    },
+    responses: {
+      200: {
+        description: "Messages response",
+        content: { "application/json": { schema: messagesResponse } },
+      },
+      400: {
+        description: "Invalid query parameters",
+        content: { "application/json": { schema: errorResponse } },
+      },
+      401: {
+        description: "Invalid or missing API key",
+        content: { "application/json": { schema: errorResponse } },
+      },
+      500: {
+        description: "Server error",
+        content: { "application/json": { schema: errorResponse } },
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/v2/messages/by-id",
+    description: "Fetch a single message by its ID.",
+    security: [{ ApiKeyAuth: [] }],
+    request: {
+      query: z.object({
+        id: z.string(),
+      }),
+    },
+    responses: {
+      200: {
+        description: "Message response",
+        content: { "application/json": { schema: messageResponse } },
+      },
+      400: {
+        description: "Missing or invalid id parameter",
+        content: { "application/json": { schema: errorResponse } },
+      },
+      401: {
+        description: "Invalid or missing API key",
+        content: { "application/json": { schema: errorResponse } },
+      },
+      404: {
+        description: "Message not found",
+        content: { "application/json": { schema: errorResponse } },
+      },
+      500: {
+        description: "Server error",
+        content: { "application/json": { schema: errorResponse } },
+      },
+    },
+  });
+
+  const generator = new OpenApiGeneratorV3(registry.definitions);
+
+  const document = generator.generateDocument({
+    openapi: "3.0.0",
+    info: {
+      title: "OboApp Public API",
+      version: "2.0.0",
+      description:
+        "Read-only public API for external consumption of OboApp city-infrastructure data. All data endpoints require a registered API key sent via the X-Api-Key header. You can create and manage API keys from the OboApp Settings page.",
+    },
+    security: [{ ApiKeyAuth: [] }],
+  });
+
+  return sortOpenApiDocument(document);
+}
+
+let cachedSpec: OpenAPIObject | null = null;
+
+export const openapiRouteV2 = new Hono();
+
+openapiRouteV2.get("/openapi", (c) => {
+  if (!cachedSpec) {
+    cachedSpec = buildV2OpenApiSpec();
+  }
+  return c.json(cachedSpec);
+});
+
+openapiRouteV2.get("/docs", (c) => {
+  const html = `<!DOCTYPE html>
+<html>
+<head>
+  <title>OboApp API Reference v2</title>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+</head>
+<body>
+  <script id="api-reference" data-url="/v2/openapi"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.25.59"></script>
+</body>
+</html>`;
+  return c.html(html);
+});

--- a/api/src/routes/v2/sources.ts
+++ b/api/src/routes/v2/sources.ts
@@ -1,0 +1,25 @@
+import { Hono } from "hono";
+import { SOURCES } from "@oboapp/shared";
+import { apiKeyAuth } from "../../middleware/api-key";
+
+export const sourcesRouteV2 = new Hono();
+
+sourcesRouteV2.get("/sources", apiKeyAuth, (c) => {
+  const baseUrl =
+    process.env.NEXT_PUBLIC_BASE_URL ||
+    process.env.BASE_URL ||
+    "https://oboapp.online";
+  const locality = process.env.LOCALITY || "bg.sofia";
+
+  const sources = SOURCES.filter((source) =>
+    source.localities.includes(locality),
+  ).map((source) => ({
+    id: source.id,
+    name: source.name,
+    url: source.url,
+    logoUrl: `${baseUrl}/sources/${source.id}.png`,
+    locality,
+  }));
+
+  return c.json({ sources });
+});

--- a/api/src/schema/contract.v2.ts
+++ b/api/src/schema/contract.v2.ts
@@ -1,0 +1,115 @@
+/**
+ * Forked API contract schemas — public API v2 contract.
+ *
+ * Compared to v1, the pipeline-internal geo-derivable fields are removed:
+ * addresses, pins, streets, cadastralProperties, busStops.
+ * All of this information is available via geoJson.
+ */
+
+import { z } from "../lib/zod-openapi";
+
+// ---- Category ----
+
+export const CategoryEnum = z.enum([
+  "air-quality",
+  "art",
+  "bicycles",
+  "construction-and-repairs",
+  "culture",
+  "electricity",
+  "health",
+  "heating",
+  "parking",
+  "public-transport",
+  "road-block",
+  "sports",
+  "traffic",
+  "vehicles",
+  "waste",
+  "water",
+  "weather",
+]);
+
+export type Category = z.infer<typeof CategoryEnum>;
+
+// ---- GeoJSON ----
+
+export const GeoJsonPointSchema = z.object({
+  type: z.literal("Point"),
+  coordinates: z.tuple([z.number(), z.number()]),
+});
+
+export const GeoJsonMultiPointSchema = z.object({
+  type: z.literal("MultiPoint"),
+  coordinates: z.array(z.tuple([z.number(), z.number()])),
+});
+
+export const GeoJsonLineStringSchema = z.object({
+  type: z.literal("LineString"),
+  coordinates: z.array(z.tuple([z.number(), z.number()])),
+});
+
+export const GeoJsonPolygonSchema = z.object({
+  type: z.literal("Polygon"),
+  coordinates: z.array(z.array(z.tuple([z.number(), z.number()]))),
+});
+
+export const GeoJsonGeometrySchema = z.discriminatedUnion("type", [
+  GeoJsonPointSchema,
+  GeoJsonMultiPointSchema,
+  GeoJsonLineStringSchema,
+  GeoJsonPolygonSchema,
+]);
+
+export const GeoJsonFeatureSchema = z.object({
+  type: z.literal("Feature"),
+  geometry: GeoJsonGeometrySchema,
+  properties: z.record(z.string(), z.unknown()),
+});
+
+export const GeoJsonFeatureCollectionSchema = z.object({
+  type: z.literal("FeatureCollection"),
+  features: z.array(GeoJsonFeatureSchema),
+});
+
+export type GeoJsonPoint = z.infer<typeof GeoJsonPointSchema>;
+export type GeoJsonGeometry = z.infer<typeof GeoJsonGeometrySchema>;
+export type GeoJsonFeature = z.infer<typeof GeoJsonFeatureSchema>;
+export type GeoJsonFeatureCollection = z.infer<
+  typeof GeoJsonFeatureCollectionSchema
+>;
+
+// ---- Message v2 ----
+
+export const MessageV2Schema = z.object({
+  id: z.string().optional(),
+  text: z.string(),
+  plainText: z.string().optional(),
+  markdownText: z.string().optional(),
+  source: z.string().optional(),
+  sourceUrl: z.string().optional(),
+  locality: z.string(),
+  categories: z.array(CategoryEnum).optional(),
+  geoJson: GeoJsonFeatureCollectionSchema.optional(),
+  crawledAt: z.string().optional(),
+  createdAt: z.string(),
+  finalizedAt: z.string().optional(),
+  timespanStart: z.string().optional(),
+  timespanEnd: z.string().optional(),
+  cityWide: z.boolean().optional(),
+  responsibleEntity: z.string().optional(),
+});
+
+export type MessageV2 = z.infer<typeof MessageV2Schema>;
+
+// ---- Source (unchanged from v1) ----
+
+export const SourceSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  url: z.string(),
+  logoUrl: z.string(),
+  locality: z.string(),
+});
+
+export type Source = z.infer<typeof SourceSchema>;

--- a/api/src/schema/index.ts
+++ b/api/src/schema/index.ts
@@ -44,3 +44,34 @@ export {
 
 // Query schemas
 export { messagesQuerySchema, type MessagesQuery } from "./query";
+
+// v2 contract types
+export {
+  MessageV2Schema,
+  SourceSchema as SourceV2Schema,
+  CategoryEnum as CategoryV2Enum,
+  GeoJsonFeatureCollectionSchema as GeoJsonFeatureCollectionV2Schema,
+  GeoJsonFeatureSchema as GeoJsonFeatureV2Schema,
+  GeoJsonGeometrySchema as GeoJsonGeometryV2Schema,
+  GeoJsonPointSchema as GeoJsonPointV2Schema,
+  GeoJsonLineStringSchema as GeoJsonLineStringV2Schema,
+  GeoJsonPolygonSchema as GeoJsonPolygonV2Schema,
+  GeoJsonMultiPointSchema as GeoJsonMultiPointV2Schema,
+  type MessageV2,
+  type Source as SourceV2,
+  type Category as CategoryV2,
+  type GeoJsonFeatureCollection as GeoJsonFeatureCollectionV2,
+  type GeoJsonFeature as GeoJsonFeatureV2,
+  type GeoJsonGeometry as GeoJsonGeometryV2,
+  type GeoJsonPoint as GeoJsonPointV2,
+} from "./contract.v2";
+
+// v2 response schemas
+export {
+  V2SourcesResponseSchema,
+  V2MessagesResponseSchema,
+  V2MessageResponseSchema,
+  type V2SourcesResponse,
+  type V2MessagesResponse,
+  type V2MessageResponse,
+} from "./response.v2";

--- a/api/src/schema/response.v2.ts
+++ b/api/src/schema/response.v2.ts
@@ -1,0 +1,18 @@
+import { z } from "../lib/zod-openapi";
+import { MessageV2Schema, SourceSchema } from "./contract.v2";
+
+export const V2SourcesResponseSchema = z.object({
+  sources: z.array(SourceSchema),
+});
+
+export const V2MessagesResponseSchema = z.object({
+  messages: z.array(MessageV2Schema),
+});
+
+export const V2MessageResponseSchema = z.object({
+  message: MessageV2Schema,
+});
+
+export type V2SourcesResponse = z.infer<typeof V2SourcesResponseSchema>;
+export type V2MessagesResponse = z.infer<typeof V2MessagesResponseSchema>;
+export type V2MessageResponse = z.infer<typeof V2MessageResponseSchema>;

--- a/docs/features/public-api.md
+++ b/docs/features/public-api.md
@@ -1,8 +1,75 @@
 # Public API
 
-## Overview
+> ⚠️ **API v1 is deprecated.** The v1 endpoints will be removed on **October 14, 2026**. New integrations should use [v2](#api-v2-current). Existing callers should [migrate](#migrating-from-v1-to-v2).
 
-OboApp exposes a read-only public REST API for external consumption of Sofia city-infrastructure disruption data.
+---
+
+## API v2 (Current)
+
+**Base URL:** `https://api.oboapp.online/v2`
+
+**Interactive documentation:** [`https://api.oboapp.online/v2/docs`](https://api.oboapp.online/v2/docs)
+
+### Overview
+
+v2 is identical to v1 except that five pipeline-internal fields have been removed from the `Message` object. All of the contained location data is already available through the `geoJson` field, making the removed fields redundant and leaking internal pipeline structure.
+
+**Removed fields:** `addresses`, `pins`, `streets`, `cadastralProperties`, `busStops`
+
+### Endpoints
+
+| Method | Path                 | Description                                                          |
+| ------ | -------------------- | -------------------------------------------------------------------- |
+| `GET`  | `/v2/sources`        | List all data sources                                                |
+| `GET`  | `/v2/messages`       | Fetch messages filtered by geographic bounds and optional categories |
+| `GET`  | `/v2/messages/by-id` | Fetch a single message by ID                                         |
+| `GET`  | `/v2/openapi`        | OpenAPI 3.0 specification (no key required)                          |
+
+### Message Object (v2)
+
+| Field               | Type                 | Description                              |
+| ------------------- | -------------------- | ---------------------------------------- |
+| `id`                | `string?`            | 8-character message ID                   |
+| `text`              | `string`             | Original raw text                        |
+| `plainText`         | `string?`            | Plain-text version (no markdown)         |
+| `markdownText`      | `string?`            | Markdown-formatted version               |
+| `source`            | `string?`            | Source identifier                        |
+| `sourceUrl`         | `string?`            | URL to the original source document      |
+| `locality`          | `string`             | Locality identifier (e.g. `bg.sofia`)    |
+| `categories`        | `Category[]?`        | Assigned categories                      |
+| `geoJson`           | `FeatureCollection?` | Full GeoJSON geometry for the event      |
+| `crawledAt`         | `string?`            | ISO 8601 — when the source was crawled   |
+| `createdAt`         | `string`             | ISO 8601 — when the record was created   |
+| `finalizedAt`       | `string?`            | ISO 8601 — when processing was completed |
+| `timespanStart`     | `string?`            | ISO 8601 — start of the disruption       |
+| `timespanEnd`       | `string?`            | ISO 8601 — end of the disruption         |
+| `cityWide`          | `boolean?`           | Whether the event affects the whole city |
+| `responsibleEntity` | `string?`            | Entity responsible for the disruption    |
+
+### Migrating from v1 to v2
+
+Replace the base URL and remove any reads of the five dropped fields:
+
+```diff
+- GET https://api.oboapp.online/v1/messages
++ GET https://api.oboapp.online/v2/messages
+```
+
+Fields removed in v2 — stop reading these from the response:
+
+| Removed field         | Alternative                                                |
+| --------------------- | ---------------------------------------------------------- |
+| `addresses`           | Use `geoJson` features with `Point` geometry               |
+| `pins`                | Use `geoJson` features; pin timespans are in feature props |
+| `streets`             | Use `geoJson` features with `LineString` geometry          |
+| `cadastralProperties` | Use `geoJson` features with `Polygon` geometry             |
+| `busStops`            | Use `geoJson` features tagged with bus-stop properties     |
+
+---
+
+## API v1 (Deprecated)
+
+> ⚠️ v1 is deprecated. Sunset: **October 14, 2026**. Use [v2](#api-v2-current) for new integrations.
 
 **Base URL:** `https://api.oboapp.online/v1`
 
@@ -10,7 +77,9 @@ OboApp exposes a read-only public REST API for external consumption of Sofia cit
 
 All data endpoints require a registered API key. The OpenAPI specification is available without authentication.
 
-## Endpoints
+v1 responses include the `Deprecation: true`, `Sunset`, and `Link` HTTP response headers on all data endpoints.
+
+### Endpoints
 
 | Method | Path                 | Description                                                          |
 | ------ | -------------------- | -------------------------------------------------------------------- |
@@ -18,6 +87,8 @@ All data endpoints require a registered API key. The OpenAPI specification is av
 | `GET`  | `/v1/messages`       | Fetch messages filtered by geographic bounds and optional categories |
 | `GET`  | `/v1/messages/by-id` | Fetch a single message by ID                                         |
 | `GET`  | `/v1/openapi`        | OpenAPI 3.0 specification (no key required)                          |
+
+---
 
 ## Authentication
 


### PR DESCRIPTION
- Add v2 endpoints at /v2/sources, /v2/messages, /v2/messages/by-id
- v2 Message drops pipeline-internal fields: addresses, pins, streets, cadastralProperties, busStops (all derivable from geoJson)
- v1 deprecated: Deprecation/Sunset/Link response headers, OpenAPI spec description warning, visible HTML banner on /v1/docs → /v2/docs
- Sunset date: October 14 2026
- Extract shared DB query helpers to lib/messages-query.ts (DRY)
- 28/28 tests pass; tsc + lint clean