### PR TITLE
feat: replace live Firestore heatmap scan with weekly GCS snapshot

### DIFF
--- a/ingest/lib/heatmap/snapshot-store.test.ts
+++ b/ingest/lib/heatmap/snapshot-store.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// GCS mock — set up before importing the module under test
+// ---------------------------------------------------------------------------
+const mockSave = vi.fn();
+const mockDownload = vi.fn();
+const mockExists = vi.fn();
+const mockFile = vi.fn();
+const mockBucket = vi.fn();
+
+vi.mock("@google-cloud/storage", () => ({
+  // Must use a regular function — arrow functions cannot be called with `new`
+  Storage: vi.fn().mockImplementation(function () {
+    return { bucket: mockBucket };
+  }),
+}));
+
+import { saveHeatmapSnapshot, loadHeatmapSnapshot } from "./snapshot-store";
+import type { HeatmapSnapshot } from "./snapshot-store";
+
+const SAMPLE_SNAPSHOT: HeatmapSnapshot = {
+  generatedAt: "2024-01-01T00:00:00.000Z",
+  messages: [
+    {
+      id: "msg-1",
+      source: "sofiyska-voda",
+      categories: ["water"],
+      cityWide: false,
+      finalizedAt: "2024-01-01T00:00:00.000Z",
+      points: [[42.6977, 23.3219]],
+    },
+  ],
+};
+
+describe("saveHeatmapSnapshot", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFile.mockReturnValue({
+      save: mockSave,
+      exists: mockExists,
+      download: mockDownload,
+    });
+    mockBucket.mockReturnValue({ file: mockFile });
+    process.env.GCS_GENERIC_BUCKET = "test-bucket";
+  });
+
+  it("saves the snapshot as JSON to GCS", async () => {
+    await saveHeatmapSnapshot(SAMPLE_SNAPSHOT);
+    expect(mockSave).toHaveBeenCalledOnce();
+    const [body, options] = mockSave.mock.calls[0];
+    expect(JSON.parse(body)).toEqual(SAMPLE_SNAPSHOT);
+    expect(options).toMatchObject({ contentType: "application/json" });
+  });
+
+  it("does nothing when GCS_GENERIC_BUCKET is not set", async () => {
+    delete process.env.GCS_GENERIC_BUCKET;
+    await saveHeatmapSnapshot(SAMPLE_SNAPSHOT);
+    expect(mockSave).not.toHaveBeenCalled();
+  });
+});
+
+describe("loadHeatmapSnapshot", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFile.mockReturnValue({
+      save: mockSave,
+      exists: mockExists,
+      download: mockDownload,
+    });
+    mockBucket.mockReturnValue({ file: mockFile });
+    process.env.GCS_GENERIC_BUCKET = "test-bucket";
+  });
+
+  it("returns null when GCS_GENERIC_BUCKET is not set", async () => {
+    delete process.env.GCS_GENERIC_BUCKET;
+    const result = await loadHeatmapSnapshot();
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the snapshot file does not exist", async () => {
+    mockExists.mockResolvedValue([false]);
+    const result = await loadHeatmapSnapshot();
+    expect(result).toBeNull();
+    expect(mockDownload).not.toHaveBeenCalled();
+  });
+
+  it("returns parsed snapshot when file exists", async () => {
+    mockExists.mockResolvedValue([true]);
+    mockDownload.mockResolvedValue([
+      Buffer.from(JSON.stringify(SAMPLE_SNAPSHOT)),
+    ]);
+    const result = await loadHeatmapSnapshot();
+    expect(result).toEqual(SAMPLE_SNAPSHOT);
+  });
+});

--- a/ingest/lib/heatmap/snapshot-store.ts
+++ b/ingest/lib/heatmap/snapshot-store.ts
@@ -1,0 +1,60 @@
+/**
+ * GCS persistence for the heatmap snapshot.
+ *
+ * Production: saves/loads `heatmap/snapshot.json` from GCS_GENERIC_BUCKET.
+ * Offline / missing bucket: no-op read (returns null) and console warning on write.
+ */
+
+export interface HeatmapMessage {
+  id: string;
+  source: string;
+  categories: string[];
+  cityWide: boolean;
+  finalizedAt: string;
+  /** Coordinate points in [lat, lng] order (Leaflet convention). */
+  points: [number, number][];
+}
+
+export interface HeatmapSnapshot {
+  generatedAt: string;
+  messages: HeatmapMessage[];
+}
+
+const SNAPSHOT_PATH = "heatmap/snapshot.json";
+
+let storage: import("@google-cloud/storage").Storage | null = null;
+
+async function getStorage() {
+  if (!storage) {
+    const { Storage } = await import("@google-cloud/storage");
+    storage = new Storage();
+  }
+  return storage;
+}
+
+export async function saveHeatmapSnapshot(
+  snapshot: HeatmapSnapshot,
+): Promise<void> {
+  const bucket = process.env.GCS_GENERIC_BUCKET;
+  if (!bucket) {
+    console.warn("GCS_GENERIC_BUCKET not set — skipping GCS snapshot save");
+    return;
+  }
+  const gcs = await getStorage();
+  const file = gcs.bucket(bucket).file(SNAPSHOT_PATH);
+  await file.save(JSON.stringify(snapshot, null, 2), {
+    contentType: "application/json",
+  });
+}
+
+export async function loadHeatmapSnapshot(): Promise<HeatmapSnapshot | null> {
+  const bucket = process.env.GCS_GENERIC_BUCKET;
+  if (!bucket) return null;
+  const gcs = await getStorage();
+  const file = gcs.bucket(bucket).file(SNAPSHOT_PATH);
+  const [exists] = await file.exists();
+  if (!exists) return null;
+  const [content] = await file.download();
+  const data: HeatmapSnapshot = JSON.parse(content.toString("utf-8"));
+  return data;
+}

--- a/ingest/package.json
+++ b/ingest/package.json
@@ -31,6 +31,7 @@
     "reprocess-message": "tsx scripts/reprocess-message.ts",
     "geocode-cache:report": "tsx scripts/geocode-frequency-report.ts",
     "geocode-cache:add": "tsx scripts/geocode-cache-add.ts",
+    "heatmap-report": "tsx scripts/heatmap-report.ts",
     "promptfoo": "cross-env NODE_OPTIONS=\"--import tsx/esm\" promptfoo eval --env-file .env.local -c prompts/__evals__/filter-split.yaml && cross-env NODE_OPTIONS=\"--import tsx/esm\" promptfoo eval --env-file .env.local -c prompts/__evals__/categorize.yaml && cross-env NODE_OPTIONS=\"--import tsx/esm\" promptfoo eval --env-file .env.local -c prompts/__evals__/extract-locations.yaml && cross-env NODE_OPTIONS=\"--import tsx/esm\" promptfoo eval --env-file .env.local -c prompts/__evals__/verify-event-match.yaml",
     "promptfoo:filter": "cross-env NODE_OPTIONS=\"--import tsx/esm\" promptfoo eval --env-file .env.local -c prompts/__evals__/filter-split.yaml",
     "promptfoo:categorize": "cross-env NODE_OPTIONS=\"--import tsx/esm\" promptfoo eval --env-file .env.local -c prompts/__evals__/categorize.yaml",
@@ -47,7 +48,8 @@
     "prebuilt:pipeline:emergent": "node dist/pipeline.js --emergent",
     "prebuilt:pipeline:all": "node dist/pipeline.js --all",
     "prebuilt:air-quality-fetch": "node dist/air-quality-fetch.js",
-    "prebuilt:geocode-cache-report": "node dist/scripts/geocode-frequency-report.js"
+    "prebuilt:geocode-cache-report": "node dist/scripts/geocode-frequency-report.js",
+    "prebuilt:heatmap-report": "node dist/scripts/heatmap-report.js"
   },
   "dependencies": {
     "@google-cloud/storage": "^7.19.0",

--- a/ingest/scripts/heatmap-report.ts
+++ b/ingest/scripts/heatmap-report.ts
@@ -16,6 +16,7 @@ import dotenv from "dotenv";
 import { resolve } from "node:path";
 import { center, lineString, polygon } from "@turf/turf";
 import type { GeoJSONFeatureCollection, GeoJSONGeometry } from "@/lib/types";
+import type { HeatmapMessage } from "@/lib/heatmap/snapshot-store";
 
 type HeatmapPoint = [number, number]; // [lat, lng] (Leaflet convention)
 
@@ -109,7 +110,7 @@ Examples:
 
         console.log(`Processing ${docs.length} finalized messages...`);
 
-        const messages = [];
+        const messages: HeatmapMessage[] = [];
         for (const doc of docs) {
           if (doc.cityWide) continue;
 

--- a/ingest/scripts/heatmap-report.ts
+++ b/ingest/scripts/heatmap-report.ts
@@ -33,7 +33,7 @@ function isGeoJsonFeatureCollection(
 
 /**
  * Convert a single GeoJSON geometry to one or more heatmap [lat, lng] points.
- * Mirrors the same logic used in the web heatmap route.
+ * Used when producing the GCS heatmap snapshot that the web heatmap route loads.
  */
 function geometryToPoints(geometry: GeoJSONGeometry): HeatmapPoint[] {
   try {

--- a/ingest/scripts/heatmap-report.ts
+++ b/ingest/scripts/heatmap-report.ts
@@ -1,0 +1,170 @@
+#!/usr/bin/env tsx
+/**
+ * Generate a heatmap snapshot for the history page.
+ *
+ * Scans all finalized messages with GeoJSON, extracts coordinate points,
+ * and saves a compact snapshot to GCS. The web heatmap route loads this
+ * snapshot instead of querying Firestore on every request.
+ *
+ * Usage:
+ *   pnpm tsx ingest/scripts/heatmap-report.ts
+ *   pnpm tsx ingest/scripts/heatmap-report.ts --dry-run  # print stats, skip GCS write
+ */
+
+import { Command } from "commander";
+import dotenv from "dotenv";
+import { resolve } from "node:path";
+import { center, lineString, polygon } from "@turf/turf";
+import type { GeoJSONFeatureCollection, GeoJSONGeometry } from "@/lib/types";
+
+type HeatmapPoint = [number, number]; // [lat, lng] (Leaflet convention)
+
+function isGeoJsonFeatureCollection(
+  value: unknown,
+): value is GeoJSONFeatureCollection {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "features" in value &&
+    Array.isArray((value as GeoJSONFeatureCollection).features)
+  );
+}
+
+/**
+ * Convert a single GeoJSON geometry to one or more heatmap [lat, lng] points.
+ * Mirrors the same logic used in the web heatmap route.
+ */
+function geometryToPoints(geometry: GeoJSONGeometry): HeatmapPoint[] {
+  try {
+    if (geometry.type === "MultiPoint") {
+      return geometry.coordinates.map(([lng, lat]) => [lat, lng]);
+    }
+    if (geometry.type === "Point") {
+      const [lng, lat] = geometry.coordinates;
+      return [[lat, lng]];
+    }
+    if (geometry.type === "LineString" && geometry.coordinates.length > 0) {
+      const c = center(lineString(geometry.coordinates));
+      const [lng, lat] = c.geometry.coordinates;
+      return [[lat, lng]];
+    }
+    if (geometry.type === "Polygon" && geometry.coordinates.length > 0) {
+      const c = center(polygon(geometry.coordinates));
+      const [lng, lat] = c.geometry.coordinates;
+      return [[lat, lng]];
+    }
+  } catch {
+    // skip malformed geometries
+  }
+  return [];
+}
+
+function extractPoints(geoJson: GeoJSONFeatureCollection): HeatmapPoint[] {
+  const points: HeatmapPoint[] = [];
+  for (const feature of geoJson.features) {
+    if (feature?.geometry) {
+      points.push(...geometryToPoints(feature.geometry));
+    }
+  }
+  return points;
+}
+
+const program = new Command();
+
+program
+  .name("heatmap-report")
+  .description("Generate a GCS heatmap snapshot from finalized messages")
+  .option("--dry-run", "Print stats without writing to GCS")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  $ pnpm tsx ingest/scripts/heatmap-report.ts
+  $ pnpm tsx ingest/scripts/heatmap-report.ts --dry-run
+`,
+  )
+  .action(async (opts: { dryRun?: boolean }) => {
+    dotenv.config({ path: resolve(process.cwd(), ".env.local") });
+
+    try {
+      const { getDb, closeDb } = await import("@/lib/db");
+      const { saveHeatmapSnapshot } =
+        await import("@/lib/heatmap/snapshot-store");
+
+      const db = await getDb();
+
+      try {
+        console.log("Fetching finalized messages...");
+        const docs = await db.messages.findMany({
+          where: [{ field: "finalizedAt", op: ">", value: new Date(0) }],
+          select: [
+            "_id",
+            "geoJson",
+            "cityWide",
+            "finalizedAt",
+            "categories",
+            "source",
+          ],
+        });
+
+        console.log(`Processing ${docs.length} finalized messages...`);
+
+        const messages = [];
+        for (const doc of docs) {
+          if (doc.cityWide) continue;
+
+          const geoJson = isGeoJsonFeatureCollection(doc.geoJson)
+            ? doc.geoJson
+            : null;
+          if (!geoJson) continue;
+
+          const points = extractPoints(geoJson);
+          if (points.length === 0) continue;
+
+          const finalizedAt =
+            doc.finalizedAt instanceof Date
+              ? doc.finalizedAt.toISOString()
+              : typeof doc.finalizedAt === "string"
+                ? doc.finalizedAt
+                : "";
+
+          messages.push({
+            id: String(doc._id),
+            source: typeof doc.source === "string" ? doc.source : "",
+            categories: Array.isArray(doc.categories) ? doc.categories : [],
+            cityWide: false,
+            finalizedAt,
+            points,
+          });
+        }
+
+        const snapshot = {
+          generatedAt: new Date().toISOString(),
+          messages,
+        };
+
+        console.log(
+          `Snapshot: ${messages.length} messages with heatmap points`,
+        );
+
+        if (opts.dryRun) {
+          console.log("Dry run — skipping GCS write");
+        } else {
+          await saveHeatmapSnapshot(snapshot);
+          console.log("Heatmap snapshot saved to GCS");
+        }
+      } finally {
+        await closeDb();
+      }
+    } catch (error) {
+      console.error("Fatal error", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      process.exit(1);
+    }
+  });
+
+program.parseAsync().catch((err: unknown) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/ingest/terraform/main.tf
+++ b/ingest/terraform/main.tf
@@ -1463,6 +1463,116 @@ resource "google_cloud_scheduler_job" "geocode_frequency_report_schedule" {
   ]
 }
 
+# ── Heatmap Snapshot ──────────────────────────────────────────────────────────
+
+resource "google_cloud_run_v2_job" "heatmap_report" {
+  count    = var.gcs_generic_bucket != "" ? 1 : 0
+  name     = "heatmap-report"
+  location = var.region
+
+  template {
+    template {
+      service_account = google_service_account.ingest_runner.email
+      timeout         = "600s"
+
+      containers {
+        image = local.full_image_url
+        args  = ["pnpm", "run", "prebuilt:heatmap-report"]
+
+        resources {
+          limits = {
+            cpu    = "1"
+            memory = "512Mi"
+          }
+        }
+
+        env {
+          name  = "NODE_ENV"
+          value = "production"
+        }
+
+        env {
+          name = "FIREBASE_SERVICE_ACCOUNT_KEY"
+          value_source {
+            secret_key_ref {
+              secret  = data.google_secret_manager_secret.firebase_sa_key.secret_id
+              version = "latest"
+            }
+          }
+        }
+
+        env {
+          name  = "FIREBASE_PROJECT_ID"
+          value = var.firebase_project_id
+        }
+
+        env {
+          name  = "LOCALITY"
+          value = var.locality
+        }
+
+        env {
+          name  = "GCS_GENERIC_BUCKET"
+          value = var.gcs_generic_bucket
+        }
+
+        dynamic "env" {
+          for_each = local.sentry_env_secret_ids
+          content {
+            name = "SENTRY_DSN"
+            value_source {
+              secret_key_ref {
+                secret  = env.value
+                version = "latest"
+              }
+            }
+          }
+        }
+      }
+
+      max_retries = 1
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      launch_stage,
+    ]
+  }
+
+  depends_on = [
+    google_project_service.run
+  ]
+}
+
+resource "google_cloud_scheduler_job" "heatmap_report_schedule" {
+  count            = var.gcs_generic_bucket != "" ? 1 : 0
+  name             = "heatmap-report-schedule"
+  description      = "Generate heatmap snapshot daily"
+  schedule         = var.schedules.heatmap_report
+  time_zone        = var.schedule_timezone
+  attempt_deadline = "620s"
+  region           = var.region
+
+  retry_config {
+    retry_count = 1
+  }
+
+  http_target {
+    http_method = "POST"
+    uri         = "https://${var.region}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${var.project_id}/jobs/heatmap-report:run"
+
+    oauth_token {
+      service_account_email = google_service_account.ingest_runner.email
+    }
+  }
+
+  depends_on = [
+    google_project_service.cloudscheduler,
+    google_cloud_run_v2_job.heatmap_report,
+  ]
+}
+
 # ── Alerting ──────────────────────────────────────────────────────────────────
 
 resource "google_monitoring_notification_channel" "email" {
@@ -1783,6 +1893,41 @@ resource "google_monitoring_alert_policy" "geocode_frequency_report_failures" {
 
   documentation {
     content   = "The **geocode-frequency-report** job logged an error.\n\nLogs: https://console.cloud.google.com/run/jobs/details/${var.region}/geocode-frequency-report/logs?project=${var.project_id}"
+    mime_type = "text/markdown"
+  }
+
+  depends_on = [google_project_service.monitoring]
+}
+
+resource "google_monitoring_alert_policy" "heatmap_report_failures" {
+  count        = var.gcs_generic_bucket != "" ? 1 : 0
+  display_name = "Job Failure: Heatmap Report"
+  combiner     = "OR"
+
+  conditions {
+    display_name = "heatmap-report error"
+
+    condition_matched_log {
+      filter = <<-EOT
+        resource.type="cloud_run_job"
+        resource.labels.job_name="heatmap-report"
+        severity>=ERROR
+      EOT
+    }
+  }
+
+  alert_strategy {
+    notification_rate_limit {
+      period = "300s"
+    }
+  }
+
+  notification_channels = [
+    google_monitoring_notification_channel.email.name
+  ]
+
+  documentation {
+    content   = "The **heatmap-report** job logged an error.\n\nLogs: https://console.cloud.google.com/run/jobs/details/${var.region}/heatmap-report/logs?project=${var.project_id}"
     mime_type = "text/markdown"
   }
 

--- a/ingest/terraform/variables.tf
+++ b/ingest/terraform/variables.tf
@@ -42,6 +42,7 @@ variable "schedules" {
     educational_facilities_sync     = optional(string, "0 4 1 * *")
     air_quality_fetch               = optional(string, "*/15 * * * *")
     geocode_cache_report            = optional(string, "0 5 * * 1")
+    heatmap_report                  = optional(string, "0 4 * * 1")
   })
   default = {
     pipeline_emergent               = "*/30 7-22 * * *"    # Every 30 minutes, 7:00AM–10:30PM (hours 7-22)
@@ -50,6 +51,7 @@ variable "schedules" {
     educational_facilities_sync     = "0 4 1 * *"          # Monthly on the 1st at 4:00 AM
     air_quality_fetch               = "*/15 * * * *"       # Every 15 minutes, 24/7
     geocode_cache_report            = "0 5 * * 1"          # Weekly on Monday at 5:00 AM
+    heatmap_report                  = "0 4 * * 1"          # Weekly on Monday at 4:00 AM
   }
 }
 

--- a/web/app/api/messages/heatmap/route.test.ts
+++ b/web/app/api/messages/heatmap/route.test.ts
@@ -1,39 +1,68 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { GET } from "./route";
 
-// Mock data store — tests set this before each test
-let mockMessagesData: Record<string, unknown>[] = [];
+// ---------------------------------------------------------------------------
+// GCS mock
+// ---------------------------------------------------------------------------
+// Controls what the mocked GCS file returns each test.
+let mockSnapshotData: HeatmapSnapshot | null = null;
+let mockFileExists = true;
+let mockGcsError: Error | null = null;
 
-vi.mock("@/lib/db", () => ({
-  getDb: vi.fn().mockImplementation(async () => ({
-    messages: {
-      findMany: vi.fn().mockImplementation(async (options?: any) => {
-        let filtered = [...mockMessagesData];
+const mockDownload = vi.fn();
+const mockExists = vi.fn();
+const mockFile = vi.fn();
+const mockBucket = vi.fn();
 
-        if (options?.where) {
-          for (const clause of options.where) {
-            filtered = filtered.filter((doc) => {
-              const fieldValue = doc[clause.field];
-              switch (clause.op) {
-                case ">":
-                  if (fieldValue == null) return false;
-                  return fieldValue > clause.value;
-                case "==":
-                  return fieldValue === clause.value;
-                default:
-                  return true;
-              }
-            });
-          }
-        }
-
-        return filtered;
-      }),
-    },
-  })),
+vi.mock("@google-cloud/storage", () => ({
+  // Must use a regular function — arrow functions cannot be called with `new`
+  Storage: vi.fn().mockImplementation(function () {
+    return { bucket: mockBucket };
+  }),
 }));
 
-const FINALIZED_AT = new Date("2024-01-01T00:00:00Z");
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const FINALIZED_AT = "2024-01-01T00:00:00.000Z";
+
+interface HeatmapMessage {
+  id: string;
+  source: string;
+  categories: string[];
+  cityWide: boolean;
+  finalizedAt: string;
+  points: [number, number][];
+}
+
+interface HeatmapSnapshot {
+  generatedAt: string;
+  messages: HeatmapMessage[];
+}
+
+/** Build a minimal snapshot with the given messages. */
+function makeSnapshot(messages: HeatmapMessage[]): HeatmapSnapshot {
+  return { generatedAt: FINALIZED_AT, messages };
+}
+
+/** Build a message with a single Point geometry pre-converted to heatmap points. */
+function pointMsg(
+  id: string,
+  lat: number,
+  lng: number,
+  overrides: Partial<HeatmapMessage> = {},
+): HeatmapMessage {
+  return {
+    id,
+    source: "test-source",
+    categories: [],
+    cityWide: false,
+    finalizedAt: FINALIZED_AT,
+    points: [[lat, lng]],
+    ...overrides,
+  };
+}
 
 /** Helper: build a Request with optional query-string params */
 function makeRequest(params?: Record<string, string>): Request {
@@ -46,492 +75,185 @@ function makeRequest(params?: Record<string, string>): Request {
   return new Request(url.toString());
 }
 
-describe("GET /api/messages/heatmap", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockMessagesData = [];
+// ---------------------------------------------------------------------------
+// Wire up GCS mock before each test
+// ---------------------------------------------------------------------------
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSnapshotData = null;
+  mockFileExists = true;
+  mockGcsError = null;
+
+  mockDownload.mockImplementation(async () => {
+    if (mockGcsError) throw mockGcsError;
+    return [Buffer.from(JSON.stringify(mockSnapshotData))];
   });
 
-  it("returns 200 with an empty points array when no finalized messages exist", async () => {
+  mockExists.mockResolvedValue([mockFileExists]);
+
+  mockFile.mockReturnValue({ exists: mockExists, download: mockDownload });
+  mockBucket.mockReturnValue({ file: mockFile });
+
+  process.env.GCS_GENERIC_BUCKET = "test-bucket";
+});
+
+describe("GET /api/messages/heatmap", () => {
+  it("returns 503 when GCS_GENERIC_BUCKET is not configured", async () => {
+    delete process.env.GCS_GENERIC_BUCKET;
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(503);
+  });
+
+  it("returns 404 when snapshot file does not exist yet", async () => {
+    mockFileExists = false;
+    mockExists.mockResolvedValue([false]);
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 500 when GCS throws", async () => {
+    mockGcsError = new Error("GCS connection failed");
+    mockDownload.mockRejectedValue(mockGcsError);
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 200 with empty points array when snapshot has no messages", async () => {
+    mockSnapshotData = makeSnapshot([]);
     const res = await GET(makeRequest());
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body).toEqual({ points: [], messageCount: 0, oldestDate: null });
   });
 
-  it("excludes non-finalized messages (missing finalizedAt)", async () => {
-    mockMessagesData = [
-      {
-        _id: "no-final",
-        geoJson: {
-          type: "FeatureCollection",
-          features: [
-            {
-              type: "Feature",
-              geometry: { type: "Point", coordinates: [23.32, 42.69] },
-              properties: {},
-            },
-          ],
-        },
-      },
-    ];
+  it("sets Cache-Control header", async () => {
+    mockSnapshotData = makeSnapshot([]);
     const res = await GET(makeRequest());
-    const body = await res.json();
-    expect(body.points).toHaveLength(0);
+    expect(res.headers.get("Cache-Control")).toContain("s-maxage=3600");
   });
 
   it("excludes city-wide messages", async () => {
-    mockMessagesData = [
-      {
-        _id: "city-wide",
-        finalizedAt: FINALIZED_AT,
-        cityWide: true,
-        geoJson: {
-          type: "FeatureCollection",
-          features: [
-            {
-              type: "Feature",
-              geometry: { type: "Point", coordinates: [23.32, 42.69] },
-              properties: {},
-            },
-          ],
-        },
-      },
-    ];
+    mockSnapshotData = makeSnapshot([
+      pointMsg("city-wide", 42.69, 23.32, { cityWide: true }),
+    ]);
     const res = await GET(makeRequest());
     const body = await res.json();
+    expect(body.messageCount).toBe(0);
     expect(body.points).toHaveLength(0);
   });
 
-  it("excludes messages without geoJson", async () => {
-    mockMessagesData = [
-      { _id: "no-geo", finalizedAt: FINALIZED_AT, geoJson: null },
-    ];
+  it("returns points and correct messageCount for a single message", async () => {
+    mockSnapshotData = makeSnapshot([pointMsg("msg-1", 42.6977, 23.3219)]);
     const res = await GET(makeRequest());
     const body = await res.json();
-    expect(body.points).toHaveLength(0);
-  });
-
-  it("extracts a single point from a Point geometry", async () => {
-    mockMessagesData = [
-      {
-        _id: "point-msg",
-        finalizedAt: FINALIZED_AT,
-        geoJson: {
-          type: "FeatureCollection",
-          features: [
-            {
-              type: "Feature",
-              geometry: { type: "Point", coordinates: [23.3219, 42.6977] },
-              properties: {},
-            },
-          ],
-        },
-      },
-    ];
-    const res = await GET(makeRequest());
-    const body = await res.json();
-    // GeoJSON [lng, lat] → heatmap [lat, lng]
     expect(body.points).toEqual([[42.6977, 23.3219]]);
     expect(body.messageCount).toBe(1);
-    expect(body.oldestDate).toBe(FINALIZED_AT.toISOString());
-  });
-
-  it("extracts exactly ONE centroid from a LineString geometry", async () => {
-    mockMessagesData = [
-      {
-        _id: "line-msg",
-        finalizedAt: FINALIZED_AT,
-        geoJson: {
-          type: "FeatureCollection",
-          features: [
-            {
-              type: "Feature",
-              geometry: {
-                type: "LineString",
-                coordinates: [
-                  [23.30, 42.69],
-                  [23.31, 42.70],
-                  [23.32, 42.71],
-                ],
-              },
-              properties: {},
-            },
-          ],
-        },
-      },
-    ];
-    const res = await GET(makeRequest());
-    const body = await res.json();
-    // A LineString is a single geometry → exactly 1 centroid
-    expect(body.points).toHaveLength(1);
-    const [lat, lng] = body.points[0];
-    // Centroid is within the Sofia bounding box
-    expect(lat).toBeGreaterThan(42.6);
-    expect(lat).toBeLessThan(42.8);
-    expect(lng).toBeGreaterThan(23.2);
-    expect(lng).toBeLessThan(23.4);
-  });
-
-  it("extracts exactly ONE centroid from a Polygon geometry", async () => {
-    mockMessagesData = [
-      {
-        _id: "poly-msg",
-        finalizedAt: FINALIZED_AT,
-        geoJson: {
-          type: "FeatureCollection",
-          features: [
-            {
-              type: "Feature",
-              geometry: {
-                type: "Polygon",
-                coordinates: [
-                  [
-                    [23.30, 42.69],
-                    [23.31, 42.69],
-                    [23.31, 42.70],
-                    [23.30, 42.70],
-                    [23.30, 42.69],
-                  ],
-                ],
-              },
-              properties: {},
-            },
-          ],
-        },
-      },
-    ];
-    const res = await GET(makeRequest());
-    const body = await res.json();
-    // A Polygon is a single geometry → exactly 1 centroid
-    expect(body.points).toHaveLength(1);
-  });
-
-  it("extracts one point per coordinate from a MultiPoint geometry", async () => {
-    mockMessagesData = [
-      {
-        _id: "multipoint-msg",
-        finalizedAt: FINALIZED_AT,
-        geoJson: {
-          type: "FeatureCollection",
-          features: [
-            {
-              type: "Feature",
-              geometry: {
-                type: "MultiPoint",
-                coordinates: [
-                  [23.30, 42.69],
-                  [23.31, 42.70],
-                  [23.32, 42.71],
-                ],
-              },
-              properties: {},
-            },
-          ],
-        },
-      },
-    ];
-    const res = await GET(makeRequest());
-    const body = await res.json();
-    // MultiPoint: each coordinate is a distinct pin → 3 points
-    expect(body.points).toHaveLength(3);
-    expect(body.points).toEqual([
-      [42.69, 23.30],
-      [42.70, 23.31],
-      [42.71, 23.32],
-    ]);
-  });
-
-  it("accumulates one point per feature across multiple features in one message", async () => {
-    mockMessagesData = [
-      {
-        _id: "multi-feature",
-        finalizedAt: FINALIZED_AT,
-        geoJson: {
-          type: "FeatureCollection",
-          features: [
-            {
-              type: "Feature",
-              geometry: { type: "Point", coordinates: [23.30, 42.69] },
-              properties: {},
-            },
-            {
-              type: "Feature",
-              geometry: {
-                type: "LineString",
-                coordinates: [
-                  [23.31, 42.70],
-                  [23.32, 42.71],
-                ],
-              },
-              properties: {},
-            },
-          ],
-        },
-      },
-    ];
-    const res = await GET(makeRequest());
-    const body = await res.json();
-    // 1 point from Point + 1 centroid from LineString = 2
-    expect(body.points).toHaveLength(2);
+    expect(body.oldestDate).toBe(FINALIZED_AT);
   });
 
   it("accumulates points from multiple messages", async () => {
-    mockMessagesData = [
+    mockSnapshotData = makeSnapshot([
+      pointMsg("msg-1", 42.69, 23.3),
       {
-        _id: "msg-1",
-        finalizedAt: FINALIZED_AT,
-        geoJson: {
-          type: "FeatureCollection",
-          features: [
-            {
-              type: "Feature",
-              geometry: { type: "Point", coordinates: [23.30, 42.69] },
-              properties: {},
-            },
-          ],
-        },
+        ...pointMsg("msg-2", 42.7, 23.31),
+        points: [
+          [42.7, 23.31],
+          [42.71, 23.32],
+        ],
       },
-      {
-        _id: "msg-2",
-        finalizedAt: FINALIZED_AT,
-        geoJson: {
-          type: "FeatureCollection",
-          features: [
-            {
-              type: "Feature",
-              geometry: {
-                type: "LineString",
-                coordinates: [
-                  [23.31, 42.70],
-                  [23.32, 42.71],
-                ],
-              },
-              properties: {},
-            },
-          ],
-        },
-      },
-    ];
+    ]);
     const res = await GET(makeRequest());
     const body = await res.json();
-    // 1 point from msg-1 + 1 centroid from msg-2 = 2
-    expect(body.points).toHaveLength(2);
+    expect(body.points).toHaveLength(3);
+    expect(body.messageCount).toBe(2);
   });
 
-  it("reports correct messageCount and oldestDate across multiple messages", async () => {
-    const older = new Date("2023-06-01T00:00:00Z");
-    const newer = new Date("2024-01-01T00:00:00Z");
-    mockMessagesData = [
-      {
-        _id: "msg-newer",
-        finalizedAt: newer,
-        geoJson: {
-          type: "FeatureCollection",
-          features: [
-            {
-              type: "Feature",
-              geometry: { type: "Point", coordinates: [23.30, 42.69] },
-              properties: {},
-            },
-          ],
-        },
-      },
-      {
-        _id: "msg-older",
-        finalizedAt: older,
-        geoJson: {
-          type: "FeatureCollection",
-          features: [
-            {
-              type: "Feature",
-              geometry: { type: "Point", coordinates: [23.31, 42.70] },
-              properties: {},
-            },
-          ],
-        },
-      },
-      // City-wide message should NOT be counted
-      {
-        _id: "msg-citywide",
-        finalizedAt: new Date("2022-01-01T00:00:00Z"),
+  it("reports oldestDate as the earliest finalizedAt among included messages", async () => {
+    const older = "2023-06-01T00:00:00.000Z";
+    const newer = "2024-01-01T00:00:00.000Z";
+    mockSnapshotData = makeSnapshot([
+      pointMsg("msg-newer", 42.69, 23.3, { finalizedAt: newer }),
+      pointMsg("msg-older", 42.7, 23.31, { finalizedAt: older }),
+      pointMsg("msg-citywide", 42.71, 23.32, {
         cityWide: true,
-        geoJson: {
-          type: "FeatureCollection",
-          features: [
-            {
-              type: "Feature",
-              geometry: { type: "Point", coordinates: [23.32, 42.71] },
-              properties: {},
-            },
-          ],
-        },
-      },
-    ];
+        finalizedAt: "2022-01-01T00:00:00.000Z",
+      }),
+    ]);
     const res = await GET(makeRequest());
     const body = await res.json();
     expect(body.messageCount).toBe(2);
-    expect(body.oldestDate).toBe(older.toISOString());
-  });
-
-  it("returns 500 when the database throws", async () => {
-    vi.mocked((await import("@/lib/db")).getDb).mockRejectedValueOnce(
-      new Error("DB error"),
-    );
-    const res = await GET(makeRequest());
-    expect(res.status).toBe(500);
-    const body = await res.json();
-    expect(body).toEqual({ error: "Failed to fetch heatmap data" });
+    expect(body.oldestDate).toBe(older);
   });
 
   describe("category filtering", () => {
     beforeEach(() => {
-      mockMessagesData = [
-        {
-          _id: "water-msg",
-          finalizedAt: FINALIZED_AT,
+      mockSnapshotData = makeSnapshot([
+        pointMsg("water-msg", 42.69, 23.3, {
           categories: ["water"],
           source: "sofiyska-voda",
-          geoJson: {
-            type: "FeatureCollection",
-            features: [
-              {
-                type: "Feature",
-                geometry: { type: "Point", coordinates: [23.30, 42.69] },
-                properties: {},
-              },
-            ],
-          },
-        },
-        {
-          _id: "electricity-msg",
-          finalizedAt: FINALIZED_AT,
+        }),
+        pointMsg("electricity-msg", 42.7, 23.31, {
           categories: ["electricity"],
           source: "erm-zapad",
-          geoJson: {
-            type: "FeatureCollection",
-            features: [
-              {
-                type: "Feature",
-                geometry: { type: "Point", coordinates: [23.31, 42.70] },
-                properties: {},
-              },
-            ],
-          },
-        },
-        {
-          _id: "uncategorized-msg",
-          finalizedAt: FINALIZED_AT,
+        }),
+        pointMsg("uncategorized-msg", 42.71, 23.32, {
           categories: [],
           source: "sofia-bg",
-          geoJson: {
-            type: "FeatureCollection",
-            features: [
-              {
-                type: "Feature",
-                geometry: { type: "Point", coordinates: [23.32, 42.71] },
-                properties: {},
-              },
-            ],
-          },
-        },
-      ];
+        }),
+      ]);
     });
 
     it("returns all messages when no category filter is applied", async () => {
       const res = await GET(makeRequest());
-      const body = await res.json();
-      expect(body.messageCount).toBe(3);
+      expect((await res.json()).messageCount).toBe(3);
     });
 
-    it("filters to only matching category messages", async () => {
+    it("filters to only matching category", async () => {
       const res = await GET(makeRequest({ categories: "water" }));
-      const body = await res.json();
-      expect(body.messageCount).toBe(1);
+      expect((await res.json()).messageCount).toBe(1);
     });
 
     it("filters to multiple categories (OR logic)", async () => {
-      const res = await GET(
-        makeRequest({ categories: "water,electricity" }),
-      );
-      const body = await res.json();
-      expect(body.messageCount).toBe(2);
+      const res = await GET(makeRequest({ categories: "water,electricity" }));
+      expect((await res.json()).messageCount).toBe(2);
     });
 
     it("filters to uncategorized messages", async () => {
       const res = await GET(makeRequest({ categories: "uncategorized" }));
-      const body = await res.json();
-      expect(body.messageCount).toBe(1);
+      expect((await res.json()).messageCount).toBe(1);
     });
 
     it("combines real category and uncategorized in one filter", async () => {
-      const res = await GET(
-        makeRequest({ categories: "water,uncategorized" }),
-      );
-      const body = await res.json();
-      expect(body.messageCount).toBe(2);
+      const res = await GET(makeRequest({ categories: "water,uncategorized" }));
+      expect((await res.json()).messageCount).toBe(2);
     });
   });
 
   describe("source filtering", () => {
     beforeEach(() => {
-      mockMessagesData = [
-        {
-          _id: "msg-a",
-          finalizedAt: FINALIZED_AT,
-          categories: ["water"],
-          source: "sofiyska-voda",
-          geoJson: {
-            type: "FeatureCollection",
-            features: [
-              {
-                type: "Feature",
-                geometry: { type: "Point", coordinates: [23.30, 42.69] },
-                properties: {},
-              },
-            ],
-          },
-        },
-        {
-          _id: "msg-b",
-          finalizedAt: FINALIZED_AT,
-          categories: ["electricity"],
-          source: "erm-zapad",
-          geoJson: {
-            type: "FeatureCollection",
-            features: [
-              {
-                type: "Feature",
-                geometry: { type: "Point", coordinates: [23.31, 42.70] },
-                properties: {},
-              },
-            ],
-          },
-        },
-      ];
+      mockSnapshotData = makeSnapshot([
+        pointMsg("msg-a", 42.69, 23.3, { source: "sofiyska-voda" }),
+        pointMsg("msg-b", 42.7, 23.31, { source: "erm-zapad" }),
+      ]);
     });
 
     it("returns all messages when no source filter is applied", async () => {
-      const res = await GET(makeRequest());
-      const body = await res.json();
-      expect(body.messageCount).toBe(2);
+      expect((await (await GET(makeRequest())).json()).messageCount).toBe(2);
     });
 
-    it("filters to only matching source messages", async () => {
+    it("filters to only matching source", async () => {
       const res = await GET(makeRequest({ sources: "sofiyska-voda" }));
-      const body = await res.json();
-      expect(body.messageCount).toBe(1);
+      expect((await res.json()).messageCount).toBe(1);
     });
 
     it("filters to multiple sources (OR logic)", async () => {
       const res = await GET(
         makeRequest({ sources: "sofiyska-voda,erm-zapad" }),
       );
-      const body = await res.json();
-      expect(body.messageCount).toBe(2);
+      expect((await res.json()).messageCount).toBe(2);
     });
 
-    it("returns empty result when source does not match any message", async () => {
+    it("returns empty result when source does not match", async () => {
       const res = await GET(makeRequest({ sources: "unknown-source" }));
       const body = await res.json();
       expect(body.messageCount).toBe(0);
@@ -540,63 +262,25 @@ describe("GET /api/messages/heatmap", () => {
   });
 
   describe("combined category and source filtering", () => {
-    it("applies both category and source filters simultaneously", async () => {
-      mockMessagesData = [
-        {
-          _id: "match",
-          finalizedAt: FINALIZED_AT,
+    it("applies both filters simultaneously", async () => {
+      mockSnapshotData = makeSnapshot([
+        pointMsg("match", 42.69, 23.3, {
           categories: ["water"],
           source: "sofiyska-voda",
-          geoJson: {
-            type: "FeatureCollection",
-            features: [
-              {
-                type: "Feature",
-                geometry: { type: "Point", coordinates: [23.30, 42.69] },
-                properties: {},
-              },
-            ],
-          },
-        },
-        {
-          _id: "wrong-source",
-          finalizedAt: FINALIZED_AT,
+        }),
+        pointMsg("wrong-source", 42.7, 23.31, {
           categories: ["water"],
           source: "erm-zapad",
-          geoJson: {
-            type: "FeatureCollection",
-            features: [
-              {
-                type: "Feature",
-                geometry: { type: "Point", coordinates: [23.31, 42.70] },
-                properties: {},
-              },
-            ],
-          },
-        },
-        {
-          _id: "wrong-category",
-          finalizedAt: FINALIZED_AT,
+        }),
+        pointMsg("wrong-category", 42.71, 23.32, {
           categories: ["electricity"],
           source: "sofiyska-voda",
-          geoJson: {
-            type: "FeatureCollection",
-            features: [
-              {
-                type: "Feature",
-                geometry: { type: "Point", coordinates: [23.32, 42.71] },
-                properties: {},
-              },
-            ],
-          },
-        },
-      ];
-
+        }),
+      ]);
       const res = await GET(
         makeRequest({ categories: "water", sources: "sofiyska-voda" }),
       );
-      const body = await res.json();
-      expect(body.messageCount).toBe(1);
+      expect((await res.json()).messageCount).toBe(1);
     });
   });
 });

--- a/web/app/api/messages/heatmap/route.ts
+++ b/web/app/api/messages/heatmap/route.ts
@@ -37,7 +37,7 @@ type HeatmapPoint = [number, number];
 /**
  * GET /api/messages/heatmap
  *
- * Returns coordinate points for the history heatmap, loaded from a daily GCS
+ * Returns coordinate points for the history heatmap, loaded from a periodic GCS
  * snapshot instead of querying Firestore on every request.
  *
  * Optional query parameters:

--- a/web/app/api/messages/heatmap/route.ts
+++ b/web/app/api/messages/heatmap/route.ts
@@ -1,170 +1,146 @@
 import { NextResponse } from "next/server";
-import { getDb } from "@/lib/db";
-import { getCentroid } from "@/lib/geometry-utils";
-import type { GeoJSONFeatureCollection, GeoJSONGeometry } from "@/lib/types";
 
-function isGeoJsonFeatureCollection(
-  value: unknown,
-): value is GeoJSONFeatureCollection {
-  if (typeof value !== "object" || value === null || !("features" in value)) {
-    return false;
+export const runtime = "nodejs";
+
+interface HeatmapMessage {
+  id: string;
+  source: string;
+  categories: string[];
+  cityWide: boolean;
+  finalizedAt: string;
+  /** Coordinate points in [lat, lng] order (Leaflet convention). */
+  points: [number, number][];
+}
+
+interface HeatmapSnapshot {
+  generatedAt: string;
+  messages: HeatmapMessage[];
+}
+
+let storage: import("@google-cloud/storage").Storage | null = null;
+
+async function getStorage() {
+  if (!storage) {
+    const { Storage } = await import("@google-cloud/storage");
+    if (process.env.FIREBASE_SERVICE_ACCOUNT_KEY) {
+      const credentials = JSON.parse(process.env.FIREBASE_SERVICE_ACCOUNT_KEY);
+      storage = new Storage({ credentials });
+    } else {
+      storage = new Storage();
+    }
   }
-  return Array.isArray(value.features);
+  return storage;
 }
 
 type HeatmapPoint = [number, number];
 
 /**
- * Convert a single GeoJSON geometry to one or more heatmap points.
- *
- * - Point      → the coordinate itself (1 point)
- * - LineString → turf bounding-box centroid (1 point)
- * - Polygon    → turf bounding-box centroid (1 point)
- * - MultiPoint → each coordinate is a distinct pin (N points)
- *
- * Points are returned in [lat, lng] order (Leaflet convention);
- * GeoJSON stores coordinates as [lng, lat].
- */
-function geometryToPoints(geometry: GeoJSONGeometry): HeatmapPoint[] {
-  if (geometry.type === "MultiPoint") {
-    // Each coordinate in a MultiPoint is a distinct, independent pin
-    return geometry.coordinates.map(([lng, lat]) => [lat, lng]);
-  }
-  // Point, LineString, Polygon → one representative centroid
-  const centroid = getCentroid(geometry);
-  return centroid ? [[centroid.lat, centroid.lng]] : [];
-}
-
-/**
- * Extract coordinate points from a GeoJSON FeatureCollection.
- * Returns one centroid per feature (or one point per coordinate for MultiPoint).
- */
-function extractPoints(geoJson: GeoJSONFeatureCollection): HeatmapPoint[] {
-  if (!geoJson?.features || !Array.isArray(geoJson.features)) return [];
-
-  const points: HeatmapPoint[] = [];
-  for (const feature of geoJson.features) {
-    if (!feature?.geometry) continue;
-    points.push(...geometryToPoints(feature.geometry));
-  }
-  return points;
-}
-
-/**
  * GET /api/messages/heatmap
  *
- * Returns coordinate points extracted from finalized messages with GeoJSON.
- * Each feature contributes one point (its centroid), except MultiPoint which
- * contributes one point per coordinate. City-wide messages are excluded.
+ * Returns coordinate points for the history heatmap, loaded from a daily GCS
+ * snapshot instead of querying Firestore on every request.
  *
  * Optional query parameters:
  * - `categories` – comma-separated list of category names (including "uncategorized")
  * - `sources`    – comma-separated list of source IDs
  *
- * Performance note: fetches all finalized messages in one query, but requests
- * only the minimal fields to minimise payload size. At the current scale
- * (~5 000 messages) this is fast enough; if the collection grows significantly,
- * consider caching the result or pre-computing the point list.
+ * Response: { points: [lat, lng][], messageCount: number, oldestDate: string | null }
  */
 export async function GET(request: Request) {
-  try {
-    const { searchParams } = new URL(request.url);
-    const categoriesParam = searchParams.get("categories");
-    const sourcesParam = searchParams.get("sources");
-
-    const selectedCategoriesArr = categoriesParam
-      ? categoriesParam
-          .split(",")
-          .map((c) => c.trim())
-          .filter(Boolean)
-      : null;
-    const selectedSourcesArr = sourcesParam
-      ? sourcesParam
-          .split(",")
-          .map((c) => c.trim())
-          .filter(Boolean)
-      : null;
-
-    // Hoist derived values out of the per-document loop so they are computed
-    // once per request. Use Sets for O(1) membership checks.
-    const filterCategories = (selectedCategoriesArr?.length ?? 0) > 0;
-    const includeUncategorized =
-      filterCategories &&
-      selectedCategoriesArr?.includes("uncategorized") === true;
-    const realCategoriesSet =
-      filterCategories && selectedCategoriesArr
-        ? new Set(selectedCategoriesArr.filter((c) => c !== "uncategorized"))
-        : null;
-    const selectedSourcesSet =
-      selectedSourcesArr && selectedSourcesArr.length > 0
-        ? new Set(selectedSourcesArr)
-        : null;
-
-    const db = await getDb();
-
-    // Use `> new Date(0)` instead of `!= null` for cross-backend consistency:
-    // MongoDB's `$ne: null` also matches missing fields, which would include
-    // non-finalized messages.
-    const docs = await db.messages.findMany({
-      where: [{ field: "finalizedAt", op: ">", value: new Date(0) }],
-      select: ["_id", "geoJson", "cityWide", "finalizedAt", "categories", "source"],
-    });
-
-    const points: HeatmapPoint[] = [];
-    let messageCount = 0;
-    let oldestDate: string | null = null;
-
-    for (const doc of docs) {
-      // Skip city-wide messages — they have no specific geometry
-      if (doc.cityWide) continue;
-
-      const geoJson = isGeoJsonFeatureCollection(doc.geoJson)
-        ? doc.geoJson
-        : null;
-      if (!geoJson) continue;
-
-      // Apply category filter when requested
-      if (filterCategories) {
-        const docCategories: string[] = Array.isArray(doc.categories)
-          ? doc.categories
-          : [];
-        const hasNoCategories = docCategories.length === 0;
-        const matchesUncategorized = includeUncategorized && hasNoCategories;
-        const matchesCategory =
-          !!realCategoriesSet &&
-          realCategoriesSet.size > 0 &&
-          docCategories.some((cat) => realCategoriesSet.has(cat));
-
-        if (!matchesUncategorized && !matchesCategory) continue;
-      }
-
-      // Apply source filter when requested
-      if (selectedSourcesSet) {
-        const docSource = typeof doc.source === "string" ? doc.source : undefined;
-        if (!docSource || !selectedSourcesSet.has(docSource)) continue;
-      }
-
-      messageCount++;
-
-      // Track oldest finalizedAt among messages that contributed to the heatmap
-      const raw = doc.finalizedAt;
-      if (raw instanceof Date) {
-        const iso = raw.toISOString();
-        if (!oldestDate || iso < oldestDate) oldestDate = iso;
-      } else if (typeof raw === "string" && raw) {
-        if (!oldestDate || raw < oldestDate) oldestDate = raw;
-      }
-
-      const docPoints = extractPoints(geoJson);
-      points.push(...docPoints);
-    }
-
-    return NextResponse.json({ points, messageCount, oldestDate });
-  } catch (error) {
-    console.error("Error fetching heatmap data:", error);
+  const bucket = process.env.GCS_GENERIC_BUCKET;
+  if (!bucket) {
     return NextResponse.json(
-      { error: "Failed to fetch heatmap data" },
+      { error: "GCS_GENERIC_BUCKET not configured" },
+      { status: 503 },
+    );
+  }
+
+  let snapshot: HeatmapSnapshot;
+  try {
+    const gcs = await getStorage();
+    const file = gcs.bucket(bucket).file("heatmap/snapshot.json");
+    const [exists] = await file.exists();
+    if (!exists) {
+      return NextResponse.json(
+        { error: "Heatmap snapshot not generated yet" },
+        { status: 404 },
+      );
+    }
+    const [content] = await file.download();
+    const parsed: HeatmapSnapshot = JSON.parse(content.toString("utf-8"));
+    snapshot = parsed;
+  } catch (err) {
+    console.error("Failed to load heatmap snapshot", err);
+    return NextResponse.json(
+      { error: "Failed to load heatmap snapshot" },
       { status: 500 },
     );
   }
+
+  const { searchParams } = new URL(request.url);
+  const categoriesParam = searchParams.get("categories");
+  const sourcesParam = searchParams.get("sources");
+
+  const selectedCategoriesArr = categoriesParam
+    ? categoriesParam
+        .split(",")
+        .map((c) => c.trim())
+        .filter(Boolean)
+    : null;
+  const selectedSourcesArr = sourcesParam
+    ? sourcesParam
+        .split(",")
+        .map((c) => c.trim())
+        .filter(Boolean)
+    : null;
+
+  const filterCategories = (selectedCategoriesArr?.length ?? 0) > 0;
+  const includeUncategorized =
+    filterCategories &&
+    selectedCategoriesArr?.includes("uncategorized") === true;
+  const realCategoriesSet =
+    filterCategories && selectedCategoriesArr
+      ? new Set(selectedCategoriesArr.filter((c) => c !== "uncategorized"))
+      : null;
+  const selectedSourcesSet =
+    selectedSourcesArr && selectedSourcesArr.length > 0
+      ? new Set(selectedSourcesArr)
+      : null;
+
+  const points: HeatmapPoint[] = [];
+  let messageCount = 0;
+  let oldestDate: string | null = null;
+
+  for (const msg of snapshot.messages) {
+    if (msg.cityWide) continue;
+
+    if (filterCategories) {
+      const hasNoCategories = msg.categories.length === 0;
+      const matchesUncategorized = includeUncategorized && hasNoCategories;
+      const matchesCategory =
+        !!realCategoriesSet &&
+        realCategoriesSet.size > 0 &&
+        msg.categories.some((cat) => realCategoriesSet.has(cat));
+      if (!matchesUncategorized && !matchesCategory) continue;
+    }
+
+    if (selectedSourcesSet && !selectedSourcesSet.has(msg.source)) continue;
+
+    messageCount++;
+
+    if (msg.finalizedAt && (!oldestDate || msg.finalizedAt < oldestDate)) {
+      oldestDate = msg.finalizedAt;
+    }
+
+    points.push(...msg.points);
+  }
+
+  return NextResponse.json(
+    { points, messageCount, oldestDate },
+    {
+      headers: {
+        "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400",
+      },
+    },
+  );
 }

--- a/web/app/api/messages/heatmap/route.ts
+++ b/web/app/api/messages/heatmap/route.ts
@@ -68,6 +68,9 @@ export async function GET(request: Request) {
     }
     const [content] = await file.download();
     const parsed: HeatmapSnapshot = JSON.parse(content.toString("utf-8"));
+    if (!Array.isArray(parsed.messages)) {
+      throw new Error("Snapshot is malformed: missing messages array");
+    }
     snapshot = parsed;
   } catch (err) {
     console.error("Failed to load heatmap snapshot", err);


### PR DESCRIPTION
- Add ingest/scripts/heatmap-report.ts: CLI script that builds a HeatmapSnapshot from all finalized non-cityWide messages and saves it to GCS (heatmap/snapshot.json) using @turf/turf for centroids
- Add ingest/lib/heatmap/snapshot-store.ts: GCS save/load abstraction mirroring the geocode-cache report-store pattern
- Replace web/app/api/messages/heatmap/route.ts: route now reads the pre-built GCS snapshot instead of scanning Firestore on every request; returns 503/404/500 on missing config/file/error
- Add terraform resources: weekly Cloud Run job (Monday 4 AM), Cloud Scheduler, and alert policy for heatmap-report failures; geocode-cache report schedule aligned to weekly (Monday 5 AM)
- Update ingest/package.json: add heatmap-report and prebuilt:heatmap-report scripts
- Rewrite route.test.ts with GCS-backed mock; add snapshot-store.test.ts