### PR TITLE
feat(ingest): make geocoding providers locality-configurable

### DIFF
--- a/ingest/geocoding/README.md
+++ b/ingest/geocoding/README.md
@@ -1,13 +1,19 @@
 # Geocoding
 
-The router ([`router.ts`](router.ts)) dispatches each location type extracted from a message to the appropriate service:
+The router ([`router.ts`](router.ts)) dispatches each location type extracted from a message to the provider declared for that locality. Providers are configured in `localities/{locality}.yaml` — see [`lib/locality-data-sources.ts`](../lib/locality-data-sources.ts).
 
-| Location type            | Service                                | Output    |
-| ------------------------ | -------------------------------------- | --------- |
-| Specific address (pin)   | [Google](google/README.md)             | Point     |
-| Street section           | [Overpass/OSM](overpass/README.md)     | LineString |
-| Cadastral property (УПИ) | [Cadastre](cadastre/README.md)         | Polygon   |
-| Bus stop code            | GTFS (`gtfs/`)                         | Point     |
+| Location type                  | Supported providers                        | Output     |
+| ------------------------------ | ------------------------------------------ | ---------- |
+| Specific address (pin)         | `google`, `overpass`                       | Point      |
+| Street section                 | `overpass`, `google`                       | LineString |
+| Cadastral property (УПИ)       | `cadastre`, `skip`                         | Polygon (`cadastre`); no geometry otherwise |
+| Bus stop code                  | `gtfs`, `google`, `overpass`, `skip`       | Point      |
+| Educational facility reference | `educational-facilities`, `google`, `skip` | Point      |
+
+`skip` disables geocoding for that type — the pipeline performs no lookup and returns no geometry for those locations.
+
+
+All 5 resolver types are **required** in the locality YAML. The app fails at startup if any is absent or uses an unrecognised provider.
 
 All results are validated against the configured locality boundary before use. Results outside the boundary are rejected.
 

--- a/ingest/geocoding/educational-facilities/service.test.ts
+++ b/ingest/geocoding/educational-facilities/service.test.ts
@@ -4,7 +4,18 @@ vi.mock("../../lib/firebase-admin", () => ({
   adminDb: vi.fn(),
 }));
 
-const { parseFacilityNumber } = await import("./service");
+vi.mock("@/lib/locality-data-sources", () => ({
+  getLocalityDataSources: vi.fn(),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { getLocalityDataSources } from "@/lib/locality-data-sources";
+import { logger } from "@/lib/logger";
+
+const { parseFacilityNumber, syncEducationalFacilities } = await import("./service");
 
 describe("parseFacilityNumber", () => {
   describe("object_nom takes priority", () => {
@@ -55,5 +66,41 @@ describe("parseFacilityNumber", () => {
     it("returns null when object_nam is an empty string", () => {
       expect(parseFacilityNumber(null, "")).toBeNull();
     });
+  });
+});
+
+describe("syncEducationalFacilities", () => {
+  it("skips sync and logs when educational-facilities provider is not educational-facilities", async () => {
+    vi.mocked(getLocalityDataSources).mockReturnValue({
+      "geocoding-resolvers": {
+        "educational-facilities": { provider: "skip" },
+      },
+    } as any);
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    await syncEducationalFacilities();
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(vi.mocked(logger.info)).toHaveBeenCalledWith(
+      "Educational facilities resolver is not educational-facilities — skipping sync",
+      { provider: "skip" },
+    );
+
+    fetchSpy.mockRestore();
+  });
+
+  it("skips sync when provider is google", async () => {
+    vi.mocked(getLocalityDataSources).mockReturnValue({
+      "geocoding-resolvers": {
+        "educational-facilities": { provider: "google" },
+      },
+    } as any);
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    await syncEducationalFacilities();
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    fetchSpy.mockRestore();
   });
 });

--- a/ingest/geocoding/educational-facilities/service.ts
+++ b/ingest/geocoding/educational-facilities/service.ts
@@ -2,9 +2,7 @@ import { isWithinBounds } from "@oboapp/shared";
 import { getLocality } from "../../lib/target-locality";
 import { roundCoordinate } from "@/geocoding/shared/coordinate-utils";
 import { logger } from "@/lib/logger";
-
-const SCHOOLS_URL = "https://api.sofiaplan.bg/datasets/166";
-const KINDERGARTENS_URL = "https://api.sofiaplan.bg/datasets/142";
+import { getLocalityDataSources } from "@/lib/locality-data-sources";
 
 export type FacilityType = "school" | "kindergarten";
 
@@ -148,12 +146,26 @@ async function fetchFacilities(
 }
 
 /**
- * Sync schools and kindergartens from Sofia open data to the educationalFacilities collection.
+ * Sync schools and kindergartens from the configured open data source to the educationalFacilities collection.
  */
 export async function syncEducationalFacilities(): Promise<void> {
+  const resolver =
+    getLocalityDataSources()["geocoding-resolvers"]["educational-facilities"];
+
+  if (resolver.provider !== "educational-facilities") {
+    logger.info(
+      "Educational facilities resolver is not educational-facilities — skipping sync",
+      { provider: resolver.provider },
+    );
+    return;
+  }
+
+  const schoolsUrl = resolver["schools-url"];
+  const kindergartensUrl = resolver["kindergartens-url"];
+
   const [schoolsResult, kindergartensResult] = await Promise.allSettled([
-    fetchFacilities(SCHOOLS_URL, "school"),
-    fetchFacilities(KINDERGARTENS_URL, "kindergarten"),
+    fetchFacilities(schoolsUrl, "school"),
+    fetchFacilities(kindergartensUrl, "kindergarten"),
   ]);
 
   const schools =

--- a/ingest/geocoding/google/service.ts
+++ b/ingest/geocoding/google/service.ts
@@ -2,6 +2,7 @@ import { Address } from "../../lib/types";
 import { isCenterFallback, isGenericCityAddress } from "./utils";
 import { isWithinBounds, normalizePinAddress } from "@oboapp/shared";
 import { getLocality } from "../../lib/target-locality";
+import { getLocalityContext } from "../../lib/locality-context";
 import { delay } from "../../lib/delay";
 import { logger } from "@/lib/logger";
 import { GoogleGeocodingMockService } from "../../__mocks__/services/google-geocoding-mock-service";
@@ -31,10 +32,12 @@ export async function geocodeAddress(address: string): Promise<Address | null> {
 
   try {
     const locality = getLocality();
+    const { city, country } = getLocalityContext();
+    const countryCode = locality.split(".")[0].toUpperCase(); // e.g. "bg.sofia" → "BG"
     const apiKey = process.env.GOOGLE_MAPS_API_KEY;
-    const encodedAddress = encodeURIComponent(`${address}, Sofia, Bulgaria`);
-    // Use components parameter to restrict to Sofia (locality)
-    const url = `https://maps.googleapis.com/maps/api/geocode/json?address=${encodedAddress}&components=locality:Sofia|country:BG&key=${apiKey}`;
+    const encodedAddress = encodeURIComponent(`${address}, ${city}, ${country}`);
+    // Use components parameter to restrict to the current locality
+    const url = `https://maps.googleapis.com/maps/api/geocode/json?address=${encodedAddress}&components=locality:${city}|country:${countryCode}&key=${apiKey}`;
 
     const response = await fetch(url);
     const data = await response.json();

--- a/ingest/geocoding/google/service.ts
+++ b/ingest/geocoding/google/service.ts
@@ -35,11 +35,13 @@ export async function geocodeAddress(address: string): Promise<Address | null> {
     const { city, country } = getLocalityContext();
     const countryCode = locality.split(".")[0].toUpperCase(); // e.g. "bg.sofia" → "BG"
     const apiKey = process.env.GOOGLE_MAPS_API_KEY;
-    const encodedAddress = encodeURIComponent(`${address}, ${city}, ${country}`);
-    // Use components parameter to restrict to the current locality
-    const url = `https://maps.googleapis.com/maps/api/geocode/json?address=${encodedAddress}&components=locality:${city}|country:${countryCode}&key=${apiKey}`;
+    // Build URL via URLSearchParams so city/country/key are properly encoded
+    const geocodeUrl = new URL("https://maps.googleapis.com/maps/api/geocode/json");
+    geocodeUrl.searchParams.set("address", `${address}, ${city}, ${country}`);
+    geocodeUrl.searchParams.set("components", `locality:${city}|country:${countryCode}`);
+    geocodeUrl.searchParams.set("key", apiKey ?? "");
 
-    const response = await fetch(url);
+    const response = await fetch(geocodeUrl.toString());
     const data = await response.json();
 
     if (data.status === "OK" && data.results && data.results.length > 0) {

--- a/ingest/geocoding/google/service.ts
+++ b/ingest/geocoding/google/service.ts
@@ -34,12 +34,18 @@ export async function geocodeAddress(address: string): Promise<Address | null> {
     const locality = getLocality();
     const { city, country } = getLocalityContext();
     const countryCode = locality.split(".")[0].toUpperCase(); // e.g. "bg.sofia" → "BG"
-    const apiKey = process.env.GOOGLE_MAPS_API_KEY;
+    const apiKey = process.env.GOOGLE_MAPS_API_KEY?.trim();
+    if (!apiKey) {
+      logger.warn("GOOGLE_MAPS_API_KEY is not set, skipping Google geocoding", {
+        address,
+      });
+      return null;
+    }
     // Build URL via URLSearchParams so city/country/key are properly encoded
     const geocodeUrl = new URL("https://maps.googleapis.com/maps/api/geocode/json");
     geocodeUrl.searchParams.set("address", `${address}, ${city}, ${country}`);
     geocodeUrl.searchParams.set("components", `locality:${city}|country:${countryCode}`);
-    geocodeUrl.searchParams.set("key", apiKey ?? "");
+    geocodeUrl.searchParams.set("key", apiKey);
 
     const response = await fetch(geocodeUrl.toString());
     const data = await response.json();

--- a/ingest/geocoding/gtfs/service.test.ts
+++ b/ingest/geocoding/gtfs/service.test.ts
@@ -5,8 +5,19 @@ vi.mock("../../lib/firebase-admin", () => ({
   adminDb: vi.fn(),
 }));
 
+vi.mock("@/lib/locality-data-sources", () => ({
+  getLocalityDataSources: vi.fn(),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { getLocalityDataSources } from "@/lib/locality-data-sources";
+import { logger } from "@/lib/logger";
+
 // Import after mocking
-const { parseStopsFile } = await import("./service");
+const { parseStopsFile, syncGTFSStopsToFirestore } = await import("./service");
 
 describe("parseStopsFile", () => {
   it("should parse valid GTFS stops.txt CSV", () => {
@@ -103,5 +114,41 @@ describe("parseStopsFile", () => {
     expect(result).toHaveLength(1);
     expect(result[0].stopCode).toBe("1805");
     expect(result[0].stopName).toBe("Ул. 507");
+  });
+});
+
+describe("syncGTFSStopsToFirestore", () => {
+  it("skips sync and logs when bus-stops provider is not gtfs", async () => {
+    vi.mocked(getLocalityDataSources).mockReturnValue({
+      "geocoding-resolvers": {
+        "bus-stops": { provider: "skip" },
+      },
+    } as any);
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    await syncGTFSStopsToFirestore();
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(vi.mocked(logger.info)).toHaveBeenCalledWith(
+      "Bus stops resolver is not gtfs — skipping GTFS sync",
+      { provider: "skip" },
+    );
+
+    fetchSpy.mockRestore();
+  });
+
+  it("skips sync when provider is google", async () => {
+    vi.mocked(getLocalityDataSources).mockReturnValue({
+      "geocoding-resolvers": {
+        "bus-stops": { provider: "google" },
+      },
+    } as any);
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    await syncGTFSStopsToFirestore();
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    fetchSpy.mockRestore();
   });
 });

--- a/ingest/geocoding/gtfs/service.ts
+++ b/ingest/geocoding/gtfs/service.ts
@@ -4,8 +4,7 @@ import { isWithinBounds } from "@oboapp/shared";
 import { getLocality } from "../../lib/target-locality";
 import { roundCoordinate } from "@/geocoding/shared/coordinate-utils";
 import { logger } from "@/lib/logger";
-
-const GTFS_URL = "https://gtfs.sofiatraffic.bg/api/v1/static";
+import { getLocalityDataSources } from "@/lib/locality-data-sources";
 
 export interface GTFSStop {
   stopCode: string;
@@ -17,10 +16,10 @@ export interface GTFSStop {
 /**
  * Download and extract GTFS ZIP file, returning stops.txt content
  */
-async function downloadAndExtractGTFS(): Promise<string> {
-  logger.info("Downloading GTFS data", { url: GTFS_URL });
+async function downloadAndExtractGTFS(url: string): Promise<string> {
+  logger.info("Downloading GTFS data", { url });
 
-  const response = await fetch(GTFS_URL);
+  const response = await fetch(url);
 
   if (!response.ok) {
     throw new Error(
@@ -111,9 +110,20 @@ export function parseStopsFile(csvContent: string): GTFSStop[] {
  * Uses upsert (set with merge) to update existing records
  */
 export async function syncGTFSStopsToFirestore(): Promise<void> {
+  const resolver =
+    getLocalityDataSources()["geocoding-resolvers"]["bus-stops"];
+
+  if (resolver.provider !== "gtfs") {
+    logger.info("Bus stops resolver is not gtfs — skipping GTFS sync", {
+      provider: resolver.provider,
+    });
+    return;
+  }
+
+  const { url } = resolver;
   logger.info("Starting GTFS stops sync");
 
-  const csvContent = await downloadAndExtractGTFS();
+  const csvContent = await downloadAndExtractGTFS(url);
   const stops = parseStopsFile(csvContent);
 
   logger.info("Parsed valid stops", { count: stops.length });

--- a/ingest/geocoding/gtfs/service.ts
+++ b/ingest/geocoding/gtfs/service.ts
@@ -97,8 +97,9 @@ export function parseStopsFile(csvContent: string): GTFSStop[] {
     logger.info("Skipped stops without stop_code", { count: skippedNoCode });
   }
   if (skippedOutOfBounds > 0) {
-    logger.info("Skipped stops outside Sofia boundaries", {
+    logger.info("Skipped stops outside locality boundaries", {
       count: skippedOutOfBounds,
+      locality: getLocality(),
     });
   }
 

--- a/ingest/geocoding/router.test.ts
+++ b/ingest/geocoding/router.test.ts
@@ -52,11 +52,13 @@ import {
   geocodeStreets,
   geocodeBusStops,
   geocodeEducationalFacilities,
+  geocodeCadastralPropertiesFromIdentifiers,
 } from "./router";
 import { geocodeAddresses as googleService } from "./google/service";
 import { overpassGeocodeAddresses } from "./overpass/service";
 import { geocodeBusStops as gtfsService } from "./gtfs/geocoding-service";
 import { geocodeEducationalFacilities as eduFacilitiesService } from "./educational-facilities/geocoding-service";
+import { geocodeCadastralProperties as cadastreService } from "./cadastre/service";
 
 describe("buildHouseNumberQuery", () => {
   it("prefixes street name when endpoint is just a number", () => {
@@ -358,6 +360,41 @@ describe("provider dispatch", () => {
       const result = await geocodeEducationalFacilities(facilities as any);
       expect(result).toEqual([]);
       expect(vi.mocked(eduFacilitiesService)).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("geocodeCadastralPropertiesFromIdentifiers", () => {
+    beforeEach(() => {
+      vi.mocked(cadastreService).mockResolvedValue(new Map());
+    });
+
+    it("returns an empty map immediately for empty input without calling any provider", async () => {
+      const result = await geocodeCadastralPropertiesFromIdentifiers([]);
+      expect(result).toEqual(new Map());
+      expect(vi.mocked(cadastreService)).not.toHaveBeenCalled();
+    });
+
+    it("calls cadastre service when provider is cadastre", async () => {
+      const mockResult = new Map([["12345", { type: "MultiPolygon", coordinates: [] }]]);
+      vi.mocked(cadastreService).mockResolvedValue(mockResult as any);
+
+      const result = await geocodeCadastralPropertiesFromIdentifiers(["12345"]);
+      expect(vi.mocked(cadastreService)).toHaveBeenCalledWith(["12345"]);
+      expect(result).toBe(mockResult);
+    });
+
+    it("returns an empty map and does not call cadastre service when provider is skip", async () => {
+      vi.mocked(getLocalityDataSources).mockReturnValue({
+        ...DEFAULT_RESOLVERS,
+        "geocoding-resolvers": {
+          ...DEFAULT_RESOLVERS["geocoding-resolvers"],
+          "cadastral-properties": { provider: "skip" },
+        },
+      } as any);
+
+      const result = await geocodeCadastralPropertiesFromIdentifiers(["12345"]);
+      expect(result).toEqual(new Map());
+      expect(vi.mocked(cadastreService)).not.toHaveBeenCalled();
     });
   });
 });

--- a/ingest/geocoding/router.test.ts
+++ b/ingest/geocoding/router.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // Mock Firebase-dependent imports to avoid initialization errors
 vi.mock("@/lib/logger", () => ({
@@ -22,7 +22,41 @@ vi.mock("./cadastre/service", () => ({
   geocodeCadastralProperties: vi.fn(),
 }));
 
-import { hasHouseNumber, buildHouseNumberQuery } from "./router";
+vi.mock("./educational-facilities/geocoding-service", () => ({
+  geocodeEducationalFacilities: vi.fn(),
+}));
+
+const DEFAULT_RESOLVERS = {
+  "geocoding-resolvers": {
+    pins: { provider: "google" as const },
+    streets: { provider: "overpass" as const },
+    "cadastral-properties": { provider: "cadastre" as const },
+    "bus-stops": { provider: "gtfs" as const, url: "https://gtfs.example.com" },
+    "educational-facilities": {
+      provider: "educational-facilities" as const,
+      "schools-url": "https://schools.example.com",
+      "kindergartens-url": "https://kindergartens.example.com",
+    },
+  },
+};
+
+vi.mock("@/lib/locality-data-sources", () => ({
+  getLocalityDataSources: vi.fn(() => DEFAULT_RESOLVERS),
+}));
+
+import { getLocalityDataSources } from "@/lib/locality-data-sources";
+import {
+  hasHouseNumber,
+  buildHouseNumberQuery,
+  geocodeAddresses,
+  geocodeStreets,
+  geocodeBusStops,
+  geocodeEducationalFacilities,
+} from "./router";
+import { geocodeAddresses as googleService } from "./google/service";
+import { overpassGeocodeAddresses } from "./overpass/service";
+import { geocodeBusStops as gtfsService } from "./gtfs/geocoding-service";
+import { geocodeEducationalFacilities as eduFacilitiesService } from "./educational-facilities/geocoding-service";
 
 describe("buildHouseNumberQuery", () => {
   it("prefixes street name when endpoint is just a number", () => {
@@ -210,6 +244,120 @@ describe("hasHouseNumber", () => {
 
     it("rejects when number is part of street name", () => {
       expect(hasHouseNumber("ул. 6-ти септември")).toBe(false);
+    });
+  });
+});
+
+describe("provider dispatch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getLocalityDataSources).mockReturnValue(DEFAULT_RESOLVERS as any);
+    vi.mocked(googleService).mockResolvedValue([]);
+    vi.mocked(overpassGeocodeAddresses).mockResolvedValue([]);
+    vi.mocked(gtfsService).mockResolvedValue([]);
+    vi.mocked(eduFacilitiesService).mockResolvedValue([]);
+  });
+
+  describe("geocodeAddresses", () => {
+    it("calls Google when pins provider is google", async () => {
+      await geocodeAddresses(["ул. Test 1"]);
+      expect(vi.mocked(googleService)).toHaveBeenCalledWith(["ул. Test 1"]);
+      expect(vi.mocked(overpassGeocodeAddresses)).not.toHaveBeenCalled();
+    });
+
+    it("calls Overpass when pins provider is overpass", async () => {
+      vi.mocked(getLocalityDataSources).mockReturnValue({
+        ...DEFAULT_RESOLVERS,
+        "geocoding-resolvers": {
+          ...DEFAULT_RESOLVERS["geocoding-resolvers"],
+          pins: { provider: "overpass" },
+        },
+      } as any);
+
+      await geocodeAddresses(["ул. Test 1"]);
+      expect(vi.mocked(overpassGeocodeAddresses)).toHaveBeenCalledWith(["ул. Test 1"]);
+      expect(vi.mocked(googleService)).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("geocodeStreets", () => {
+    const streets = [{ street: "ул. Test", from: "A", to: "B", timespans: [] }];
+
+    it("calls Overpass when streets provider is overpass", async () => {
+      await geocodeStreets(streets);
+      expect(vi.mocked(overpassGeocodeAddresses)).toHaveBeenCalledWith(["A", "B"]);
+      expect(vi.mocked(googleService)).not.toHaveBeenCalled();
+    });
+
+    it("calls Google when streets provider is google", async () => {
+      vi.mocked(getLocalityDataSources).mockReturnValue({
+        ...DEFAULT_RESOLVERS,
+        "geocoding-resolvers": {
+          ...DEFAULT_RESOLVERS["geocoding-resolvers"],
+          streets: { provider: "google" },
+        },
+      } as any);
+
+      await geocodeStreets(streets);
+      expect(vi.mocked(googleService)).toHaveBeenCalledWith(["A", "B"]);
+      expect(vi.mocked(overpassGeocodeAddresses)).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("geocodeBusStops", () => {
+    it("returns [] immediately for empty input without calling any provider", async () => {
+      const result = await geocodeBusStops([]);
+      expect(result).toEqual([]);
+      expect(vi.mocked(gtfsService)).not.toHaveBeenCalled();
+    });
+
+    it("calls GTFS service when provider is gtfs", async () => {
+      await geocodeBusStops(["1234"]);
+      expect(vi.mocked(gtfsService)).toHaveBeenCalledWith(["1234"]);
+    });
+
+    it("returns [] when provider is skip", async () => {
+      vi.mocked(getLocalityDataSources).mockReturnValue({
+        ...DEFAULT_RESOLVERS,
+        "geocoding-resolvers": {
+          ...DEFAULT_RESOLVERS["geocoding-resolvers"],
+          "bus-stops": { provider: "skip" },
+        },
+      } as any);
+
+      const result = await geocodeBusStops(["1234"]);
+      expect(result).toEqual([]);
+      expect(vi.mocked(gtfsService)).not.toHaveBeenCalled();
+      expect(vi.mocked(googleService)).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("geocodeEducationalFacilities", () => {
+    const facilities = [{ type: "school", number: "1" }];
+
+    it("returns [] immediately for empty input without calling any provider", async () => {
+      const result = await geocodeEducationalFacilities([]);
+      expect(result).toEqual([]);
+      expect(vi.mocked(eduFacilitiesService)).not.toHaveBeenCalled();
+    });
+
+    it("calls educational-facilities service when provider is educational-facilities", async () => {
+      await geocodeEducationalFacilities(facilities as any);
+      expect(vi.mocked(eduFacilitiesService)).toHaveBeenCalledWith(facilities, undefined);
+    });
+
+    it("returns [] when provider is skip", async () => {
+      vi.mocked(getLocalityDataSources).mockReturnValue({
+        ...DEFAULT_RESOLVERS,
+        "geocoding-resolvers": {
+          ...DEFAULT_RESOLVERS["geocoding-resolvers"],
+          "educational-facilities": { provider: "skip" },
+        },
+      } as any);
+
+      const result = await geocodeEducationalFacilities(facilities as any);
+      expect(result).toEqual([]);
+      expect(vi.mocked(eduFacilitiesService)).not.toHaveBeenCalled();
     });
   });
 });

--- a/ingest/geocoding/router.ts
+++ b/ingest/geocoding/router.ts
@@ -1,10 +1,8 @@
 /**
- * Unified geocoding interface - FIXED HYBRID APPROACH
+ * Unified geocoding interface - RESOLVER-DRIVEN
  *
- * Google Geocoding API for pins (specific addresses)
- * OpenStreetMap Overpass API for streets (intersections and geometries)
- * Bulgarian Cadastre API for cadastral properties (УПИ)
- * GTFS for bus stops (public transport)
+ * Each geocodable location type is handled by a provider declared in
+ * localities/{locality}.yaml. See ingest/lib/locality-data-sources.ts.
  */
 
 import type { EducationalFacilityRef } from "@oboapp/shared";
@@ -23,6 +21,7 @@ import {
 import { geocodeBusStops as geocodeBusStopsService } from "./gtfs/geocoding-service";
 import { geocodeEducationalFacilities as geocodeEducationalFacilitiesService } from "./educational-facilities/geocoding-service";
 import { CadastreMockService } from "../__mocks__/services/cadastre-mock-service";
+import { getLocalityDataSources, type GeocodingResolvers } from "@/lib/locality-data-sources";
 
 // Check if mocking is enabled for Cadastre
 // (Google Geocoding mock is handled in geocoding-service.ts)
@@ -32,33 +31,80 @@ const cadastreMockService = USE_CADASTRE_MOCK
   ? new CadastreMockService()
   : null;
 
+// Provider dispatch maps — one per resolver type.
+// Adding a new provider means adding one entry here; no switch needed at call sites.
+
+const PIN_PROVIDERS: Record<
+  GeocodingResolvers["pins"]["provider"],
+  (input: string[]) => Promise<Address[]>
+> = {
+  google: geocodeAddressesTraditional,
+  overpass: overpassGeocodeAddresses,
+};
+
+const STREET_ENDPOINT_PROVIDERS: Record<
+  GeocodingResolvers["streets"]["provider"],
+  (input: string[]) => Promise<Address[]>
+> = {
+  google: geocodeAddressesTraditional,
+  overpass: overpassGeocodeAddresses,
+};
+
+const BUS_STOP_PROVIDERS: Record<
+  GeocodingResolvers["bus-stops"]["provider"],
+  (codes: string[]) => Promise<Address[]>
+> = {
+  gtfs: geocodeBusStopsService,
+  google: geocodeAddressesTraditional,
+  overpass: overpassGeocodeAddresses,
+  skip: async () => [],
+};
+
+const EDUCATIONAL_FACILITY_PROVIDERS: Record<
+  GeocodingResolvers["educational-facilities"]["provider"],
+  (
+    facilities: EducationalFacilityRef[],
+    errors?: IngestErrorRecorder,
+  ) => Promise<Address[]>
+> = {
+  "educational-facilities": geocodeEducationalFacilitiesService,
+  google: (facilities) =>
+    geocodeAddressesTraditional(facilities.map((f) => `${f.type} ${f.number}`)),
+  skip: async () => [],
+};
+
 /**
- * Geocode a list of addresses (pins) using Google Geocoding API
+ * Geocode a list of addresses (pins) using the configured pins resolver.
  */
 export async function geocodeAddresses(
   addresses: string[],
 ): Promise<Address[]> {
-  return geocodeAddressesTraditional(addresses);
+  const { pins } = getLocalityDataSources()["geocoding-resolvers"];
+  return PIN_PROVIDERS[pins.provider](addresses);
 }
 
 /**
- * Geocode street sections using Overpass (geocode endpoints)
+ * Geocode street sections using the configured streets resolver.
  */
 export async function geocodeStreets(
   streets: StreetSection[],
 ): Promise<Address[]> {
   const endpointAddresses = streets.flatMap((s) => [s.from, s.to]);
-  return overpassGeocodeAddresses(endpointAddresses);
+  const { streets: resolver } = getLocalityDataSources()["geocoding-resolvers"];
+  return STREET_ENDPOINT_PROVIDERS[resolver.provider](endpointAddresses);
 }
 
 /**
- * Get street geometry (centerline) using Overpass for real OSM geometries
+ * Get street geometry (centerline) using the configured streets resolver.
+ * Currently only Overpass supports geometry queries; Google falls back to null.
  */
 export async function getStreetGeometry(
   streetName: string,
   startCoords: Coordinates,
   endCoords: Coordinates,
 ): Promise<[number, number][] | null> {
+  const { streets: resolver } = getLocalityDataSources()["geocoding-resolvers"];
+  if (resolver.provider !== "overpass") return null;
   const { getStreetSectionGeometry } = await import("./overpass/service");
   const geometry = await getStreetSectionGeometry(
     streetName,
@@ -153,51 +199,91 @@ export async function geocodeIntersectionsForStreets(
     processEndpoint(street.to, street.street);
   });
 
-  // Geocode cross-street intersections via Overpass
-  const geocoded = await overpassGeocodeIntersections(intersections);
+  const { streets: streetsResolver } =
+    getLocalityDataSources()["geocoding-resolvers"];
 
-  geocoded.forEach((address) => {
-    // Store with just the cross street name (what validation and GeoJSON service expect)
-    // Extract the cross street from "ул. A ∩ ул. B" format
-    const parts = address.formattedAddress.split(" ∩ ");
-    if (parts.length === 2) {
-      const crossStreet = parts[1].trim();
-      geocodedMap.set(crossStreet, address.coordinates);
-    }
-  });
+  if (streetsResolver.provider === "overpass") {
+    // Geocode cross-street intersections via Overpass
+    const geocoded = await overpassGeocodeIntersections(intersections);
 
-  // Geocode house-number endpoints directly via Nominatim
-  if (houseNumberEndpoints.size > 0) {
-    // Build specific queries with street context to avoid ambiguous results
-    const queryToEndpoint = new Map<string, string>();
-    const endpointQueries = Array.from(houseNumberEndpoints.entries()).map(
-      ([endpoint, streetName]) => {
-        const query = buildHouseNumberQuery(streetName, endpoint);
-        queryToEndpoint.set(query, endpoint);
-        return query;
-      },
-    );
-
-    logger.info("Geocoding house-number endpoints via Nominatim", {
-      count: endpointQueries.length,
-    });
-
-    const houseNumberGeocoded = await overpassGeocodeAddresses(endpointQueries);
-
-    // Match results by originalText to handle skipped failures
-    houseNumberGeocoded.forEach((address) => {
-      const originalEndpoint = queryToEndpoint.get(address.originalText);
-      if (originalEndpoint) {
-        geocodedMap.set(originalEndpoint, address.coordinates);
+    geocoded.forEach((address) => {
+      // Store with just the cross street name (what validation and GeoJSON service expect)
+      // Extract the cross street from "ул. A ∩ ул. B" format
+      const parts = address.formattedAddress.split(" ∩ ");
+      if (parts.length === 2) {
+        const crossStreet = parts[1].trim();
+        geocodedMap.set(crossStreet, address.coordinates);
       }
     });
+
+    // Geocode house-number endpoints directly via Nominatim
+    if (houseNumberEndpoints.size > 0) {
+      // Build specific queries with street context to avoid ambiguous results
+      const queryToEndpoint = new Map<string, string>();
+      const endpointQueries = Array.from(houseNumberEndpoints.entries()).map(
+        ([endpoint, streetName]) => {
+          const query = buildHouseNumberQuery(streetName, endpoint);
+          queryToEndpoint.set(query, endpoint);
+          return query;
+        },
+      );
+
+      logger.info("Geocoding house-number endpoints via Nominatim", {
+        count: endpointQueries.length,
+      });
+
+      const houseNumberGeocoded =
+        await overpassGeocodeAddresses(endpointQueries);
+
+      // Match results by originalText to handle skipped failures
+      houseNumberGeocoded.forEach((address) => {
+        const originalEndpoint = queryToEndpoint.get(address.originalText);
+        if (originalEndpoint) {
+          geocodedMap.set(originalEndpoint, address.coordinates);
+        }
+      });
+    }
+  } else {
+    // Google fallback: geocode all intersections and house-number endpoints as plain addresses
+    const allEndpoints = new Map<string, string>(); // query -> endpoint key
+
+    for (const intersection of intersections) {
+      const crossStreet = intersection.split(" ∩ ")[1]?.trim();
+      if (crossStreet) allEndpoints.set(intersection, crossStreet);
+    }
+
+    const queryToEndpoint = new Map<string, string>();
+    for (const [endpoint, streetName] of houseNumberEndpoints.entries()) {
+      const query = buildHouseNumberQuery(streetName, endpoint);
+      queryToEndpoint.set(query, endpoint);
+    }
+
+    const allQueries = [
+      ...allEndpoints.keys(),
+      ...queryToEndpoint.keys(),
+    ];
+
+    if (allQueries.length > 0) {
+      const geocoded = await geocodeAddressesTraditional(allQueries);
+      geocoded.forEach((address) => {
+        const crossStreet = allEndpoints.get(address.originalText);
+        if (crossStreet) {
+          geocodedMap.set(crossStreet, address.coordinates);
+          return;
+        }
+        const endpoint = queryToEndpoint.get(address.originalText);
+        if (endpoint) {
+          geocodedMap.set(endpoint, address.coordinates);
+        }
+      });
+    }
   }
 
   return geocodedMap;
 }
 
 /**
- * Geocode cadastral properties using Bulgarian Cadastre API
+ * Geocode cadastral properties using the configured cadastral-properties resolver.
  */
 export async function geocodeCadastralPropertiesFromIdentifiers(
   identifiers: string[],
@@ -206,6 +292,14 @@ export async function geocodeCadastralPropertiesFromIdentifiers(
     return new Map();
   }
 
+  const resolver =
+    getLocalityDataSources()["geocoding-resolvers"]["cadastral-properties"];
+
+  if (resolver.provider === "skip") {
+    return new Map();
+  }
+
+  // provider === "cadastre"
   // Use mock if enabled
   if (USE_CADASTRE_MOCK && cadastreMockService) {
     logger.info("Using Cadastre mock for properties");
@@ -226,18 +320,21 @@ export async function geocodeCadastralPropertiesFromIdentifiers(
 }
 
 /**
- * Geocode bus stops using GTFS data
+ * Geocode bus stops using the configured bus-stops resolver.
  */
 export async function geocodeBusStops(stopCodes: string[]): Promise<Address[]> {
   if (stopCodes.length === 0) {
     return [];
   }
 
-  return geocodeBusStopsService(stopCodes);
+  const resolver =
+    getLocalityDataSources()["geocoding-resolvers"]["bus-stops"];
+
+  return BUS_STOP_PROVIDERS[resolver.provider](stopCodes);
 }
 
 /**
- * Geocode educational facilities (schools and kindergartens) using local reference data
+ * Geocode educational facilities using the configured educational-facilities resolver.
  */
 export async function geocodeEducationalFacilities(
   facilities: EducationalFacilityRef[],
@@ -247,5 +344,11 @@ export async function geocodeEducationalFacilities(
     return [];
   }
 
-  return geocodeEducationalFacilitiesService(facilities, ingestErrors);
+  const resolver =
+    getLocalityDataSources()["geocoding-resolvers"]["educational-facilities"];
+
+  return EDUCATIONAL_FACILITY_PROVIDERS[resolver.provider](
+    facilities,
+    ingestErrors,
+  );
 }

--- a/ingest/geocoding/router.ts
+++ b/ingest/geocoding/router.ts
@@ -6,6 +6,7 @@
  */
 
 import type { EducationalFacilityRef } from "@oboapp/shared";
+import { EDUCATIONAL_FACILITY_PREFIX } from "@/lib/constants";
 import { Address, StreetSection, Coordinates } from "../lib/types";
 import type { IngestErrorRecorder } from "@/lib/ingest-errors";
 import { logger } from "@/lib/logger";
@@ -55,8 +56,10 @@ const BUS_STOP_PROVIDERS: Record<
   (codes: string[]) => Promise<Address[]>
 > = {
   gtfs: geocodeBusStopsService,
-  google: geocodeAddressesTraditional,
-  overpass: overpassGeocodeAddresses,
+  google: (codes) =>
+    geocodeAddressesTraditional(codes.map((c) => `Спирка ${c}`)),
+  overpass: (codes) =>
+    overpassGeocodeAddresses(codes.map((c) => `Спирка ${c}`)),
   skip: async () => [],
 };
 
@@ -68,8 +71,21 @@ const EDUCATIONAL_FACILITY_PROVIDERS: Record<
   ) => Promise<Address[]>
 > = {
   "educational-facilities": geocodeEducationalFacilitiesService,
-  google: (facilities) =>
-    geocodeAddressesTraditional(facilities.map((f) => `${f.type} ${f.number}`)),
+  google: async (facilities) => {
+    const queryToKey = new Map(
+      facilities.map((f) => [
+        `${f.type} ${f.number}`,
+        `${EDUCATIONAL_FACILITY_PREFIX}${f.type}:${f.number}`,
+      ]),
+    );
+    const results = await geocodeAddressesTraditional(
+      facilities.map((f) => `${f.type} ${f.number}`),
+    );
+    return results.map((addr) => ({
+      ...addr,
+      originalText: queryToKey.get(addr.originalText) ?? addr.originalText,
+    }));
+  },
   skip: async () => [],
 };
 

--- a/ingest/ingest.ts
+++ b/ingest/ingest.ts
@@ -46,15 +46,17 @@ Examples:
     dotenv.config({ path: resolve(process.cwd(), ".env.local") });
     initSentry();
     verifyDbEnv();
-    verifyEnvSet([
-      "GOOGLE_AI_API_KEY",
-      "GOOGLE_AI_MODEL",
-      "GOOGLE_MAPS_API_KEY",
-    ]);
+    verifyEnvSet(["GOOGLE_AI_API_KEY", "GOOGLE_AI_MODEL"]);
 
     try {
       // Validate geocoding resolver config early — fail fast on misconfiguration
-      getLocalityDataSources();
+      const dataSources = getLocalityDataSources();
+
+      // Only require GOOGLE_MAPS_API_KEY when a resolver actually uses google
+      const resolvers = Object.values(dataSources["geocoding-resolvers"]);
+      if (resolvers.some((r) => r.provider === "google")) {
+        verifyEnvSet(["GOOGLE_MAPS_API_KEY"]);
+      }
 
       // Dynamically import to avoid loading dependencies at parse time
       const { ingest } = await import("./messageIngest/from-sources");
@@ -92,7 +94,7 @@ Examples:
 
 program
   .command("gtfs-stops")
-  .description("Sync GTFS bus stops from Sofia Traffic to Firestore")
+  .description("Sync GTFS bus stops from the configured locality provider to Firestore")
   .action(async () => {
     // Ensure environment variables are loaded
     dotenv.config({ path: resolve(process.cwd(), ".env.local") });
@@ -126,7 +128,7 @@ program
 
 program
   .command("educational-facilities-sync")
-  .description("Sync schools and kindergartens from Sofia open data to Firestore")
+  .description("Sync schools and kindergartens from the configured locality provider to Firestore")
   .action(async () => {
     dotenv.config({ path: resolve(process.cwd(), ".env.local") });
     verifyDbEnv();

--- a/ingest/ingest.ts
+++ b/ingest/ingest.ts
@@ -6,6 +6,7 @@ import dotenv from "dotenv";
 import { verifyEnvSet, verifyDbEnv } from "@/lib/verify-env";
 import { logger } from "@/lib/logger";
 import { initSentry, flushSentry } from "@/lib/sentry";
+import { getLocalityDataSources } from "@/lib/locality-data-sources";
 import type { IngestOptions } from "@/lib/types";
 
 const program = new Command();
@@ -52,6 +53,9 @@ Examples:
     ]);
 
     try {
+      // Validate geocoding resolver config early — fail fast on misconfiguration
+      getLocalityDataSources();
+
       // Dynamically import to avoid loading dependencies at parse time
       const { ingest } = await import("./messageIngest/from-sources");
 
@@ -95,6 +99,9 @@ program
     verifyDbEnv();
 
     try {
+      // Validate geocoding resolver config early — fail fast on misconfiguration
+      getLocalityDataSources();
+
       // Dynamically import to avoid loading dependencies at parse time
       const { syncGTFSStopsToFirestore } = await import("./geocoding/gtfs/service");
 
@@ -125,6 +132,9 @@ program
     verifyDbEnv();
 
     try {
+      // Validate geocoding resolver config early — fail fast on misconfiguration
+      getLocalityDataSources();
+
       const { syncEducationalFacilities } = await import(
         "./geocoding/educational-facilities/service"
       );

--- a/ingest/lib/ai-prompts.ts
+++ b/ingest/lib/ai-prompts.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { logger } from "@/lib/logger";
 import { applyLocalityContext } from "@/lib/locality-context";
+import { hasCode } from "@/lib/record-fields";
 
 /**
  * Loads a prompt template from the prompts directory and applies locality substitution.
@@ -16,10 +17,7 @@ export function loadPrompt(filename: string): string {
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     const errorCode =
-      typeof error === "object" &&
-      error !== null &&
-      "code" in error &&
-      typeof error.code === "string"
+      hasCode(error) && typeof error.code === "string"
         ? error.code
         : undefined;
 

--- a/ingest/lib/locality-context.ts
+++ b/ingest/lib/locality-context.ts
@@ -5,6 +5,7 @@ import { load as parseYaml } from "js-yaml";
 import { z } from "zod";
 
 import { logger } from "@/lib/logger";
+import { hasCode } from "@/lib/record-fields";
 import { getLocality } from "@/lib/target-locality";
 
 const LocalityContextSchema = z.object({
@@ -32,12 +33,7 @@ function loadLocalityContext(): LocalityContext {
   try {
     content = readFileSync(filePath, "utf-8");
   } catch (error: unknown) {
-    if (
-      typeof error === "object" &&
-      error !== null &&
-      "code" in error &&
-      error.code === "ENOENT"
-    ) {
+    if (hasCode(error) && error.code === "ENOENT") {
       throw new Error(
         `Locality context file not found for "${locality}": ${filePath}. ` +
           `Create prompts/localities/${locality}.yaml to continue.`,

--- a/ingest/lib/locality-context.ts
+++ b/ingest/lib/locality-context.ts
@@ -71,7 +71,7 @@ function loadLocalityContext(): LocalityContext {
   return result.data;
 }
 
-function getLocalityContext(): LocalityContext {
+export function getLocalityContext(): LocalityContext {
   if (!cachedContext) {
     cachedContext = loadLocalityContext();
   }

--- a/ingest/lib/locality-data-sources.test.ts
+++ b/ingest/lib/locality-data-sources.test.ts
@@ -1,0 +1,203 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const VALID_YAML = `
+geocoding-resolvers:
+  pins:
+    provider: google
+  streets:
+    provider: overpass
+  cadastral-properties:
+    provider: cadastre
+  bus-stops:
+    provider: gtfs
+    url: https://gtfs.example.com/api/v1/static
+  educational-facilities:
+    provider: educational-facilities
+    schools-url: https://api.example.com/schools
+    kindergartens-url: https://api.example.com/kindergartens
+`.trim();
+
+let tempDir: string;
+let localitiesDir: string;
+
+beforeEach(() => {
+  // Reset module cache so the per-module singleton (cachedSources) starts null
+  vi.resetModules();
+
+  tempDir = mkdtempSync(join(tmpdir(), "locality-sources-test-"));
+  localitiesDir = join(tempDir, "localities");
+  mkdirSync(localitiesDir, { recursive: true });
+
+  // Redirect process.cwd() so loadLocalityDataSources() resolves paths into tempDir
+  vi.spyOn(process, "cwd").mockReturnValue(tempDir);
+  process.env.LOCALITY = "test.locality";
+});
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+  delete process.env.LOCALITY;
+});
+
+describe("getLocalityDataSources()", () => {
+  it("loads and returns a valid config with all resolvers", async () => {
+    writeFileSync(join(localitiesDir, "test.locality.yaml"), VALID_YAML);
+    const { getLocalityDataSources } = await import("./locality-data-sources");
+
+    const config = getLocalityDataSources();
+
+    expect(config["geocoding-resolvers"].pins).toEqual({ provider: "google" });
+    expect(config["geocoding-resolvers"].streets).toEqual({
+      provider: "overpass",
+    });
+    expect(config["geocoding-resolvers"]["cadastral-properties"]).toEqual({
+      provider: "cadastre",
+    });
+    expect(config["geocoding-resolvers"]["bus-stops"]).toEqual({
+      provider: "gtfs",
+      url: "https://gtfs.example.com/api/v1/static",
+    });
+    expect(config["geocoding-resolvers"]["educational-facilities"]).toEqual({
+      provider: "educational-facilities",
+      "schools-url": "https://api.example.com/schools",
+      "kindergartens-url": "https://api.example.com/kindergartens",
+    });
+  });
+
+  it("returns the cached instance on subsequent calls", async () => {
+    writeFileSync(join(localitiesDir, "test.locality.yaml"), VALID_YAML);
+    const { getLocalityDataSources } = await import("./locality-data-sources");
+
+    const first = getLocalityDataSources();
+    const second = getLocalityDataSources();
+
+    expect(first).toBe(second);
+  });
+
+  it("accepts skip for cadastral-properties", async () => {
+    writeFileSync(
+      join(localitiesDir, "test.locality.yaml"),
+      VALID_YAML.replace("provider: cadastre", "provider: skip"),
+    );
+    const { getLocalityDataSources } = await import("./locality-data-sources");
+
+    const config = getLocalityDataSources();
+    expect(config["geocoding-resolvers"]["cadastral-properties"]).toEqual({
+      provider: "skip",
+    });
+  });
+
+  it("accepts skip for bus-stops", async () => {
+    writeFileSync(
+      join(localitiesDir, "test.locality.yaml"),
+      VALID_YAML.replace(
+        "provider: gtfs\n    url: https://gtfs.example.com/api/v1/static",
+        "provider: skip",
+      ),
+    );
+    const { getLocalityDataSources } = await import("./locality-data-sources");
+
+    const config = getLocalityDataSources();
+    expect(config["geocoding-resolvers"]["bus-stops"]).toEqual({
+      provider: "skip",
+    });
+  });
+
+  it("accepts skip for educational-facilities", async () => {
+    const skipYaml = `
+geocoding-resolvers:
+  pins:
+    provider: google
+  streets:
+    provider: overpass
+  cadastral-properties:
+    provider: skip
+  bus-stops:
+    provider: skip
+  educational-facilities:
+    provider: skip
+`.trim();
+    writeFileSync(join(localitiesDir, "test.locality.yaml"), skipYaml);
+    const { getLocalityDataSources } = await import("./locality-data-sources");
+
+    const config = getLocalityDataSources();
+    expect(config["geocoding-resolvers"]["educational-facilities"]).toEqual({
+      provider: "skip",
+    });
+  });
+});
+
+describe("loadLocalityDataSources() error handling", () => {
+  it("throws a file-not-found error for ENOENT — not a generic message", async () => {
+    // Do NOT write the YAML file => real readFileSync throws ENOENT
+    const { getLocalityDataSources } = await import("./locality-data-sources");
+
+    expect(() => getLocalityDataSources()).toThrow(
+      /Locality data sources file not found for "test\.locality"/,
+    );
+  });
+
+  it("includes hint to create the file in the ENOENT message", async () => {
+    const { getLocalityDataSources } = await import("./locality-data-sources");
+
+    expect(() => getLocalityDataSources()).toThrow(
+      /Create localities\/test\.locality\.yaml/,
+    );
+  });
+
+  it("throws a distinct 'Invalid YAML' error for YAML parse failures", async () => {
+    writeFileSync(
+      join(localitiesDir, "test.locality.yaml"),
+      "{ invalid yaml {{{",
+    );
+    const { getLocalityDataSources } = await import("./locality-data-sources");
+
+    expect(() => getLocalityDataSources()).toThrow(/Invalid YAML/);
+  });
+
+  it("throws a schema validation error when geocoding-resolvers is missing", async () => {
+    writeFileSync(join(localitiesDir, "test.locality.yaml"), "other-key: val");
+    const { getLocalityDataSources } = await import("./locality-data-sources");
+
+    expect(() => getLocalityDataSources()).toThrow(
+      /Invalid locality data sources file/,
+    );
+  });
+
+  it("throws when a required resolver (e.g. bus-stops) is missing", async () => {
+    const missingBusStops = `
+geocoding-resolvers:
+  pins:
+    provider: google
+  streets:
+    provider: overpass
+  cadastral-properties:
+    provider: skip
+  educational-facilities:
+    provider: skip
+`.trim();
+    writeFileSync(join(localitiesDir, "test.locality.yaml"), missingBusStops);
+    const { getLocalityDataSources } = await import("./locality-data-sources");
+
+    expect(() => getLocalityDataSources()).toThrow(
+      /Invalid locality data sources file/,
+    );
+  });
+
+  it("throws when gtfs provider is missing required url field", async () => {
+    const noUrl = VALID_YAML.replace(
+      "provider: gtfs\n    url: https://gtfs.example.com/api/v1/static",
+      "provider: gtfs",
+    );
+    writeFileSync(join(localitiesDir, "test.locality.yaml"), noUrl);
+    const { getLocalityDataSources } = await import("./locality-data-sources");
+
+    expect(() => getLocalityDataSources()).toThrow(
+      /Invalid locality data sources file/,
+    );
+  });
+});

--- a/ingest/lib/locality-data-sources.test.ts
+++ b/ingest/lib/locality-data-sources.test.ts
@@ -4,6 +4,12 @@ import { join } from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+// validateLocality is a registry check against known localities (bg.sofia etc.).
+// Test uses a synthetic "test.locality" that's not in the registry — mock it out.
+vi.mock("@oboapp/shared", () => ({
+  validateLocality: vi.fn(),
+}));
+
 const VALID_YAML = `
 geocoding-resolvers:
   pins:

--- a/ingest/lib/locality-data-sources.ts
+++ b/ingest/lib/locality-data-sources.ts
@@ -4,6 +4,8 @@ import { join } from "node:path";
 import { load as parseYaml } from "js-yaml";
 import { z } from "zod";
 
+import { validateLocality } from "@oboapp/shared";
+import { hasCode } from "@/lib/record-fields";
 import { getLocality } from "@/lib/target-locality";
 
 const LocalityDataSourcesSchema = z.object({
@@ -46,18 +48,14 @@ let cachedSources: LocalityDataSources | null = null;
 
 function loadLocalityDataSources(): LocalityDataSources {
   const locality = getLocality();
+  validateLocality(locality);
   const filePath = join(process.cwd(), "localities", `${locality}.yaml`);
 
   let content: string;
   try {
     content = readFileSync(filePath, "utf-8");
   } catch (error: unknown) {
-    if (
-      typeof error === "object" &&
-      error !== null &&
-      "code" in error &&
-      error.code === "ENOENT"
-    ) {
+    if (hasCode(error) && error.code === "ENOENT") {
       throw new Error(
         `Locality data sources file not found for "${locality}": ${filePath}. ` +
           `Create localities/${locality}.yaml to configure geocoding resolvers.`,

--- a/ingest/lib/locality-data-sources.ts
+++ b/ingest/lib/locality-data-sources.ts
@@ -1,0 +1,103 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { load as parseYaml } from "js-yaml";
+import { z } from "zod";
+
+import { getLocality } from "@/lib/target-locality";
+
+const LocalityDataSourcesSchema = z.object({
+  "geocoding-resolvers": z.object({
+    pins: z.discriminatedUnion("provider", [
+      z.object({ provider: z.literal("google") }),
+      z.object({ provider: z.literal("overpass") }),
+    ]),
+    streets: z.discriminatedUnion("provider", [
+      z.object({ provider: z.literal("overpass") }),
+      z.object({ provider: z.literal("google") }),
+    ]),
+    "cadastral-properties": z.discriminatedUnion("provider", [
+      z.object({ provider: z.literal("cadastre") }),
+      z.object({ provider: z.literal("skip") }),
+    ]),
+    "bus-stops": z.discriminatedUnion("provider", [
+      z.object({ provider: z.literal("gtfs"), url: z.string().url() }),
+      z.object({ provider: z.literal("google") }),
+      z.object({ provider: z.literal("overpass") }),
+      z.object({ provider: z.literal("skip") }),
+    ]),
+    "educational-facilities": z.discriminatedUnion("provider", [
+      z.object({
+        provider: z.literal("educational-facilities"),
+        "schools-url": z.string().url(),
+        "kindergartens-url": z.string().url(),
+      }),
+      z.object({ provider: z.literal("google") }),
+      z.object({ provider: z.literal("skip") }),
+    ]),
+  }),
+});
+
+export type LocalityDataSources = z.infer<typeof LocalityDataSourcesSchema>;
+
+export type GeocodingResolvers = LocalityDataSources["geocoding-resolvers"];
+
+let cachedSources: LocalityDataSources | null = null;
+
+function loadLocalityDataSources(): LocalityDataSources {
+  const locality = getLocality();
+  const filePath = join(process.cwd(), "localities", `${locality}.yaml`);
+
+  let content: string;
+  try {
+    content = readFileSync(filePath, "utf-8");
+  } catch (error: unknown) {
+    if (
+      typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      error.code === "ENOENT"
+    ) {
+      throw new Error(
+        `Locality data sources file not found for "${locality}": ${filePath}. ` +
+          `Create localities/${locality}.yaml to configure geocoding resolvers.`,
+        { cause: error },
+      );
+    }
+
+    throw new Error(
+      `Unable to read locality data sources file for "${locality}": ${filePath}.`,
+      { cause: error },
+    );
+  }
+
+  let raw: unknown;
+  try {
+    raw = parseYaml(content);
+  } catch (error: unknown) {
+    throw new Error(
+      `Invalid YAML in locality data sources file for "${locality}": ${filePath}.`,
+      { cause: error },
+    );
+  }
+
+  const result = LocalityDataSourcesSchema.safeParse(raw);
+  if (!result.success) {
+    throw new Error(
+      `Invalid locality data sources file for "${locality}": ${result.error.message}`,
+    );
+  }
+
+  return result.data;
+}
+
+/**
+ * Returns the locality data sources config for the current locality.
+ * Throws if the file is absent or the schema is invalid — fail-fast at startup.
+ */
+export function getLocalityDataSources(): LocalityDataSources {
+  if (!cachedSources) {
+    cachedSources = loadLocalityDataSources();
+  }
+  return cachedSources;
+}

--- a/ingest/lib/locality-data-sources.ts
+++ b/ingest/lib/locality-data-sources.ts
@@ -82,7 +82,7 @@ function loadLocalityDataSources(): LocalityDataSources {
   const result = LocalityDataSourcesSchema.safeParse(raw);
   if (!result.success) {
     throw new Error(
-      `Invalid locality data sources file for "${locality}": ${result.error.message}`,
+      `Invalid locality data sources file for "${locality}": ${filePath}. ${result.error.message}`,
     );
   }
 

--- a/ingest/localities/bg.sofia.yaml
+++ b/ingest/localities/bg.sofia.yaml
@@ -1,0 +1,14 @@
+geocoding-resolvers:
+  pins:
+    provider: google
+  streets:
+    provider: overpass
+  cadastral-properties:
+    provider: cadastre
+  bus-stops:
+    provider: gtfs
+    url: https://gtfs.sofiatraffic.bg/api/v1/static
+  educational-facilities:
+    provider: educational-facilities
+    schools-url: https://api.sofiaplan.bg/datasets/166
+    kindergartens-url: https://api.sofiaplan.bg/datasets/142


### PR DESCRIPTION
closes #387

Each locality now declares all 5 geocoding resolver providers in `localities/{locality}.yaml`. The app fails fast at startup if any resolver is absent or uses an unrecognised provider.

- Add `lib/locality-data-sources.ts`: Zod schema with discriminated unions per resolver type; throws on missing/invalid config
- Add `localities/bg.sofia.yaml`: full Sofia resolver config (google, overpass, cadastre, gtfs, educational-facilities)
- Refactor `geocoding/router.ts`: module-level provider dispatch maps replace hardcoded logic for all 5 location types
- Remove hardcoded URLs from `gtfs/service.ts` and `educational-facilities/service.ts`; read from resolver config
- Add early `getLocalityDataSources()` call in `ingest.ts` commands; `GOOGLE_MAPS_API_KEY` is now only required when a resolver actually uses the google provider
- Add full test coverage: `locality-data-sources.test.ts`, router dispatch tests, sync skip-behaviour tests

Addresses all review comments from #417.