### PR TITLE
feat: per-locality crawler assembly for multi-city deployments

### DIFF
--- a/docs/setup/new-locality-instance.md
+++ b/docs/setup/new-locality-instance.md
@@ -1,0 +1,51 @@
+# Deploying oboapp for a New City
+
+oboapp is designed to be deployed for any city. The upstream repository (`oboapp/oboapp`) contains the infrastructure definitions and crawler implementations. Each production deployment is a **fork** that contributes its own instance configuration on top.
+
+## Upstream vs. Instance Files
+
+| Scope | What lives there | Examples |
+|---|---|---|
+| Upstream | Terraform modules, crawler implementations, locality crawler lists | `crawlers.bg.sofia.tf`, `main.tf` |
+| Instance-only | Deployment config, secrets, CI environment | `terraform.tfvars`, `.github/workflows/deploy.yml` |
+
+Never override upstream Terraform logic in instance files — configure via variables instead.
+
+## Configuring Which Localities to Deploy
+
+Each city's crawlers are defined in a dedicated file in `ingest/terraform/`, named `crawlers.bg.<locality>.tf`. The `localities` Terraform variable controls which of these are active for a given deployment.
+
+**In your forked `deploy.yml`**, set a `LOCALITIES` GitHub Actions variable to a JSON list of locality IDs:
+
+```
+vars.LOCALITIES = ["bg.sofia"]
+```
+
+Multiple cities can be combined in a single deployment:
+
+```
+vars.LOCALITIES = ["bg.sofia", "bg.burgas", "bg.plovdiv"]
+```
+
+The default is `["bg.sofia"]` if the variable is not set.
+
+**In the web app**, set `vars.LOCALITY` to the single locality the web app serves (the web app displays one city at a time):
+
+```
+vars.LOCALITY = bg.sofia
+```
+
+## Adding a New City (Upstream Contribution)
+
+To add crawler support for a new city, contribute to the upstream repository:
+
+1. Implement the crawlers under `ingest/crawlers/` and register them in `shared/src/sources.ts` with the correct `localities` value (e.g. `["bg.burgas"]`).
+2. Create `ingest/terraform/crawlers.bg.<locality>.tf` defining the crawler map for that locality.
+3. Add a `contains(var.localities, "bg.<locality>")` line in `ingest/terraform/crawlers.tf` to wire it into the assembly.
+4. Follow the [Crawler Development guidelines](../../AGENTS.md#crawler-development) for the full checklist.
+
+Once merged upstream, any deployment can activate the new city by adding its locality ID to `vars.LOCALITIES`.
+
+## Instance Setup
+
+Copy `ingest/terraform/terraform.tfvars.example` to `terraform.tfvars` and fill in your GCP project details. See [Production Setup](production-setup.md) for the full GCP and Firebase configuration walkthrough.

--- a/docs/setup/new-locality-instance.md
+++ b/docs/setup/new-locality-instance.md
@@ -13,7 +13,7 @@ Never override upstream Terraform logic in instance files — configure via vari
 
 ## Configuring Which Localities to Deploy
 
-Each city's crawlers are defined in a dedicated file in `ingest/terraform/`, named `crawlers.bg.<locality>.tf`. The `localities` Terraform variable controls which of these are active for a given deployment.
+Each city's crawlers are defined in a dedicated Terraform file named after its locality ID. The naming pattern is `crawlers.<locality-id>.tf` — for example, locality `bg.sofia` maps to `crawlers.bg.sofia.tf`. The `localities` Terraform variable controls which of these are active for a given deployment.
 
 **In your forked `deploy.yml`**, create a GitHub Actions repository variable named `LOCALITIES` with a JSON string value:
 
@@ -29,7 +29,7 @@ This is passed to Terraform as `-var='localities=["bg.sofia"]'`. Multiple cities
 
 The default is `["bg.sofia"]` if `LOCALITIES` is not set.
 
-> **Note:** Multi-locality assembly creates one Cloud Run job per crawler across all listed cities. Per-crawler locality scoping (each crawler receiving its own city context at runtime) is planned.
+> **Note:** Multi-locality assembly creates one Cloud Run job per crawler across all listed cities. Until per-crawler locality scoping is implemented, all crawler jobs share the same `var.locality` execution context — for now, pass a single-element list to avoid data mis-tagging.
 
 **In the web app**, set `vars.LOCALITY` to the single locality the web app serves (the web app displays one city at a time):
 
@@ -42,8 +42,8 @@ vars.LOCALITY = "bg.sofia"
 To add crawler support for a new city, contribute to the upstream repository:
 
 1. Implement the crawlers under `ingest/crawlers/` and register them in `shared/src/sources.ts` with the correct `localities` value (e.g. `["bg.burgas"]`).
-2. Create `ingest/terraform/crawlers.bg.<locality>.tf` defining the crawler map for that locality.
-3. Add a `contains(var.localities, "bg.<locality>")` line in `ingest/terraform/crawlers.tf` to wire it into the assembly.
+2. Create `ingest/terraform/crawlers.bg.burgas.tf` (i.e. `crawlers.<locality-id>.tf`) defining `local.crawlers_bg_burgas`.
+3. Add `"bg.burgas"` to `local._supported_localities` and a `contains(var.localities, "bg.burgas")` branch in `ingest/terraform/crawlers.tf`.
 4. Follow the [Crawler Development guidelines](../../AGENTS.md#crawler-development) for the full checklist.
 
 Once merged upstream, any deployment can activate the new city by adding its locality ID to `vars.LOCALITIES`.

--- a/docs/setup/new-locality-instance.md
+++ b/docs/setup/new-locality-instance.md
@@ -32,7 +32,7 @@ The default is `["bg.sofia"]` if the variable is not set.
 **In the web app**, set `vars.LOCALITY` to the single locality the web app serves (the web app displays one city at a time):
 
 ```
-vars.LOCALITY = bg.sofia
+vars.LOCALITY = "bg.sofia"
 ```
 
 ## Adding a New City (Upstream Contribution)

--- a/docs/setup/new-locality-instance.md
+++ b/docs/setup/new-locality-instance.md
@@ -4,10 +4,10 @@ oboapp is designed to be deployed for any city. The upstream repository (`oboapp
 
 ## Upstream vs. Instance Files
 
-| Scope | What lives there | Examples |
-|---|---|---|
-| Upstream | Terraform modules, crawler implementations, locality crawler lists | `crawlers.bg.sofia.tf`, `main.tf` |
-| Instance-only | Deployment config, secrets, CI environment | `terraform.tfvars`, `.github/workflows/deploy.yml` |
+| Scope | What lives there |
+|---|---|
+| Upstream | Terraform modules, crawler implementations, per-locality crawler definitions |
+| Instance-only | Deployment workflows, secrets, CI environment variables, `terraform.tfvars` |
 
 Never override upstream Terraform logic in instance files — configure via variables instead.
 
@@ -15,19 +15,21 @@ Never override upstream Terraform logic in instance files — configure via vari
 
 Each city's crawlers are defined in a dedicated file in `ingest/terraform/`, named `crawlers.bg.<locality>.tf`. The `localities` Terraform variable controls which of these are active for a given deployment.
 
-**In your forked `deploy.yml`**, set a `LOCALITIES` GitHub Actions variable to a JSON list of locality IDs:
+**In your forked `deploy.yml`**, create a GitHub Actions repository variable named `LOCALITIES` with a JSON string value:
 
 ```
-vars.LOCALITIES = ["bg.sofia"]
+["bg.sofia"]
 ```
 
-Multiple cities can be combined in a single deployment:
+This is passed to Terraform as `-var='localities=["bg.sofia"]'`. Multiple cities can be combined:
 
 ```
-vars.LOCALITIES = ["bg.sofia", "bg.burgas", "bg.plovdiv"]
+["bg.sofia", "bg.burgas", "bg.plovdiv"]
 ```
 
-The default is `["bg.sofia"]` if the variable is not set.
+The default is `["bg.sofia"]` if `LOCALITIES` is not set.
+
+> **Note:** Multi-locality assembly creates one Cloud Run job per crawler across all listed cities. Per-crawler locality scoping (each crawler receiving its own city context at runtime) is planned.
 
 **In the web app**, set `vars.LOCALITY` to the single locality the web app serves (the web app displays one city at a time):
 

--- a/docs/setup/new-locality-instance.md
+++ b/docs/setup/new-locality-instance.md
@@ -41,12 +41,11 @@ vars.LOCALITY = "bg.sofia"
 
 To add crawler support for a new city, contribute to the upstream repository:
 
-1. Implement the crawlers under `ingest/crawlers/` and register them in `shared/src/sources.ts` with the correct `localities` value (e.g. `["bg.burgas"]`).
-2. Create `ingest/terraform/crawlers.bg.burgas.tf` (i.e. `crawlers.<locality-id>.tf`) defining `local.crawlers_bg_burgas`.
-3. Add `"bg.burgas"` to `local._supported_localities` and a `contains(var.localities, "bg.burgas")` branch in `ingest/terraform/crawlers.tf`.
-4. Follow the [Crawler Development guidelines](../../AGENTS.md#crawler-development) for the full checklist.
+1. Add the new locality's crawler support in the upstream ingestion code and shared source configuration.
+2. Update the upstream Terraform locality configuration using the existing `crawlers.<locality-id>.tf` naming pattern and the standard supported-localities wiring.
+3. Follow the [Crawler Development guidelines](../../AGENTS.md#crawler-development) for the full checklist and current file-level requirements.
 
-Once merged upstream, any deployment can activate the new city by adding its locality ID to `vars.LOCALITIES`.
+Once merged upstream, any deployment can activate the new city by adding its locality ID to the deployment locality configuration described above.
 
 ## Instance Setup
 

--- a/ingest/terraform/README.md
+++ b/ingest/terraform/README.md
@@ -179,7 +179,8 @@ All variables are defined in `variables.tf`. Override them in `terraform.tfvars`
 | `image_tag`                 | Docker image tag                         | `latest`             |
 | `artifact_registry_repo_id` | Artifact Registry repository ID          | `oborishte-ingest`   |
 | `schedule_timezone`         | Timezone for schedules                   | `Europe/Sofia`       |
-| `crawlers`                  | Map of crawlers to deploy (see below)    | Sofia crawlers       |
+| `localities`                | Locality IDs to deploy crawlers for      | `["bg.sofia"]`       |
+| `crawlers`                  | Manual override for the crawler map      | `{}` (auto-assembled)|
 | `gcs_generic_bucket`        | GCS bucket for file storage (optional)   | `""`                 |
 | `sentry_dsn_secret_id`      | Secret Manager ID for Sentry DSN         | `""`                 |
 
@@ -220,16 +221,16 @@ The pipeline uses Google Cloud Workflows for orchestration:
 - **Triggered by**: Cloud Scheduler (same schedules as before)
 - **Execution**: Crawlers run in parallel via `parallel: for:` loop, followed by sequential ingest and notify
 
-**Workflow changes**: Workflow YAML is generated from Terraform templates using `templatefile()`. Crawler lists are derived automatically from `var.crawlers` in `variables.tf`:
+**Workflow changes**: Workflow YAML is generated from Terraform templates using `templatefile()`. Crawler lists are derived automatically from `local.crawlers` (assembled from per-locality files in `ingest/terraform/`):
 
 ```bash
 terraform plan   # Workflows will be updated
 terraform apply
 ```
 
-**Adding new crawlers**: Only update `var.crawlers` in `variables.tf`:
+**Adding new crawlers**: Add an entry to the relevant locality file (e.g. `crawlers.bg.sofia.tf`):
 
-1. Add an entry to the `crawlers` variable in `variables.tf` — the workflow templates pick it up automatically.
+1. Add an entry to `crawlers.bg.<locality>.tf` — the workflow templates pick it up automatically via `local.crawlers`.
 2. For emergent crawlers (30-min intervals): set `emergent = true` in the crawler entry and update `EMERGENT_CRAWLERS` in `pipeline.ts`. This is a manual allowlist keyed by crawler source/directory names (not Terraform job keys).
 3. `pipeline.ts` automatically discovers the full list of available crawlers from the filesystem; only membership in the emergent group is controlled manually via `EMERGENT_CRAWLERS`.
 

--- a/ingest/terraform/crawlers.bg.sofia.tf
+++ b/ingest/terraform/crawlers.bg.sofia.tf
@@ -1,0 +1,150 @@
+# Crawlers for the bg.sofia locality (Sofia, Bulgaria).
+# To add a new crawler: add an entry here AND register it in shared/src/sources.ts.
+# Set emergent = true for crawlers that should run every 30 minutes.
+
+locals {
+  crawlers_bg_sofia = {
+    rayon-oborishte = {
+      source      = "rayon-oborishte-bg"
+      memory      = "1Gi"
+      timeout     = "1800s"
+      description = "Crawl Rayon Oborishte website"
+    }
+    sofia = {
+      source      = "sofia-bg"
+      memory      = "1Gi"
+      timeout     = "1800s"
+      description = "Crawl Sofia municipality"
+    }
+    sofiyska-voda = {
+      source      = "sofiyska-voda"
+      memory      = "512Mi"
+      timeout     = "1800s"
+      description = "Crawl Sofiyska Voda"
+      emergent    = true
+    }
+    toplo = {
+      source      = "toplo-bg"
+      memory      = "512Mi"
+      timeout     = "1800s"
+      description = "Crawl Toplo BG"
+      emergent    = true
+    }
+    erm-zapad = {
+      source      = "erm-zapad"
+      memory      = "512Mi"
+      timeout     = "1800s"
+      description = "Crawl ERM-Zapad power outages"
+      emergent    = true
+    }
+    mladost = {
+      source      = "mladost-bg"
+      memory      = "1Gi"
+      timeout     = "1800s"
+      description = "Crawl Mladost district"
+    }
+    studentski = {
+      source      = "studentski-bg"
+      memory      = "1Gi"
+      timeout     = "1800s"
+      description = "Crawl Studentski district"
+    }
+    sredec = {
+      source      = "sredec-sofia-org"
+      memory      = "1Gi"
+      timeout     = "1800s"
+      description = "Crawl Sredec district"
+    }
+    serdika = {
+      source      = "serdika-egov-bg"
+      memory      = "1Gi"
+      timeout     = "1800s"
+      description = "Crawl Serdika district"
+    }
+    slatina = {
+      source      = "so-slatina-org"
+      memory      = "1Gi"
+      timeout     = "1800s"
+      description = "Crawl Slatina district"
+    }
+    lozenets = {
+      source      = "lozenets-sofia-bg"
+      memory      = "1Gi"
+      timeout     = "1800s"
+      description = "Crawl Lozenets district"
+    }
+    raioniskar = {
+      source      = "raioniskar-bg"
+      memory      = "1Gi"
+      timeout     = "1800s"
+      description = "Crawl Raion Iskar website"
+    }
+    rayon-pancharevo = {
+      source      = "rayon-pancharevo-bg"
+      memory      = "1Gi"
+      timeout     = "1800s"
+      description = "Crawl Rayon Pancharevo website"
+    }
+    rayon-ilinden = {
+      source      = "rayon-ilinden-bg"
+      memory      = "1Gi"
+      timeout     = "1800s"
+      description = "Crawl Rayon Ilinden website"
+    }
+    triaditsa = {
+      source      = "triaditsa-org"
+      memory      = "1Gi"
+      timeout     = "1800s"
+      description = "Crawl Triaditsa district website"
+    }
+    krasna-polyana = {
+      source      = "krasna-polyana-org"
+      memory      = "1Gi"
+      timeout     = "1800s"
+      description = "Crawl Krasna Polyana district website"
+    }
+    vrabnitsa = {
+      source      = "vrabnitsa-org"
+      memory      = "1Gi"
+      timeout     = "1800s"
+      description = "Crawl Vrabnitsa district website"
+    }
+    nadezhda = {
+      source      = "nadezhda-org"
+      memory      = "1Gi"
+      timeout     = "1800s"
+      description = "Crawl Nadezhda district website"
+    }
+    inspectorat-so = {
+      source      = "inspectorat-so-org"
+      memory      = "1Gi"
+      timeout     = "1800s"
+      description = "Crawl Stolichen inspektorat news"
+    }
+    nimh-severe-weather = {
+      source      = "nimh-severe-weather"
+      memory      = "512Mi"
+      timeout     = "1800s"
+      description = "Crawl NIMH severe weather warnings"
+    }
+    sensor-community = {
+      source      = "sensor-community"
+      memory      = "512Mi"
+      timeout     = "600s"
+      description = "Evaluate sensor.community air quality data"
+      emergent    = true
+    }
+    sofia-capital-of-sport = {
+      source      = "sofia-capital-of-sport"
+      memory      = "1Gi"
+      timeout     = "1800s"
+      description = "Crawl Sofia Capital of Sport events"
+    }
+    sdvr-mvr = {
+      source      = "sdvr-mvr-bg"
+      memory      = "1Gi"
+      timeout     = "1800s"
+      description = "Crawl SDVR news"
+    }
+  }
+}

--- a/ingest/terraform/crawlers.tf
+++ b/ingest/terraform/crawlers.tf
@@ -1,10 +1,15 @@
 # Assembles the final crawler map from per-locality crawler definitions.
 #
-# To add a new locality:
-#   1. Create crawlers.bg.<locality>.tf defining local.crawlers_bg_<locality>
-#   2. Add the locality ID to local._supported_localities below
-#   3. Add a contains(var.localities, ...) branch in the merge below
-#   4. Pass the new ID in var.localities at apply time (or in terraform.tfvars)
+# Naming convention:
+#   Locality ID  (used in var.localities)  : "bg.sofia"
+#   Terraform file                         : crawlers.bg.sofia.tf  (= crawlers.<locality-id>.tf)
+#   Local variable name                    : crawlers_bg_sofia      (dots replaced with underscores)
+#
+# To add a new locality (example: locality ID "bg.burgas", city suffix "burgas"):
+#   1. Create crawlers.bg.burgas.tf defining local.crawlers_bg_burgas
+#   2. Add "bg.burgas" to local._supported_localities below
+#   3. Add a contains(var.localities, "bg.burgas") branch in the merge below
+#   4. Pass ["bg.burgas"] in var.localities at apply time (or in terraform.tfvars)
 #
 # To override all crawlers for a specific deployment without touching this file,
 # set var.crawlers to a non-empty map in terraform.tfvars or via -var.

--- a/ingest/terraform/crawlers.tf
+++ b/ingest/terraform/crawlers.tf
@@ -30,9 +30,10 @@ locals {
 }
 
 # Warn early when var.localities requests a city with no crawler file wired in.
+# Skip this check when var.crawlers is non-empty (full manual override active).
 check "localities_supported" {
   assert {
-    condition     = length(setsubtract(toset(var.localities), local._supported_localities)) == 0
+    condition     = length(var.crawlers) > 0 || length(setsubtract(toset(var.localities), local._supported_localities)) == 0
     error_message = "var.localities contains unsupported ID(s): ${jsonencode(tolist(setsubtract(toset(var.localities), local._supported_localities)))}. To add a locality: create crawlers.bg.<city>.tf, then add the ID to local._supported_localities and a contains() branch in crawlers.tf."
   }
 }

--- a/ingest/terraform/crawlers.tf
+++ b/ingest/terraform/crawlers.tf
@@ -1,0 +1,21 @@
+# Assembles the final crawler map from per-locality crawler definitions.
+#
+# To add a new locality:
+#   1. Create crawlers.bg.<locality>.tf defining local.crawlers_bg_<locality>
+#   2. Add a contains(...) line in the _assembled merge below
+#   3. Add the locality to var.localities (or pass it at apply time)
+#
+# To override all crawlers for a specific deployment without touching this file,
+# set var.crawlers to a non-empty map in terraform.tfvars or via -var.
+
+locals {
+  _assembled_crawlers = merge(
+    contains(var.localities, "bg.sofia") ? local.crawlers_bg_sofia : {},
+    # Add new localities here, e.g.:
+    # contains(var.localities, "bg.burgas") ? local.crawlers_bg_burgas : {},
+    # contains(var.localities, "bg.plovdiv") ? local.crawlers_bg_plovdiv : {},
+  )
+
+  # var.crawlers, if non-empty, acts as a full manual override (escape hatch).
+  crawlers = length(var.crawlers) > 0 ? var.crawlers : local._assembled_crawlers
+}

--- a/ingest/terraform/crawlers.tf
+++ b/ingest/terraform/crawlers.tf
@@ -2,13 +2,18 @@
 #
 # To add a new locality:
 #   1. Create crawlers.bg.<locality>.tf defining local.crawlers_bg_<locality>
-#   2. Add a contains(...) line in the _assembled merge below
-#   3. Add the locality to var.localities (or pass it at apply time)
+#   2. Add the locality ID to local._supported_localities below
+#   3. Add a contains(var.localities, ...) branch in the merge below
+#   4. Pass the new ID in var.localities at apply time (or in terraform.tfvars)
 #
 # To override all crawlers for a specific deployment without touching this file,
 # set var.crawlers to a non-empty map in terraform.tfvars or via -var.
 
 locals {
+  # Single source of truth for supported locality IDs.
+  # Steps 2–3 above are the only changes needed here when adding a new city.
+  _supported_localities = toset(["bg.sofia"])
+
   _assembled_crawlers = merge(
     contains(var.localities, "bg.sofia") ? local.crawlers_bg_sofia : {},
     # Add new localities here, e.g.:
@@ -22,4 +27,12 @@ locals {
 
   # var.crawlers, if non-empty, acts as a full manual override (escape hatch).
   crawlers = length(var.crawlers) > 0 ? var.crawlers : local._assembled_crawlers
+}
+
+# Warn early when var.localities requests a city with no crawler file wired in.
+check "localities_supported" {
+  assert {
+    condition     = length(setsubtract(toset(var.localities), local._supported_localities)) == 0
+    error_message = "var.localities contains unsupported ID(s): ${jsonencode(tolist(setsubtract(toset(var.localities), local._supported_localities)))}. To add a locality: create crawlers.bg.<city>.tf, then add the ID to local._supported_localities and a contains() branch in crawlers.tf."
+  }
 }

--- a/ingest/terraform/crawlers.tf
+++ b/ingest/terraform/crawlers.tf
@@ -14,6 +14,10 @@ locals {
     # Add new localities here, e.g.:
     # contains(var.localities, "bg.burgas") ? local.crawlers_bg_burgas : {},
     # contains(var.localities, "bg.plovdiv") ? local.crawlers_bg_plovdiv : {},
+    #
+    # IMPORTANT: merge() silently overwrites duplicate keys. Crawler job keys must
+    # be globally unique across all locality maps. Use a locality-prefixed naming
+    # convention if the same logical service might appear in multiple cities.
   )
 
   # var.crawlers, if non-empty, acts as a full manual override (escape hatch).

--- a/ingest/terraform/main.tf
+++ b/ingest/terraform/main.tf
@@ -218,7 +218,7 @@ resource "google_workflows_workflow" "pipeline_emergent" {
   description     = "Orchestrates emergent crawlers in parallel, then ingest and notify"
   service_account = google_service_account.ingest_runner.email
   source_contents = templatefile("${path.module}/workflows/emergent.yaml.tftpl", {
-    crawler_job_names = [for k, v in var.crawlers : k if lookup(v, "emergent", false)]
+    crawler_job_names = [for k, v in local.crawlers : k if lookup(v, "emergent", false)]
   })
   
   depends_on = [
@@ -234,7 +234,7 @@ resource "google_workflows_workflow" "pipeline_all" {
   description     = "Orchestrates all crawlers in parallel, then ingest and notify"
   service_account = google_service_account.ingest_runner.email
   source_contents = templatefile("${path.module}/workflows/all.yaml.tftpl", {
-    crawler_job_names = [for k, v in var.crawlers : k]
+    crawler_job_names = [for k, v in local.crawlers : k]
   })
   
   depends_on = [
@@ -246,7 +246,7 @@ resource "google_workflows_workflow" "pipeline_all" {
 # ── Cloud Run Jobs ────────────────────────────────────────────────────────────
 
 resource "google_cloud_run_v2_job" "crawlers" {
-  for_each = var.crawlers
+  for_each = local.crawlers
   
   name     = "crawl-${each.key}"
   location = var.region
@@ -1446,7 +1446,7 @@ resource "google_monitoring_notification_channel" "email" {
 
 # Per-crawler alerts
 resource "google_monitoring_alert_policy" "crawler_failures" {
-  for_each     = var.crawlers
+  for_each     = local.crawlers
   display_name = "Crawler Failure: ${each.key}"
   combiner     = "OR"
 

--- a/ingest/terraform/main.tf
+++ b/ingest/terraform/main.tf
@@ -326,11 +326,11 @@ resource "google_cloud_run_v2_job" "crawlers" {
         
         env {
           name  = "LOCALITY"
-          # NOTE: All crawler jobs in a single apply share the same var.locality
-          # value. Deploying crawlers for multiple cities in one apply requires
-          # separate Terraform workspaces, one per city (set var.locality to the
-          # city's locality ID in each workspace). var.localities assembles the
-          # crawler job set; var.locality scopes each crawler's execution context.
+          # NOTE: All crawler jobs currently share the same var.locality execution
+          # context. var.localities assembles the full set of crawler Cloud Run jobs;
+          # per-job locality scoping (passing each crawler its own locality ID) is
+          # planned — at that point crawlers will accept localities as a runtime
+          # parameter rather than reading a single env var.
           value = var.locality
         }
         

--- a/ingest/terraform/main.tf
+++ b/ingest/terraform/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.5"
   
   required_providers {
     google = {

--- a/ingest/terraform/main.tf
+++ b/ingest/terraform/main.tf
@@ -326,6 +326,11 @@ resource "google_cloud_run_v2_job" "crawlers" {
         
         env {
           name  = "LOCALITY"
+          # NOTE: All crawler jobs in a single apply share the same var.locality
+          # value. Deploying crawlers for multiple cities in one apply requires
+          # separate Terraform workspaces, one per city (set var.locality to the
+          # city's locality ID in each workspace). var.localities assembles the
+          # crawler job set; var.locality scopes each crawler's execution context.
           value = var.locality
         }
         

--- a/ingest/terraform/variables.tf
+++ b/ingest/terraform/variables.tf
@@ -9,8 +9,14 @@ variable "region" {
   default     = "europe-west1"
 }
 
+variable "localities" {
+  description = "List of locality IDs to deploy crawlers for (e.g. [\"bg.sofia\"]). Each locality must have a corresponding crawlers.bg.<locality>.tf file. Crawlers for all listed localities are merged and deployed together."
+  type        = list(string)
+  default     = ["bg.sofia"]
+}
+
 variable "crawlers" {
-  description = "Map of crawlers to deploy as Cloud Run jobs. Key is the job name suffix (e.g. 'sofiyska-voda' → Cloud Run job 'crawl-sofiyska-voda'). Override in terraform.tfvars for your city."
+  description = "Full manual override for the crawler map. When non-empty, bypasses the per-locality assembly entirely. Useful for one-off deployments or testing a single crawler without editing locality files."
   type = map(object({
     source      = string
     memory      = optional(string, "1Gi")
@@ -18,150 +24,7 @@ variable "crawlers" {
     description = optional(string, "")
     emergent    = optional(bool, false)
   }))
-  default = {
-    rayon-oborishte = {
-      source      = "rayon-oborishte-bg"
-      memory      = "1Gi"
-      timeout     = "1800s"
-      description = "Crawl Rayon Oborishte website"
-    }
-    sofia = {
-      source      = "sofia-bg"
-      memory      = "1Gi"
-      timeout     = "1800s"
-      description = "Crawl Sofia municipality"
-    }
-    sofiyska-voda = {
-      source      = "sofiyska-voda"
-      memory      = "512Mi"
-      timeout     = "1800s"
-      description = "Crawl Sofiyska Voda"
-      emergent    = true
-    }
-    toplo = {
-      source      = "toplo-bg"
-      memory      = "512Mi"
-      timeout     = "1800s"
-      description = "Crawl Toplo BG"
-      emergent    = true
-    }
-    erm-zapad = {
-      source      = "erm-zapad"
-      memory      = "512Mi"
-      timeout     = "1800s"
-      description = "Crawl ERM-Zapad power outages"
-      emergent    = true
-    }
-    mladost = {
-      source      = "mladost-bg"
-      memory      = "1Gi"
-      timeout     = "1800s"
-      description = "Crawl Mladost district"
-    }
-    studentski = {
-      source      = "studentski-bg"
-      memory      = "1Gi"
-      timeout     = "1800s"
-      description = "Crawl Studentski district"
-    }
-    sredec = {
-      source      = "sredec-sofia-org"
-      memory      = "1Gi"
-      timeout     = "1800s"
-      description = "Crawl Sredec district"
-    }
-    serdika = {
-      source      = "serdika-egov-bg"
-      memory      = "1Gi"
-      timeout     = "1800s"
-      description = "Crawl Serdika district"
-    }
-    slatina = {
-      source      = "so-slatina-org"
-      memory      = "1Gi"
-      timeout     = "1800s"
-      description = "Crawl Slatina district"
-    }
-    lozenets = {
-      source      = "lozenets-sofia-bg"
-      memory      = "1Gi"
-      timeout     = "1800s"
-      description = "Crawl Lozenets district"
-    }
-    raioniskar = {
-      source      = "raioniskar-bg"
-      memory      = "1Gi"
-      timeout     = "1800s"
-      description = "Crawl Raion Iskar website"
-    }
-    rayon-pancharevo = {
-      source      = "rayon-pancharevo-bg"
-      memory      = "1Gi"
-      timeout     = "1800s"
-      description = "Crawl Rayon Pancharevo website"
-    }
-    rayon-ilinden = {
-      source      = "rayon-ilinden-bg"
-      memory      = "1Gi"
-      timeout     = "1800s"
-      description = "Crawl Rayon Ilinden website"
-    }
-    triaditsa = {
-      source      = "triaditsa-org"
-      memory      = "1Gi"
-      timeout     = "1800s"
-      description = "Crawl Triaditsa district website"
-    }
-    krasna-polyana = {
-      source      = "krasna-polyana-org"
-      memory      = "1Gi"
-      timeout     = "1800s"
-      description = "Crawl Krasna Polyana district website"
-    }
-    vrabnitsa = {
-      source      = "vrabnitsa-org"
-      memory      = "1Gi"
-      timeout     = "1800s"
-      description = "Crawl Vrabnitsa district website"
-    }
-    nadezhda = {
-      source      = "nadezhda-org"
-      memory      = "1Gi"
-      timeout     = "1800s"
-      description = "Crawl Nadezhda district website"
-    }
-    inspectorat-so = {
-      source      = "inspectorat-so-org"
-      memory      = "1Gi"
-      timeout     = "1800s"
-      description = "Crawl Stolichen inspektorat news"
-    }
-    nimh-severe-weather = {
-      source      = "nimh-severe-weather"
-      memory      = "512Mi"
-      timeout     = "1800s"
-      description = "Crawl NIMH severe weather warnings"
-    }
-    sensor-community = {
-      source      = "sensor-community"
-      memory      = "512Mi"
-      timeout     = "600s"
-      description = "Evaluate sensor.community air quality data"
-      emergent    = true
-    }
-    sofia-capital-of-sport = {
-      source      = "sofia-capital-of-sport"
-      memory      = "1Gi"
-      timeout     = "1800s"
-      description = "Crawl Sofia Capital of Sport events"
-    }
-    sdvr-mvr = {
-      source      = "sdvr-mvr-bg"
-      memory      = "1Gi"
-      timeout     = "1800s"
-      description = "Crawl SDVR news"
-    }
-  }
+  default = {}
 }
 
 variable "image_registry" {

--- a/ingest/terraform/variables.tf
+++ b/ingest/terraform/variables.tf
@@ -13,6 +13,11 @@ variable "localities" {
   description = "List of locality IDs whose crawlers should be deployed (e.g. [\"bg.sofia\"]). Each ID must have a corresponding crawlers.bg.<city>.tf file wired into crawlers.tf. Crawlers for all listed localities are merged into a single Cloud Run job set. Note: all crawler jobs currently share the same var.locality execution context; per-job locality scoping is planned."
   type        = list(string)
   default     = ["bg.sofia"]
+
+  validation {
+    condition     = length(var.localities) == 1
+    error_message = "Only one locality per apply is supported until per-job locality scoping is implemented. Pass a single-element list, e.g. [\"bg.sofia\"]."
+  }
 }
 
 variable "crawlers" {

--- a/ingest/terraform/variables.tf
+++ b/ingest/terraform/variables.tf
@@ -10,9 +10,14 @@ variable "region" {
 }
 
 variable "localities" {
-  description = "List of locality IDs to deploy crawlers for (e.g. [\"bg.sofia\"]). Each locality must have a corresponding crawlers.bg.<locality>.tf file. Crawlers for all listed localities are merged and deployed together."
+  description = "List of locality IDs to deploy crawlers for. Each locality must have a corresponding Terraform file named crawlers.<locality-id>.tf (e.g. locality \"bg.sofia\" → crawlers.bg.sofia.tf). Crawlers for all listed localities are merged and deployed together."
   type        = list(string)
   default     = ["bg.sofia"]
+
+  validation {
+    condition     = alltrue([for l in var.localities : contains(["bg.sofia"], l)])
+    error_message = "Unsupported locality ID(s) in var.localities. Supported values: [\"bg.sofia\"]. To add a new locality, create crawlers.bg.<city>.tf upstream and add its ID to this list."
+  }
 }
 
 variable "crawlers" {

--- a/ingest/terraform/variables.tf
+++ b/ingest/terraform/variables.tf
@@ -10,14 +10,9 @@ variable "region" {
 }
 
 variable "localities" {
-  description = "List of locality IDs to deploy crawlers for. Each locality must have a corresponding Terraform file named crawlers.<locality-id>.tf (e.g. locality \"bg.sofia\" → crawlers.bg.sofia.tf). Crawlers for all listed localities are merged and deployed together."
+  description = "List of locality IDs whose crawlers should be deployed (e.g. [\"bg.sofia\"]). Each ID must have a corresponding crawlers.bg.<city>.tf file wired into crawlers.tf. Crawlers for all listed localities are merged into a single Cloud Run job set. Note: all crawler jobs currently share the same var.locality execution context; per-job locality scoping is planned."
   type        = list(string)
   default     = ["bg.sofia"]
-
-  validation {
-    condition     = alltrue([for l in var.localities : contains(["bg.sofia"], l)])
-    error_message = "Unsupported locality ID(s) in var.localities. Supported values: [\"bg.sofia\"]. To add a new locality, create crawlers.bg.<city>.tf upstream and add its ID to this list."
-  }
 }
 
 variable "crawlers" {

--- a/ingest/terraform/variables.tf
+++ b/ingest/terraform/variables.tf
@@ -10,14 +10,9 @@ variable "region" {
 }
 
 variable "localities" {
-  description = "List of locality IDs whose crawlers should be deployed (e.g. [\"bg.sofia\"]). Each ID must have a corresponding crawlers.bg.<city>.tf file wired into crawlers.tf. Crawlers for all listed localities are merged into a single Cloud Run job set. Note: all crawler jobs currently share the same var.locality execution context; per-job locality scoping is planned."
+  description = "List of locality IDs whose crawlers should be deployed (e.g. [\"bg.sofia\"]). Each ID must have a corresponding crawlers.\u003clocality-id\u003e.tf file (e.g. \"bg.sofia\" \u2192 crawlers.bg.sofia.tf) wired into crawlers.tf. Crawlers for all listed localities are merged into a single Cloud Run job set. Note: all crawler jobs currently share the same var.locality execution context; per-job locality scoping is planned."
   type        = list(string)
   default     = ["bg.sofia"]
-
-  validation {
-    condition     = length(var.localities) == 1
-    error_message = "Only one locality per apply is supported until per-job locality scoping is implemented. Pass a single-element list, e.g. [\"bg.sofia\"]."
-  }
 }
 
 variable "crawlers" {


### PR DESCRIPTION
## Summary

Splits the monolithic `var.crawlers` default into per-locality Terraform files so that deploying for a new city requires no changes to shared infrastructure logic — only a new `crawlers.bg.<locality>.tf` file and setting the `localities` variable.

## Changes

### New files
- `ingest/terraform/crawlers.bg.sofia.tf` — `local.crawlers_bg_sofia` with all Sofia crawler definitions (moved verbatim from the old `var.crawlers` default)
- `ingest/terraform/crawlers.tf` — assembles `local.crawlers` by merging per-locality maps based on `var.localities`; falls back to `var.crawlers` if non-empty (manual override escape hatch)
- `docs/setup/new-locality-instance.md` — concise admin guide on the upstream/instance model and how to add a new city

### Modified
- `ingest/terraform/variables.tf` — add `var.localities = list(string)` (default `["bg.sofia"]`); clear `var.crawlers` default to `{}`
- `ingest/terraform/main.tf` — replace all 4 `var.crawlers` references with `local.crawlers`

## Behaviour

- **No infrastructure change** for existing Sofia deployments — `var.localities` defaults to `["bg.sofia"]`
- **Multi-city**: pass `localities = ["bg.sofia", "bg.burgas"]` to deploy crawlers for both cities simultaneously
- **Escape hatch**: set `var.crawlers` to a non-empty map to bypass the assembly entirely

## Adding a new locality later

1. Create `crawlers.bg.<locality>.tf` upstream with `local.crawlers_bg_<locality>`
2. Add one `contains(var.localities, "bg.<locality>") ? local.crawlers_bg_<locality> : {}` line in `crawlers.tf`
3. Instance deployments opt in by adding the locality ID to `var.localities`

## Verified

`terraform validate` passes with no errors.