### PR TITLE
feat(geocoding): per-feature geometry quality from provider signals

### DIFF
--- a/api/src/lib/typed-arrays.ts
+++ b/api/src/lib/typed-arrays.ts
@@ -56,5 +56,15 @@ export function getFeatureCollection(
   value: unknown,
 ): GeoJsonFeatureCollection | undefined {
   const result = GeoJsonFeatureCollectionSchema.safeParse(value);
-  return result.success ? result.data : undefined;
+  if (!result.success) return undefined;
+  // Strip internal geocoding signals from GeoJSON feature properties
+  // so they don't leak into the public v1 API response.
+  return {
+    ...result.data,
+    features: result.data.features.map((feature) => {
+      const { qualitySignals: _qs, qualityProvider: _qp, ...publicProperties } =
+        feature.properties;
+      return { ...feature, properties: publicProperties };
+    }),
+  };
 }

--- a/api/src/lib/typed-arrays.ts
+++ b/api/src/lib/typed-arrays.ts
@@ -67,7 +67,7 @@ export function getFeatureCollection(
         qualityProvider: _qp,
         geometryQuality: _gq,
         ...publicProperties
-      } = feature.properties;
+      } = feature.properties ?? {};
       return { ...feature, properties: publicProperties };
     }),
   };

--- a/api/src/lib/typed-arrays.ts
+++ b/api/src/lib/typed-arrays.ts
@@ -62,8 +62,12 @@ export function getFeatureCollection(
   return {
     ...result.data,
     features: result.data.features.map((feature) => {
-      const { qualitySignals: _qs, qualityProvider: _qp, ...publicProperties } =
-        feature.properties;
+      const {
+        qualitySignals: _qs,
+        qualityProvider: _qp,
+        geometryQuality: _gq,
+        ...publicProperties
+      } = feature.properties;
       return { ...feature, properties: publicProperties };
     }),
   };

--- a/docs/features/event-aggregation.md
+++ b/docs/features/event-aggregation.md
@@ -66,7 +66,7 @@ When a candidate scores between 0.55 and 0.70, the score alone isn't confident e
 
 Geometry quality (0–3) reflects how reliable the location data is:
 
-- **3 (Authoritative)** — Official GeoJSON (precomputed by trusted sources like utility companies), authoritative cadastral polygons, Google ROOFTOP, GTFS stops, or educational facility coordinates
+- **3 (Authoritative)** — Official GeoJSON (precomputed by trusted sources like utility companies), authoritative cadastral polygons, Google ROOFTOP (without partial match), GTFS stops, or educational facility coordinates
 - **2 (Address-level)** — Good address-level geocoding (e.g., Google RANGE_INTERPOLATED / GEOMETRIC_CENTER); street closures with real Overpass way geometry and address-level endpoints also reach this tier
 - **1 (Approximate)** — Approximate or intersection-level geocoding, Overpass node, fallback coordinates from other sources
 - **0 (None)** — No geometry available (city-wide incidents, incomplete addresses)

--- a/docs/features/event-aggregation.md
+++ b/docs/features/event-aggregation.md
@@ -67,7 +67,7 @@ When a candidate scores between 0.55 and 0.70, the score alone isn't confident e
 Geometry quality (0–3) reflects how reliable the location data is:
 
 - **3 (Authoritative)** — Official GeoJSON (precomputed by trusted sources like utility companies), authoritative cadastral polygons, Google ROOFTOP, GTFS stops, or educational facility coordinates
-- **2 (Address-level)** — Good address-level geocoding (e.g., Google RANGE_INTERPOLATED / GEOMETRIC_CENTER, or Overpass way geometry)
+- **2 (Address-level)** — Good address-level geocoding (e.g., Google RANGE_INTERPOLATED / GEOMETRIC_CENTER); street closures with real Overpass way geometry and address-level endpoints also reach this tier
 - **1 (Approximate)** — Approximate or intersection-level geocoding, Overpass node, fallback coordinates from other sources
 - **0 (None)** — No geometry available (city-wide incidents, incomplete addresses)
 

--- a/docs/features/event-aggregation.md
+++ b/docs/features/event-aggregation.md
@@ -71,13 +71,13 @@ Geometry quality (0–3) reflects how reliable the location data is:
 - **1 (Approximate)** — Approximate or intersection-level geocoding, Overpass node, fallback coordinates from other sources
 - **0 (None)** — No geometry available (city-wide incidents, incomplete addresses)
 
-Quality is derived from **actual provider signals** in the geocoded geometry — not from source reputation alone. For example, two messages from the same source may have different quality scores depending on their geocoding precision.
+For geocoded geometry, quality is derived from **actual provider signals** — not from source reputation alone. For example, two messages from the same source may have different quality scores depending on their geocoding precision. Precomputed sources (those providing their own GeoJSON) are an exception: since no geocoding is performed, quality is derived from source trust instead (see _Source Trust_ below).
 
 When a message contains multiple location features (pins, streets, cadastral shapes), the lowest quality among them is used. This conservative approach ensures the event quality reflects its least-certain geometry element.
 
 ## Source Trust
 
-Source trust (per-source configuration, 0–1) measures how reliable a source's metadata is — used for embedding selection and deduplication, independent of geometry quality.
+Source trust (per-source configuration, 0–1) measures how reliable a source's metadata is — used for embedding selection and deduplication. For geocoded sources trust does not affect geometry quality; quality is determined by geocoding precision alone. For precomputed sources (those supplying their own GeoJSON), trust is used to derive geometry quality since no geocoding signals are available.
 
 Precomputed sources (those providing their own GeoJSON) skip geocoding. During ingest each feature is annotated with a geometry quality derived from the source's trust score: authoritative official sources (trust ≥ 0.9) receive quality 3; lower-trust precomputed sources such as sensor networks receive quality 2. Features that already carry a `geometryQuality` property (e.g., from a crawler that grades its own geometry) keep their existing value. Other sources are geocoded, and their final quality depends on geocoding precision, not source reputation.
 

--- a/docs/features/event-aggregation.md
+++ b/docs/features/event-aggregation.md
@@ -62,9 +62,24 @@ When a candidate scores between 0.55 and 0.70, the score alone isn't confident e
 - **Conservative fallback**: if the LLM call fails or returns invalid data, the match is rejected (new event created). This avoids incorrectly merging unrelated incidents.
 - **Cost**: only ~5–15% of messages fall in the uncertain zone, so LLM verify calls are infrequent
 
+## Geometry Quality
+
+Geometry quality (0–3) reflects how reliable the location data is:
+
+- **3 (Authoritative)** — Official GeoJSON (precomputed by trusted sources like utility companies), authoritative cadastral polygons, Google ROOFTOP, GTFS stops, or educational facility coordinates
+- **2 (Address-level)** — Good address-level geocoding (e.g., Google RANGE_INTERPOLATED / GEOMETRIC_CENTER, or Overpass way geometry)
+- **1 (Approximate)** — Approximate or intersection-level geocoding, Overpass node, fallback coordinates from other sources
+- **0 (None)** — No geometry available (city-wide incidents, incomplete addresses)
+
+Quality is derived from **actual provider signals** in the geocoded geometry — not from source reputation alone. For example, two messages from the same source may have different quality scores depending on their geocoding precision.
+
+When a message contains multiple location features (pins, streets, cadastral shapes), the lowest quality among them is used. This conservative approach ensures the event quality reflects its least-certain geometry element.
+
 ## Source Trust
 
-Higher-trust sources (e.g., utility companies with official GeoJSON) produce higher-quality geometry. When a more trusted source reports the same incident, its geometry replaces the existing one.
+Source trust (per-source configuration, 0–1) measures how reliable a source's metadata is — used for embedding selection and deduplication, independent of geometry quality.
+
+Precomputed sources (those providing their own GeoJSON) skip geocoding. During ingest each feature is annotated with a geometry quality derived from the source's trust score: authoritative official sources (trust ≥ 0.9) receive quality 3; lower-trust precomputed sources such as sensor networks receive quality 2. Features that already carry a `geometryQuality` property (e.g., from a crawler that grades its own geometry) keep their existing value. Other sources are geocoded, and their final quality depends on geocoding precision, not source reputation.
 
 ## Migration
 

--- a/ingest/__mocks__/services/google-geocoding-mock-service.ts
+++ b/ingest/__mocks__/services/google-geocoding-mock-service.ts
@@ -1,5 +1,7 @@
 import { readFileSync } from "node:fs";
 import type { Address } from "@/lib/types";
+import { gradeGoogle } from "@/geocoding/shared/quality";
+import { GOOGLE_LOCATION_TYPES } from "@/geocoding/shared/google-location-types";
 
 export class GoogleGeocodingMockService {
   private customFixturePath: string | null = null;
@@ -17,8 +19,10 @@ export class GoogleGeocodingMockService {
     // Simulate delay
     await new Promise((resolve) => setTimeout(resolve, 50));
 
-    // Return minimal mock data - Sofia center coordinates
+    // Return minimal mock data - Sofia center coordinates with ROOFTOP quality
     // Developers can add real fixtures over time
+    const qualitySignals = gradeGoogle(GOOGLE_LOCATION_TYPES.ROOFTOP, false);
+
     return {
       originalText: address,
       formattedAddress: "Sofia, Bulgaria",
@@ -26,6 +30,7 @@ export class GoogleGeocodingMockService {
         lat: 42.6977,
         lng: 23.3219,
       },
+      qualitySignals,
     };
   }
 

--- a/ingest/__mocks__/services/overpass-mock-service.ts
+++ b/ingest/__mocks__/services/overpass-mock-service.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import type { Address, Coordinates } from "@/lib/types";
 import type { Position } from "geojson";
+import { gradeOverpass } from "@/geocoding/shared/quality";
 
 export class OverpassMockService {
   private customFixturePath: string | null = null;
@@ -14,7 +15,13 @@ export class OverpassMockService {
   ): Promise<Address[]> {
     // Use custom fixture if specified
     if (this.customFixturePath) {
-      return JSON.parse(readFileSync(this.customFixturePath, "utf-8"));
+      const data = JSON.parse(readFileSync(this.customFixturePath, "utf-8"));
+      if (!Array.isArray(data)) return [];
+      // Ensure qualitySignals are present
+      return data.map((addr: Address) => ({
+        ...addr,
+        qualitySignals: addr.qualitySignals || gradeOverpass("node"),
+      }));
     }
 
     // Simulate delay
@@ -46,7 +53,13 @@ export class OverpassMockService {
   async overpassGeocodeAddresses(addresses: string[]): Promise<Address[]> {
     // Use custom fixture if specified
     if (this.customFixturePath) {
-      return JSON.parse(readFileSync(this.customFixturePath, "utf-8"));
+      const data = JSON.parse(readFileSync(this.customFixturePath, "utf-8"));
+      if (!Array.isArray(data)) return [];
+      // Ensure qualitySignals are present
+      return data.map((addr: Address) => ({
+        ...addr,
+        qualitySignals: addr.qualitySignals || gradeOverpass("node"),
+      }));
     }
 
     // Simulate delay

--- a/ingest/__mocks__/services/overpass-mock-service.ts
+++ b/ingest/__mocks__/services/overpass-mock-service.ts
@@ -16,7 +16,10 @@ export class OverpassMockService {
     // Use custom fixture if specified
     if (this.customFixturePath) {
       const data = JSON.parse(readFileSync(this.customFixturePath, "utf-8"));
-      if (!Array.isArray(data)) return [];
+      if (!Array.isArray(data))
+        throw new Error(
+          `OVERPASS_FIXTURE_PATH fixture must be a JSON array, got ${typeof data}: ${this.customFixturePath}`,
+        );
       // Ensure qualitySignals are present
       return data.map((addr: Address) => ({
         ...addr,
@@ -54,7 +57,10 @@ export class OverpassMockService {
     // Use custom fixture if specified
     if (this.customFixturePath) {
       const data = JSON.parse(readFileSync(this.customFixturePath, "utf-8"));
-      if (!Array.isArray(data)) return [];
+      if (!Array.isArray(data))
+        throw new Error(
+          `OVERPASS_FIXTURE_PATH fixture must be a JSON array, got ${typeof data}: ${this.customFixturePath}`,
+        );
       // Ensure qualitySignals are present
       return data.map((addr: Address) => ({
         ...addr,

--- a/ingest/event-matching/attach-to-event.test.ts
+++ b/ingest/event-matching/attach-to-event.test.ts
@@ -3,9 +3,9 @@ import { attachMessageToEvent } from "./attach-to-event";
 
 vi.mock("@/lib/source-trust", () => ({
   getSourceTrust: vi.fn((source: string) => {
-    if (source === "toplo-bg") return { trust: 1.0, precomputed: true };
-    if (source === "sofia-bg") return { trust: 0.8, precomputed: false };
-    return { trust: 0.5, precomputed: false };
+    if (source === "toplo-bg") return { trust: 1.0 };
+    if (source === "sofia-bg") return { trust: 0.8 };
+    return { trust: 0.5 };
   }),
 }));
 

--- a/ingest/event-matching/attach-to-event.test.ts
+++ b/ingest/event-matching/attach-to-event.test.ts
@@ -25,7 +25,12 @@ const mockDb = {
   events: { updateOne: mockUpdateEvent, findById: mockFindEventById },
 } as any;
 
-const baseSignals = { locationSimilarity: 0.9, timeOverlap: 0.8, categoryMatch: 1.0, textSimilarity: 0 };
+const baseSignals = {
+  locationSimilarity: 0.9,
+  timeOverlap: 0.8,
+  categoryMatch: 1.0,
+  textSimilarity: 0,
+};
 
 describe("attachMessageToEvent", () => {
   beforeEach(() => {
@@ -43,7 +48,12 @@ describe("attachMessageToEvent", () => {
     await attachMessageToEvent(
       mockDb,
       { _id: "msg-2", source: "sofia-bg" },
-      { _id: "evt-1", geometryQuality: 3, sources: ["toplo-bg"], messageCount: 1 },
+      {
+        _id: "evt-1",
+        geometryQuality: 3,
+        sources: ["toplo-bg"],
+        messageCount: 1,
+      },
       0.85,
       baseSignals,
     );
@@ -55,12 +65,20 @@ describe("attachMessageToEvent", () => {
   it("repairs event doc when link already exists for the same event", async () => {
     mockFindByMessageId.mockResolvedValueOnce([{ eventId: "evt-1" }]);
     // Simulate 2 links already in the collection
-    mockFindByEventId.mockResolvedValueOnce([{ messageId: "msg-1" }, { messageId: "msg-2" }]);
+    mockFindByEventId.mockResolvedValueOnce([
+      { messageId: "msg-1" },
+      { messageId: "msg-2" },
+    ]);
 
     await attachMessageToEvent(
       mockDb,
       { _id: "msg-2", source: "sofia-bg" },
-      { _id: "evt-1", geometryQuality: 3, sources: ["toplo-bg"], messageCount: 1 },
+      {
+        _id: "evt-1",
+        geometryQuality: 3,
+        sources: ["toplo-bg"],
+        messageCount: 1,
+      },
       0.85,
       baseSignals,
     );
@@ -78,7 +96,12 @@ describe("attachMessageToEvent", () => {
     await attachMessageToEvent(
       mockDb,
       { _id: "msg-2", source: "sofia-bg" },
-      { _id: "evt-1", geometryQuality: 3, sources: ["toplo-bg"], messageCount: 1 },
+      {
+        _id: "evt-1",
+        geometryQuality: 3,
+        sources: ["toplo-bg"],
+        messageCount: 1,
+      },
       0.85,
       baseSignals,
     );
@@ -101,7 +124,12 @@ describe("attachMessageToEvent", () => {
     await attachMessageToEvent(
       mockDb,
       { _id: "msg-2", source: "sofia-bg" },
-      { _id: "evt-1", geometryQuality: 3, sources: ["toplo-bg"], messageCount: 1 },
+      {
+        _id: "evt-1",
+        geometryQuality: 3,
+        sources: ["toplo-bg"],
+        messageCount: 1,
+      },
       0.85,
       baseSignals,
     );
@@ -117,7 +145,12 @@ describe("attachMessageToEvent", () => {
     await attachMessageToEvent(
       mockDb,
       { _id: "msg-2", source: "sofia-bg" },
-      { _id: "evt-1", geometryQuality: 3, sources: ["toplo-bg"], messageCount: 1 },
+      {
+        _id: "evt-1",
+        geometryQuality: 3,
+        sources: ["toplo-bg"],
+        messageCount: 1,
+      },
       0.85,
       baseSignals,
     );
@@ -133,7 +166,7 @@ describe("attachMessageToEvent", () => {
         _id: "msg-2",
         source: "sofia-bg",
         timespanStart: "2025-03-01T06:00:00Z", // earlier
-        timespanEnd: "2025-03-01T20:00:00Z",   // later
+        timespanEnd: "2025-03-01T20:00:00Z", // later
       },
       {
         _id: "evt-1",
@@ -159,7 +192,7 @@ describe("attachMessageToEvent", () => {
         _id: "msg-2",
         source: "sofia-bg",
         timespanStart: "2025-03-01T10:00:00Z", // later start
-        timespanEnd: "2025-03-01T16:00:00Z",   // earlier end
+        timespanEnd: "2025-03-01T16:00:00Z", // earlier end
       },
       {
         _id: "evt-1",
@@ -175,17 +208,37 @@ describe("attachMessageToEvent", () => {
 
     const update = mockUpdateEvent.mock.calls[0][1];
     expect(update.$set.timespanStart).toBeUndefined(); // not updated
-    expect(update.$set.timespanEnd).toBeUndefined();   // not updated
+    expect(update.$set.timespanEnd).toBeUndefined(); // not updated
   });
 
   it("upgrades geometry when new quality > existing (with fresh read)", async () => {
-    const newGeoJson = { type: "FeatureCollection" as const, features: [{ type: "Feature" as const, geometry: { type: "Point" as const, coordinates: [23.3, 42.7] as [number, number] }, properties: { geometryQuality: 3 } as Record<string, unknown> }] };
-    mockFindEventById.mockResolvedValueOnce({ _id: "evt-1", geometryQuality: 2 });
+    const newGeoJson = {
+      type: "FeatureCollection" as const,
+      features: [
+        {
+          type: "Feature" as const,
+          geometry: {
+            type: "Point" as const,
+            coordinates: [23.3, 42.7] as [number, number],
+          },
+          properties: { geometryQuality: 3 } as Record<string, unknown>,
+        },
+      ],
+    };
+    mockFindEventById.mockResolvedValueOnce({
+      _id: "evt-1",
+      geometryQuality: 2,
+    });
 
     await attachMessageToEvent(
       mockDb,
       { _id: "msg-2", source: "toplo-bg", geoJson: newGeoJson },
-      { _id: "evt-1", geometryQuality: 2, sources: ["sofia-bg"], messageCount: 1 },
+      {
+        _id: "evt-1",
+        geometryQuality: 2,
+        sources: ["sofia-bg"],
+        messageCount: 1,
+      },
       0.85,
       baseSignals,
     );
@@ -205,7 +258,12 @@ describe("attachMessageToEvent", () => {
     await attachMessageToEvent(
       mockDb,
       { _id: "msg-2", source: "sofia-bg", geoJson: newGeoJson },
-      { _id: "evt-1", geometryQuality: 3, sources: ["toplo-bg"], messageCount: 1 },
+      {
+        _id: "evt-1",
+        geometryQuality: 3,
+        sources: ["toplo-bg"],
+        messageCount: 1,
+      },
       0.85,
       baseSignals,
     );
@@ -221,7 +279,12 @@ describe("attachMessageToEvent", () => {
     await attachMessageToEvent(
       mockDb,
       { _id: "msg-2", source: "sofia-bg" },
-      { _id: "evt-1", geometryQuality: 3, sources: ["toplo-bg"], messageCount: 1 },
+      {
+        _id: "evt-1",
+        geometryQuality: 3,
+        sources: ["toplo-bg"],
+        messageCount: 1,
+      },
       0.85,
       baseSignals,
     );

--- a/ingest/event-matching/attach-to-event.test.ts
+++ b/ingest/event-matching/attach-to-event.test.ts
@@ -3,15 +3,9 @@ import { attachMessageToEvent } from "./attach-to-event";
 
 vi.mock("@/lib/source-trust", () => ({
   getSourceTrust: vi.fn((source: string) => {
-    if (source === "toplo-bg") return { trust: 1.0, geometryQuality: 3 };
-    if (source === "sofia-bg") return { trust: 0.8, geometryQuality: 2 };
-    return { trust: 0.5, geometryQuality: 0 };
-  }),
-  getGeometryQuality: vi.fn((source: string, hasPrecomputed: boolean) => {
-    if (hasPrecomputed) return 3;
-    if (source === "toplo-bg") return 3;
-    if (source === "sofia-bg") return 2;
-    return 0;
+    if (source === "toplo-bg") return { trust: 1.0, precomputed: true };
+    if (source === "sofia-bg") return { trust: 0.8, precomputed: false };
+    return { trust: 0.5, precomputed: false };
   }),
 }));
 
@@ -185,7 +179,7 @@ describe("attachMessageToEvent", () => {
   });
 
   it("upgrades geometry when new quality > existing (with fresh read)", async () => {
-    const newGeoJson = { type: "FeatureCollection" as const, features: [{ type: "Feature" as const, geometry: { type: "Point" as const, coordinates: [23.3, 42.7] as [number, number] }, properties: {} as Record<string, unknown> }] };
+    const newGeoJson = { type: "FeatureCollection" as const, features: [{ type: "Feature" as const, geometry: { type: "Point" as const, coordinates: [23.3, 42.7] as [number, number] }, properties: { geometryQuality: 3 } as Record<string, unknown> }] };
     mockFindEventById.mockResolvedValueOnce({ _id: "evt-1", geometryQuality: 2 });
 
     await attachMessageToEvent(

--- a/ingest/event-matching/attach-to-event.ts
+++ b/ingest/event-matching/attach-to-event.ts
@@ -1,6 +1,7 @@
 import type { OboDb, UpdateOperators } from "@oboapp/db";
 import type { GeoJSONFeatureCollection } from "@/lib/types";
-import { getSourceTrust, getGeometryQuality } from "@/lib/source-trust";
+import { getSourceTrust } from "@/lib/source-trust";
+import { aggregateMessageGeometryQuality } from "@/messageIngest/aggregate-quality";
 import type { MatchSignals } from "./score";
 import { toISOString, toMs, isAlreadyExistsError } from "./utils";
 import { logger } from "@/lib/logger";
@@ -50,11 +51,9 @@ export async function attachMessageToEvent(
   const isRepair = existingLinks.length > 0;
 
   const source = typeof message.source === "string" ? message.source : "";
-  const hasPrecomputedGeoJson = getSourceTrust(source).geometryQuality === 3;
-  // Geometry quality is 0 when the message has no geoJson (e.g., city-wide messages)
-  const newGeometryQuality = message.geoJson
-    ? getGeometryQuality(source, hasPrecomputedGeoJson)
-    : 0;
+  // Pass ungradedFallback=1 so legacy messages without per-feature quality stamps
+  // are treated as quality 1 (geometry present, grade unknown) rather than 0.
+  const newGeometryQuality = aggregateMessageGeometryQuality(message.geoJson, 1);
   const now = new Date().toISOString();
   const eventId = getString(event._id);
 

--- a/ingest/event-matching/create-event.test.ts
+++ b/ingest/event-matching/create-event.test.ts
@@ -1,20 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createEventFromMessage } from "./create-event";
 
-vi.mock("@/lib/source-trust", () => ({
-  getSourceTrust: vi.fn((source: string) => {
-    if (source === "toplo-bg") return { trust: 1.0, geometryQuality: 3 };
-    if (source === "sofia-bg") return { trust: 0.8, geometryQuality: 2 };
-    return { trust: 0.5, geometryQuality: 0 };
-  }),
-  getGeometryQuality: vi.fn((source: string, hasPrecomputed: boolean) => {
-    if (hasPrecomputed) return 3;
-    if (source === "toplo-bg") return 3;
-    if (source === "sofia-bg") return 2;
-    return 0;
-  }),
-}));
-
 const mockInsertEvent = vi.fn().mockResolvedValue("evt-new");
 const mockInsertEventMessage = vi.fn().mockResolvedValue("em-new");
 const mockCreateEventMessage = vi.fn().mockResolvedValue("msg-1");
@@ -43,7 +29,16 @@ describe("createEventFromMessage", () => {
       _id: "msg-1",
       plainText: "Water outage on Vitosha blvd",
       markdownText: "**Water outage** on Vitosha blvd",
-      geoJson: { type: "FeatureCollection", features: [] },
+      geoJson: {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            geometry: { type: "Point", coordinates: [23.32, 42.69] },
+            properties: { geometryQuality: 2, qualityProvider: "google" },
+          },
+        ],
+      },
       timespanStart: "2025-03-01T08:00:00Z",
       timespanEnd: "2025-03-01T18:00:00Z",
       categories: ["water"],
@@ -58,7 +53,7 @@ describe("createEventFromMessage", () => {
     const eventData = mockInsertEvent.mock.calls[0][0];
     expect(eventData.plainText).toBe("Water outage on Vitosha blvd");
     expect(eventData.markdownText).toBe("**Water outage** on Vitosha blvd");
-    expect(eventData.geometryQuality).toBe(2); // sofia-bg default
+    expect(eventData.geometryQuality).toBe(2); // Feature quality
     expect(eventData.categories).toEqual(["water"]);
     expect(eventData.sources).toEqual(["sofia-bg"]);
     expect(eventData.messageCount).toBe(1);
@@ -70,7 +65,16 @@ describe("createEventFromMessage", () => {
     await createEventFromMessage(mockDb, {
       _id: "msg-1",
       source: "toplo-bg",
-      geoJson: { type: "FeatureCollection", features: [] },
+      geoJson: {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            geometry: { type: "Point", coordinates: [23.32, 42.69] },
+            properties: { geometryQuality: 3, qualityProvider: "precomputed" },
+          },
+        ],
+      },
     });
 
     const emData = mockCreateEventMessage.mock.calls[0][0];
@@ -78,16 +82,25 @@ describe("createEventFromMessage", () => {
     expect(emData.messageId).toBe("msg-1");
     expect(emData.source).toBe("toplo-bg");
     expect(emData.confidence).toBe(1.0);
-    expect(emData.geometryQuality).toBe(3); // toplo-bg = precomputed
+    expect(emData.geometryQuality).toBe(3); // Feature quality
     expect(emData.matchSignals).toBeNull(); // No matching process — new event
     expect(mockCreateEventMessage.mock.calls[0][1]).toBe("msg-1");
   });
 
-  it("uses precomputed geometry quality for precomputed sources with geoJson", async () => {
+  it("uses geometry quality derived from features", async () => {
     await createEventFromMessage(mockDb, {
       _id: "msg-1",
       source: "toplo-bg",
-      geoJson: { type: "FeatureCollection", features: [] },
+      geoJson: {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            geometry: { type: "Point", coordinates: [23.32, 42.69] },
+            properties: { geometryQuality: 3, qualityProvider: "precomputed" },
+          },
+        ],
+      },
     });
 
     const eventData = mockInsertEvent.mock.calls[0][0];
@@ -124,7 +137,11 @@ describe("createEventFromMessage", () => {
       geoJson: { type: "FeatureCollection", features: [] },
     });
 
-    expect(result).toEqual({ eventId: "evt-existing", confidence: 1.0, action: "attached" });
+    expect(result).toEqual({
+      eventId: "evt-existing",
+      confidence: 1.0,
+      action: "attached",
+    });
     expect(mockInsertEvent).not.toHaveBeenCalled();
     expect(mockInsertEventMessage).not.toHaveBeenCalled();
   });
@@ -144,6 +161,10 @@ describe("createEventFromMessage", () => {
     });
 
     expect(mockDeleteEvent).toHaveBeenCalledWith("evt-new");
-    expect(result).toEqual({ eventId: "evt-existing", confidence: 1.0, action: "attached" });
+    expect(result).toEqual({
+      eventId: "evt-existing",
+      confidence: 1.0,
+      action: "attached",
+    });
   });
 });

--- a/ingest/event-matching/create-event.ts
+++ b/ingest/event-matching/create-event.ts
@@ -1,6 +1,6 @@
 import type { OboDb } from "@oboapp/db";
 import type { GeoJSONFeatureCollection } from "@/lib/types";
-import { getSourceTrust, getGeometryQuality } from "@/lib/source-trust";
+import { aggregateMessageGeometryQuality } from "@/messageIngest/aggregate-quality";
 import { isAlreadyExistsError, toISOString } from "./utils";
 import { logger } from "@/lib/logger";
 import { getLocality } from "@/lib/target-locality";
@@ -42,12 +42,9 @@ export async function createEventFromMessage(
   }
 
   const source = typeof message.source === "string" ? message.source : "";
-  const hasGeoJson = Boolean(message.geoJson);
-  let geometryQuality = 0;
-  if (hasGeoJson) {
-    const isPrecomputedSource = getSourceTrust(source).geometryQuality === 3;
-    geometryQuality = getGeometryQuality(source, isPrecomputedSource);
-  }
+  // Pass ungradedFallback=1 so legacy messages without per-feature quality stamps
+  // are treated as quality 1 (geometry present, grade unknown) rather than 0.
+  const geometryQuality = aggregateMessageGeometryQuality(message.geoJson, 1);
   const now = new Date().toISOString();
 
   const eventId = await db.events.insertOne({

--- a/ingest/geocode.ts
+++ b/ingest/geocode.ts
@@ -107,6 +107,7 @@ Examples:
         const geoJson = await convertMessageGeocodingToGeoJson(
           typedExtracted,
           geocodingResult.preGeocodedMap,
+          geocodingResult.qualityMap,
           geocodingResult.cadastralGeometries,
         );
 

--- a/ingest/geocoding/educational-facilities/geocoding-service.ts
+++ b/ingest/geocoding/educational-facilities/geocoding-service.ts
@@ -3,6 +3,7 @@ import type { Address } from "../../lib/types";
 import type { IngestErrorRecorder } from "@/lib/ingest-errors";
 import { logger } from "@/lib/logger";
 import { EDUCATIONAL_FACILITY_PREFIX } from "@/lib/constants";
+import { gradeEducational } from "../shared/quality";
 
 interface FacilityGeometry {
   name: string;
@@ -81,6 +82,7 @@ export async function geocodeEducationalFacilities(
     }
 
     if (geometry) {
+      const qualitySignals = gradeEducational();
       addresses.push({
         originalText: `${EDUCATIONAL_FACILITY_PREFIX}${type}:${number}`,
         formattedAddress: `${geometry.name} (${number})`,
@@ -92,6 +94,7 @@ export async function geocodeEducationalFacilities(
           type: "Point",
           coordinates: [geometry.lng, geometry.lat],
         },
+        qualitySignals,
       });
       logger.info("Geocoded educational facility", {
         type,

--- a/ingest/geocoding/google/service.ts
+++ b/ingest/geocoding/google/service.ts
@@ -5,6 +5,7 @@ import { getLocality } from "../../lib/target-locality";
 import { getLocalityContext } from "../../lib/locality-context";
 import { delay } from "../../lib/delay";
 import { logger } from "@/lib/logger";
+import { gradeGoogle } from "../shared/quality";
 import { GoogleGeocodingMockService } from "../../__mocks__/services/google-geocoding-mock-service";
 import { overpassGeocodeAddresses } from "../overpass/service";
 
@@ -78,6 +79,11 @@ export async function geocodeAddress(address: string): Promise<Address | null> {
 
         // Validate that the result is actually within the locality's boundaries
         if (isWithinBounds(locality, lat, lng)) {
+          const qualitySignals = gradeGoogle(
+            result.geometry.location_type,
+            result.partial_match,
+          );
+
           return {
             originalText: address,
             formattedAddress: result.formatted_address,
@@ -86,6 +92,7 @@ export async function geocodeAddress(address: string): Promise<Address | null> {
               type: "Point",
               coordinates: [lng, lat],
             },
+            qualitySignals,
           };
         }
         logger.warn("Result is outside locality boundaries", {

--- a/ingest/geocoding/gtfs/geocoding-service.ts
+++ b/ingest/geocoding/gtfs/geocoding-service.ts
@@ -1,5 +1,6 @@
 import type { Address } from "../../lib/types";
 import { logger } from "@/lib/logger";
+import { gradeGtfs } from "../shared/quality";
 
 export interface BusStopGeometry {
   stopCode: string;
@@ -61,6 +62,7 @@ export async function geocodeBusStops(stopCodes: string[]): Promise<Address[]> {
   for (const stopCode of stopCodes) {
     const geometry = await geocodeBusStop(stopCode);
     if (geometry) {
+      const qualitySignals = gradeGtfs();
       addresses.push({
         originalText: `Спирка ${stopCode}`,
         formattedAddress: `${geometry.stopName} (${stopCode})`,
@@ -72,6 +74,7 @@ export async function geocodeBusStops(stopCodes: string[]): Promise<Address[]> {
           type: "Point",
           coordinates: [geometry.lng, geometry.lat],
         },
+        qualitySignals,
       });
       logger.info("Geocoded bus stop", { stopCode, stopName: geometry.stopName });
     }

--- a/ingest/geocoding/overpass/service.ts
+++ b/ingest/geocoding/overpass/service.ts
@@ -17,6 +17,7 @@ import { getLocality } from "../../lib/target-locality";
 import { delay } from "../../lib/delay";
 import { roundCoordinate } from "@/geocoding/shared/coordinate-utils";
 import { logger } from "@/lib/logger";
+import { gradeOverpass } from "../shared/quality";
 import { OverpassMockService } from "../../__mocks__/services/overpass-mock-service";
 
 // Check if mocking is enabled
@@ -936,6 +937,8 @@ async function geocodeSingleIntersection(
     return null;
   }
 
+  const qualitySignals = gradeOverpass("node"); // Intersection resolves to a node point
+
   return {
     originalText: intersection,
     formattedAddress: intersection,
@@ -944,6 +947,7 @@ async function geocodeSingleIntersection(
       type: "Point",
       coordinates: [intersectionPoint.lng, intersectionPoint.lat],
     },
+    qualitySignals,
   };
 }
 
@@ -1326,6 +1330,7 @@ export async function overpassGeocodeAddresses(
       try {
         const coords = await resolveSingleAddress(address);
         if (coords) {
+          const qualitySignals = gradeOverpass("node"); // Overpass address: conservative tier
           results.push({
             originalText: address,
             formattedAddress: address,
@@ -1334,6 +1339,7 @@ export async function overpassGeocodeAddresses(
               type: "Point",
               coordinates: [coords.lng, coords.lat],
             },
+            qualitySignals,
           });
         } else {
           logger.warn("Failed to geocode address", { address });

--- a/ingest/geocoding/shared/geojson-service.test.ts
+++ b/ingest/geocoding/shared/geojson-service.test.ts
@@ -270,7 +270,8 @@ describe("convertToGeoJSON with geotagged coordinates", () => {
       ["End Point", { lat: 42.693259, lng: 23.354973 }], // Rounded from 42.693259 and 23.3549725
     ]);
 
-    const result = await convertToGeoJSON(extractedData, preGeocodedMap);
+    const qualityMap = new Map();
+    const result = await convertToGeoJSON(extractedData, preGeocodedMap, qualityMap);
 
     expect(result.features).toHaveLength(1);
     expect(result.features[0].geometry.type).toBe("Polygon");
@@ -309,7 +310,8 @@ describe("convertToGeoJSON with geotagged coordinates", () => {
       ["бул. Ситняково", { lat: 42.694, lng: 23.352 }],
     ]);
 
-    const result = await convertToGeoJSON(extractedData, preGeocodedMap);
+    const qualityMap = new Map();
+    const result = await convertToGeoJSON(extractedData, preGeocodedMap, qualityMap);
 
     expect(result.features).toHaveLength(1);
     expect(result.features[0].geometry.type).toBe("Polygon");

--- a/ingest/geocoding/shared/geojson-service.ts
+++ b/ingest/geocoding/shared/geojson-service.ts
@@ -291,17 +291,18 @@ async function createClosureFeature(
   const fromQuality = qualityMap.get(street.from);
   const toQuality = qualityMap.get(street.to);
 
-  const endpointQualities = [fromQuality?.geometryQuality, toQuality?.geometryQuality].filter(
-    (q): q is number => q !== undefined,
-  );
+  // Both endpoints must be present to grade the closure. A missing signal is
+  // treated as 0 (most conservative) so a partially-graded closure cannot
+  // silently overstate quality by ignoring the missing endpoint.
+  const fromGrade = fromQuality?.geometryQuality ?? 0;
+  const toGrade = toQuality?.geometryQuality ?? 0;
+  const endpointQualities = [fromGrade, toGrade];
   const allQualities = wayQuality !== null ? [...endpointQualities, wayQuality] : endpointQualities;
 
-  if (allQualities.length > 0) {
-    qualitySignals = {
-      provider: QUALITY_PROVIDERS.STREET,
-      geometryQuality: Math.min(...allQualities),
-    };
-  }
+  qualitySignals = {
+    provider: QUALITY_PROVIDERS.STREET,
+    geometryQuality: Math.min(...allQualities),
+  };
 
   // Assemble feature
   return {

--- a/ingest/geocoding/shared/geojson-service.ts
+++ b/ingest/geocoding/shared/geojson-service.ts
@@ -1,12 +1,14 @@
 import {
   ExtractedLocations,
   StreetSection,
-  GeoJSONFeatureCollection,
-  GeoJSONFeature,
-  GeoJSONLineString,
-  GeoJSONPolygon,
-  IntersectionCoordinates,
-} from "../../lib/types";
+  GeoJsonFeatureCollection,
+  GeoJsonFeature,
+  GeoJsonLineString,
+  GeoJsonPolygon,
+  QualitySignals,
+  QUALITY_PROVIDERS,
+} from "@oboapp/shared";
+import type { IntersectionCoordinates } from "@/lib/types";
 import { getStreetGeometry } from "../router";
 import { roundCoordinate } from "./coordinate-utils";
 import { logger } from "@/lib/logger";
@@ -20,7 +22,8 @@ const BUFFER_WIDTH_RESIDENTIAL = 7; // 6-8m average
 function createPinFeature(
   pin: { address: string; timespans: { start: string | null; end: string | null }[] },
   preGeocodedAddresses: Map<string, IntersectionCoordinates>,
-): GeoJSONFeature {
+  qualityMap: Map<string, QualitySignals>,
+): GeoJsonFeature {
   const coords = preGeocodedAddresses.get(pin.address);
 
   if (!coords) {
@@ -28,6 +31,8 @@ function createPinFeature(
       `Missing pre-geocoded coordinates for pin: "${pin.address}"`,
     );
   }
+
+  const quality = qualityMap.get(pin.address);
 
   return {
     type: "Feature",
@@ -40,7 +45,12 @@ function createPinFeature(
       address: pin.address,
       start_time: pin.timespans[0]?.start || "",
       end_time: pin.timespans[0]?.end || "",
-      timespans: JSON.stringify(pin.timespans), // Store all timespans as JSON string
+      timespans: JSON.stringify(pin.timespans),
+      ...(quality && {
+        geometryQuality: quality.geometryQuality,
+        qualityProvider: quality.provider,
+        qualitySignals: quality,
+      }),
     },
   };
 }
@@ -51,7 +61,7 @@ async function getStreetCenterline(
   endCoords: IntersectionCoordinates,
   streetName: string,
   hasGeotaggedCoordinates: boolean = false,
-): Promise<GeoJSONLineString> {
+): Promise<GeoJsonLineString> {
   // Check if start and end are the same or very close
   const distance = Math.sqrt(
     Math.pow(endCoords.lat - startCoords.lat, 2) +
@@ -112,9 +122,9 @@ async function getStreetCenterline(
 
 // Step 3 — Line-to-Polygon Conversion
 function bufferLineString(
-  lineString: GeoJSONLineString,
+  lineString: GeoJsonLineString,
   bufferMeters: number = 8,
-): GeoJSONPolygon | null {
+): GeoJsonPolygon | null {
   const coordinates = lineString.coordinates;
   if (coordinates.length < 2) return null;
 
@@ -203,7 +213,8 @@ function getBufferWidth(streetName: string): number {
 async function createClosureFeature(
   street: StreetSection,
   preGeocodedAddresses: Map<string, IntersectionCoordinates>,
-): Promise<GeoJSONFeature> {
+  qualityMap: Map<string, QualitySignals>,
+): Promise<GeoJsonFeature> {
   // Get pre-geocoded coordinates
   const startCoords = preGeocodedAddresses.get(street.from);
   const endCoords = preGeocodedAddresses.get(street.to);
@@ -247,6 +258,28 @@ async function createClosureFeature(
     throw new Error(`Failed to buffer linestring for: ${street.street}`);
   }
 
+  // Compute street quality: min of both endpoint qualities (conservative).
+  // Use "street" provider since the quality reflects aggregated endpoint signals,
+  // not a single geocoder. Fall back to whichever endpoint is available.
+  let qualitySignals: QualitySignals | null = null;
+  const fromQuality = qualityMap.get(street.from);
+  const toQuality = qualityMap.get(street.to);
+  if (fromQuality && toQuality) {
+    const minQuality = Math.min(fromQuality.geometryQuality, toQuality.geometryQuality);
+    qualitySignals = {
+      provider: QUALITY_PROVIDERS.STREET,
+      geometryQuality: minQuality,
+    };
+  } else {
+    const availableQuality = fromQuality ?? toQuality;
+    if (availableQuality) {
+      qualitySignals = {
+        provider: QUALITY_PROVIDERS.STREET,
+        geometryQuality: availableQuality.geometryQuality,
+      };
+    }
+  }
+
   // Assemble feature
   return {
     type: "Feature",
@@ -258,7 +291,12 @@ async function createClosureFeature(
       to: street.to,
       start_time: street.timespans[0]?.start || "",
       end_time: street.timespans[0]?.end || "",
-      timespans: JSON.stringify(street.timespans), // Store all timespans as JSON string
+      timespans: JSON.stringify(street.timespans),
+      ...(qualitySignals && {
+        geometryQuality: qualitySignals.geometryQuality,
+        qualityProvider: qualitySignals.provider,
+        qualitySignals,
+      }),
     },
   };
 }
@@ -267,14 +305,15 @@ async function createClosureFeature(
 export async function convertToGeoJSON(
   extractedData: ExtractedLocations,
   preGeocodedAddresses: Map<string, IntersectionCoordinates>,
-): Promise<GeoJSONFeatureCollection> {
-  const features: GeoJSONFeature[] = [];
+  qualityMap: Map<string, QualitySignals>,
+): Promise<GeoJsonFeatureCollection> {
+  const features: GeoJsonFeature[] = [];
   const fallbackPins: typeof extractedData.pins = [];
 
   // Process all street closures first
   for (const street of extractedData.streets) {
     try {
-      const feature = await createClosureFeature(street, preGeocodedAddresses);
+      const feature = await createClosureFeature(street, preGeocodedAddresses, qualityMap);
       features.push(feature);
     } catch (error) {
       // If street section creation fails, convert endpoints to pins as fallback
@@ -317,7 +356,7 @@ export async function convertToGeoJSON(
   const allPins = [...extractedData.pins, ...fallbackPins];
   for (const pin of allPins) {
     try {
-      const feature = createPinFeature(pin, preGeocodedAddresses);
+      const feature = createPinFeature(pin, preGeocodedAddresses, qualityMap);
       features.push(feature);
     } catch (error) {
       logger.error("Failed to create pin", {

--- a/ingest/geocoding/shared/geojson-service.ts
+++ b/ingest/geocoding/shared/geojson-service.ts
@@ -7,11 +7,13 @@ import {
   GeoJsonPolygon,
   QualitySignals,
   QUALITY_PROVIDERS,
+  OSM_ELEMENT_TYPES,
 } from "@oboapp/shared";
 import type { IntersectionCoordinates } from "@/lib/types";
 import { getStreetGeometry } from "../router";
 import { roundCoordinate } from "./coordinate-utils";
 import { logger } from "@/lib/logger";
+import { gradeOverpass } from "./quality";
 
 // Constants for street buffer widths (in meters)
 const BUFFER_WIDTH_BOULEVARD = 13; // 12-14m average
@@ -56,12 +58,18 @@ function createPinFeature(
 }
 
 // Step 2 — Street Centerline Retrieval
+interface CenterlineResult {
+  geometry: GeoJsonLineString;
+  /** True when Overpass returned real way geometry (not a synthesised straight line). */
+  usedWayGeometry: boolean;
+}
+
 async function getStreetCenterline(
   startCoords: IntersectionCoordinates,
   endCoords: IntersectionCoordinates,
   streetName: string,
   hasGeotaggedCoordinates: boolean = false,
-): Promise<GeoJsonLineString> {
+): Promise<CenterlineResult> {
   // Check if start and end are the same or very close
   const distance = Math.sqrt(
     Math.pow(endCoords.lat - startCoords.lat, 2) +
@@ -74,11 +82,14 @@ async function getStreetCenterline(
     // Extend slightly in a default direction (e.g., 10 meters north-south)
     const offsetDegrees = 0.00009; // approximately 10 meters
     return {
-      type: "LineString",
-      coordinates: [
-        [startCoords.lng, startCoords.lat - offsetDegrees / 2],
-        [startCoords.lng, startCoords.lat + offsetDegrees / 2],
-      ],
+      geometry: {
+        type: "LineString",
+        coordinates: [
+          [startCoords.lng, startCoords.lat - offsetDegrees / 2],
+          [startCoords.lng, startCoords.lat + offsetDegrees / 2],
+        ],
+      },
+      usedWayGeometry: false,
     };
   }
 
@@ -92,11 +103,14 @@ async function getStreetCenterline(
       },
     );
     return {
-      type: "LineString",
-      coordinates: [
-        [startCoords.lng, startCoords.lat],
-        [endCoords.lng, endCoords.lat],
-      ],
+      geometry: {
+        type: "LineString",
+        coordinates: [
+          [startCoords.lng, startCoords.lat],
+          [endCoords.lng, endCoords.lat],
+        ],
+      },
+      usedWayGeometry: false,
     };
   }
 
@@ -105,18 +119,24 @@ async function getStreetCenterline(
 
   if (geometry && geometry.length >= 2) {
     return {
-      type: "LineString",
-      coordinates: geometry,
+      geometry: {
+        type: "LineString",
+        coordinates: geometry,
+      },
+      usedWayGeometry: true,
     };
   }
 
   // Fallback to straight line between the two points
   return {
-    type: "LineString",
-    coordinates: [
-      [startCoords.lng, startCoords.lat],
-      [endCoords.lng, endCoords.lat],
-    ],
+    geometry: {
+      type: "LineString",
+      coordinates: [
+        [startCoords.lng, startCoords.lat],
+        [endCoords.lng, endCoords.lat],
+      ],
+    },
+    usedWayGeometry: false,
   };
 }
 
@@ -243,7 +263,7 @@ async function createClosureFeature(
     roundCoordinate(street.toCoordinates.lng) === endCoords.lng;
 
   // Get centerline
-  const centerline = await getStreetCenterline(
+  const { geometry: centerline, usedWayGeometry } = await getStreetCenterline(
     startCoords,
     endCoords,
     street.street,
@@ -258,26 +278,29 @@ async function createClosureFeature(
     throw new Error(`Failed to buffer linestring for: ${street.street}`);
   }
 
-  // Compute street quality: min of both endpoint qualities (conservative).
-  // Use "street" provider since the quality reflects aggregated endpoint signals,
-  // not a single geocoder. Fall back to whichever endpoint is available.
+  // Compute street quality conservatively.
+  //
+  // When the centerline came from real Overpass WAY geometry, incorporate its
+  // quality (2) alongside the endpoint qualities. This allows closures with
+  // both accurate WAY geometry and address-level endpoints to reach tier 2,
+  // consistent with the documented tier meaning and gradeOverpass('way') = 2.
+  //
+  // Use "street" provider since the quality reflects aggregated signals.
+  const wayQuality = usedWayGeometry ? gradeOverpass(OSM_ELEMENT_TYPES.WAY).geometryQuality : null;
   let qualitySignals: QualitySignals | null = null;
   const fromQuality = qualityMap.get(street.from);
   const toQuality = qualityMap.get(street.to);
-  if (fromQuality && toQuality) {
-    const minQuality = Math.min(fromQuality.geometryQuality, toQuality.geometryQuality);
+
+  const endpointQualities = [fromQuality?.geometryQuality, toQuality?.geometryQuality].filter(
+    (q): q is number => q !== undefined,
+  );
+  const allQualities = wayQuality !== null ? [...endpointQualities, wayQuality] : endpointQualities;
+
+  if (allQualities.length > 0) {
     qualitySignals = {
       provider: QUALITY_PROVIDERS.STREET,
-      geometryQuality: minQuality,
+      geometryQuality: Math.min(...allQualities),
     };
-  } else {
-    const availableQuality = fromQuality ?? toQuality;
-    if (availableQuality) {
-      qualitySignals = {
-        provider: QUALITY_PROVIDERS.STREET,
-        geometryQuality: availableQuality.geometryQuality,
-      };
-    }
   }
 
   // Assemble feature

--- a/ingest/geocoding/shared/google-location-types.ts
+++ b/ingest/geocoding/shared/google-location-types.ts
@@ -1,0 +1,5 @@
+/**
+ * Re-exported from @oboapp/shared for backward compatibility.
+ * Import from @oboapp/shared directly when possible.
+ */
+export { GOOGLE_LOCATION_TYPES, type GoogleLocationType } from "@oboapp/shared";

--- a/ingest/geocoding/shared/quality.test.ts
+++ b/ingest/geocoding/shared/quality.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect } from "vitest";
+import {
+  gradeGoogle,
+  gradeOverpass,
+  gradeCadastre,
+  gradeGtfs,
+  gradeEducational,
+  gradePrecomputed,
+  gradeUnknown,
+} from "./quality";
+import { QUALITY_PROVIDERS, OSM_ELEMENT_TYPES, GOOGLE_LOCATION_TYPES } from "@oboapp/shared";
+
+describe("gradeGoogle", () => {
+  it("returns quality 0 when locationType is missing", () => {
+    expect(gradeGoogle()).toEqual({
+      provider: QUALITY_PROVIDERS.GOOGLE,
+      geometryQuality: 0,
+    });
+  });
+
+  it("returns quality 0 when locationType is undefined explicitly", () => {
+    expect(gradeGoogle(undefined, false)).toEqual({
+      provider: QUALITY_PROVIDERS.GOOGLE,
+      geometryQuality: 0,
+    });
+  });
+
+  it("returns quality 3 for ROOFTOP without partial match", () => {
+    expect(gradeGoogle(GOOGLE_LOCATION_TYPES.ROOFTOP, false)).toEqual({
+      provider: QUALITY_PROVIDERS.GOOGLE,
+      locationType: GOOGLE_LOCATION_TYPES.ROOFTOP,
+      partialMatch: false,
+      geometryQuality: 3,
+    });
+  });
+
+  it("returns quality 1 for ROOFTOP with partial match", () => {
+    const result = gradeGoogle(GOOGLE_LOCATION_TYPES.ROOFTOP, true);
+    expect(result.geometryQuality).toBe(1);
+    expect(result.partialMatch).toBe(true);
+  });
+
+  it("returns quality 2 for RANGE_INTERPOLATED without partial match", () => {
+    expect(gradeGoogle(GOOGLE_LOCATION_TYPES.RANGE_INTERPOLATED, false)).toEqual({
+      provider: QUALITY_PROVIDERS.GOOGLE,
+      locationType: GOOGLE_LOCATION_TYPES.RANGE_INTERPOLATED,
+      partialMatch: false,
+      geometryQuality: 2,
+    });
+  });
+
+  it("returns quality 1 for RANGE_INTERPOLATED with partial match", () => {
+    const result = gradeGoogle(GOOGLE_LOCATION_TYPES.RANGE_INTERPOLATED, true);
+    expect(result.geometryQuality).toBe(1);
+  });
+
+  it("returns quality 2 for GEOMETRIC_CENTER without partial match", () => {
+    expect(gradeGoogle(GOOGLE_LOCATION_TYPES.GEOMETRIC_CENTER, false)).toEqual({
+      provider: QUALITY_PROVIDERS.GOOGLE,
+      locationType: GOOGLE_LOCATION_TYPES.GEOMETRIC_CENTER,
+      partialMatch: false,
+      geometryQuality: 2,
+    });
+  });
+
+  it("returns quality 1 for GEOMETRIC_CENTER with partial match", () => {
+    const result = gradeGoogle(GOOGLE_LOCATION_TYPES.GEOMETRIC_CENTER, true);
+    expect(result.geometryQuality).toBe(1);
+  });
+
+  it("returns quality 1 for APPROXIMATE", () => {
+    expect(gradeGoogle(GOOGLE_LOCATION_TYPES.APPROXIMATE)).toEqual({
+      provider: QUALITY_PROVIDERS.GOOGLE,
+      locationType: GOOGLE_LOCATION_TYPES.APPROXIMATE,
+      geometryQuality: 1,
+    });
+  });
+
+  it("returns quality 1 for unknown locationType with partialMatch", () => {
+    const result = gradeGoogle("UNKNOWN_TYPE", true);
+    expect(result.provider).toBe(QUALITY_PROVIDERS.GOOGLE);
+    expect(result.geometryQuality).toBe(1);
+  });
+
+  it("returns quality 1 for unknown locationType without partialMatch", () => {
+    const result = gradeGoogle("UNKNOWN_TYPE", false);
+    expect(result.provider).toBe(QUALITY_PROVIDERS.GOOGLE);
+    expect(result.geometryQuality).toBe(1);
+  });
+});
+
+describe("gradeOverpass", () => {
+  it("returns quality 2 for way", () => {
+    expect(gradeOverpass(OSM_ELEMENT_TYPES.WAY)).toEqual({
+      provider: QUALITY_PROVIDERS.OVERPASS,
+      osmElementType: OSM_ELEMENT_TYPES.WAY,
+      geometryQuality: 2,
+    });
+  });
+
+  it("returns quality 1 for node", () => {
+    expect(gradeOverpass(OSM_ELEMENT_TYPES.NODE)).toEqual({
+      provider: QUALITY_PROVIDERS.OVERPASS,
+      osmElementType: OSM_ELEMENT_TYPES.NODE,
+      geometryQuality: 1,
+    });
+  });
+
+  it("returns quality 1 for relation", () => {
+    expect(gradeOverpass(OSM_ELEMENT_TYPES.RELATION)).toEqual({
+      provider: QUALITY_PROVIDERS.OVERPASS,
+      osmElementType: OSM_ELEMENT_TYPES.RELATION,
+      geometryQuality: 1,
+    });
+  });
+
+  it("returns quality 1 when elementType is undefined (fallback)", () => {
+    expect(gradeOverpass()).toEqual({
+      provider: QUALITY_PROVIDERS.OVERPASS,
+      geometryQuality: 1,
+    });
+  });
+
+  it("returns quality 1 for unknown element type (fallback)", () => {
+    const result = gradeOverpass("area");
+    expect(result.provider).toBe(QUALITY_PROVIDERS.OVERPASS);
+    expect(result.geometryQuality).toBe(1);
+  });
+});
+
+describe("gradeCadastre", () => {
+  it("returns quality 3", () => {
+    expect(gradeCadastre()).toEqual({
+      provider: QUALITY_PROVIDERS.CADASTRE,
+      geometryQuality: 3,
+    });
+  });
+});
+
+describe("gradeGtfs", () => {
+  it("returns quality 3", () => {
+    expect(gradeGtfs()).toEqual({
+      provider: QUALITY_PROVIDERS.GTFS,
+      geometryQuality: 3,
+    });
+  });
+});
+
+describe("gradeEducational", () => {
+  it("returns quality 3", () => {
+    expect(gradeEducational()).toEqual({
+      provider: QUALITY_PROVIDERS.EDUCATIONAL,
+      geometryQuality: 3,
+    });
+  });
+});
+
+describe("gradePrecomputed", () => {
+  it("returns quality 3 for trust >= 0.9 (exact threshold)", () => {
+    expect(gradePrecomputed(0.9)).toEqual({
+      provider: QUALITY_PROVIDERS.PRECOMPUTED,
+      geometryQuality: 3,
+    });
+  });
+
+  it("returns quality 3 for trust = 1.0 (maximum)", () => {
+    expect(gradePrecomputed(1.0)).toEqual({
+      provider: QUALITY_PROVIDERS.PRECOMPUTED,
+      geometryQuality: 3,
+    });
+  });
+
+  it("returns quality 2 for trust just below 0.9", () => {
+    expect(gradePrecomputed(0.89)).toEqual({
+      provider: QUALITY_PROVIDERS.PRECOMPUTED,
+      geometryQuality: 2,
+    });
+  });
+
+  it("returns quality 2 for trust = 0 (minimum)", () => {
+    expect(gradePrecomputed(0)).toEqual({
+      provider: QUALITY_PROVIDERS.PRECOMPUTED,
+      geometryQuality: 2,
+    });
+  });
+
+  it("returns quality 2 for trust = 0.5 (mid-range)", () => {
+    expect(gradePrecomputed(0.5)).toEqual({
+      provider: QUALITY_PROVIDERS.PRECOMPUTED,
+      geometryQuality: 2,
+    });
+  });
+});
+
+describe("gradeUnknown", () => {
+  it("returns quality 0 with SOURCE provider", () => {
+    expect(gradeUnknown()).toEqual({
+      provider: QUALITY_PROVIDERS.SOURCE,
+      geometryQuality: 0,
+    });
+  });
+});

--- a/ingest/geocoding/shared/quality.ts
+++ b/ingest/geocoding/shared/quality.ts
@@ -1,0 +1,179 @@
+/**
+ * Geometry Quality Grading
+ *
+ * Computes deterministic per-feature quality scores (0–3) from geocoder signals.
+ * Scores reflect geometry precision: 3 = official/building-level, 2 = address-level,
+ * 1 = approximate/street, 0 = none/unknown.
+ */
+
+import type { QualitySignals } from "@oboapp/shared";
+import { QUALITY_PROVIDERS, OSM_ELEMENT_TYPES } from "@oboapp/shared";
+import { GOOGLE_LOCATION_TYPES } from "./google-location-types";
+
+/**
+ * Grade a Google Geocoding result
+ * Quality = 3 if ROOFTOP & not partial, 2 if RANGE_INTERPOLATED/GEOMETRIC_CENTER & not partial,
+ * 1 if APPROXIMATE or partial_match, 0 if no result.
+ */
+export function gradeGoogle(
+  locationType?: string,
+  partialMatch?: boolean,
+): QualitySignals {
+  if (!locationType) {
+    return {
+      provider: QUALITY_PROVIDERS.GOOGLE,
+      geometryQuality: 0,
+    };
+  }
+
+  if (locationType === GOOGLE_LOCATION_TYPES.ROOFTOP && !partialMatch) {
+    return {
+      provider: QUALITY_PROVIDERS.GOOGLE,
+      locationType: GOOGLE_LOCATION_TYPES.ROOFTOP,
+      partialMatch: false,
+      geometryQuality: 3,
+    };
+  }
+
+  if (
+    locationType === GOOGLE_LOCATION_TYPES.RANGE_INTERPOLATED &&
+    !partialMatch
+  ) {
+    return {
+      provider: QUALITY_PROVIDERS.GOOGLE,
+      locationType: GOOGLE_LOCATION_TYPES.RANGE_INTERPOLATED,
+      partialMatch: false,
+      geometryQuality: 2,
+    };
+  }
+
+  if (
+    locationType === GOOGLE_LOCATION_TYPES.GEOMETRIC_CENTER &&
+    !partialMatch
+  ) {
+    return {
+      provider: QUALITY_PROVIDERS.GOOGLE,
+      locationType: GOOGLE_LOCATION_TYPES.GEOMETRIC_CENTER,
+      partialMatch: false,
+      geometryQuality: 2,
+    };
+  }
+
+  if (locationType === GOOGLE_LOCATION_TYPES.APPROXIMATE) {
+    return {
+      provider: QUALITY_PROVIDERS.GOOGLE,
+      locationType: GOOGLE_LOCATION_TYPES.APPROXIMATE,
+      geometryQuality: 1,
+    };
+  }
+
+  if (partialMatch) {
+    return {
+      provider: QUALITY_PROVIDERS.GOOGLE,
+      partialMatch: true,
+      geometryQuality: 1,
+    };
+  }
+
+  return {
+    provider: QUALITY_PROVIDERS.GOOGLE,
+    geometryQuality: 1,
+  };
+}
+
+/**
+ * Grade an Overpass (OpenStreetMap) result
+ * Quality = 2 if way, 1 if node/relation/fallback.
+ */
+export function gradeOverpass(elementType?: string): QualitySignals {
+  if (elementType === OSM_ELEMENT_TYPES.WAY) {
+    return {
+      provider: QUALITY_PROVIDERS.OVERPASS,
+      osmElementType: OSM_ELEMENT_TYPES.WAY,
+      geometryQuality: 2,
+    };
+  }
+
+  if (elementType === OSM_ELEMENT_TYPES.NODE) {
+    return {
+      provider: QUALITY_PROVIDERS.OVERPASS,
+      osmElementType: OSM_ELEMENT_TYPES.NODE,
+      geometryQuality: 1,
+    };
+  }
+
+  if (elementType === OSM_ELEMENT_TYPES.RELATION) {
+    return {
+      provider: QUALITY_PROVIDERS.OVERPASS,
+      osmElementType: OSM_ELEMENT_TYPES.RELATION,
+      geometryQuality: 1,
+    };
+  }
+
+  return {
+    provider: QUALITY_PROVIDERS.OVERPASS,
+    geometryQuality: 1,
+  };
+}
+
+/**
+ * Grade a Cadastre result
+ * Quality = 3 (official polygon boundary)
+ */
+export function gradeCadastre(): QualitySignals {
+  return {
+    provider: QUALITY_PROVIDERS.CADASTRE,
+    geometryQuality: 3,
+  };
+}
+
+/**
+ * Grade a GTFS bus stop
+ * Quality = 3 (official reference data)
+ */
+export function gradeGtfs(): QualitySignals {
+  return {
+    provider: QUALITY_PROVIDERS.GTFS,
+    geometryQuality: 3,
+  };
+}
+
+/**
+ * Grade an Educational Facility (school/kindergarten)
+ * Quality = 3 (official reference data)
+ */
+export function gradeEducational(): QualitySignals {
+  return {
+    provider: QUALITY_PROVIDERS.EDUCATIONAL,
+    geometryQuality: 3,
+  };
+}
+
+/**
+ * Grade a precomputed GeoJSON source.
+ *
+ * Derives quality from the source's trust score (from source-trust.ts) so the
+ * two configs stay in sync without duplication:
+ *   - trust ≥ 0.9 → quality 3 (authoritative official sources)
+ *   - trust < 0.9 → quality 2 (trusted but not authoritative, e.g. sensor networks)
+ *
+ * @param trust - Source trust score (0–1) from getSourceTrust(source).trust
+ */
+export function gradePrecomputed(trust: number): QualitySignals {
+  const geometryQuality: 3 | 2 = trust >= 0.9 ? 3 : 2;
+
+  return {
+    provider: QUALITY_PROVIDERS.PRECOMPUTED,
+    geometryQuality,
+  };
+}
+
+/**
+ * Default quality when no provider signal available
+ */
+export function gradeUnknown(): QualitySignals {
+  return {
+    provider: QUALITY_PROVIDERS.SOURCE,
+    geometryQuality: 0,
+  };
+}

--- a/ingest/lib/source-trust.test.ts
+++ b/ingest/lib/source-trust.test.ts
@@ -1,45 +1,29 @@
 import { describe, it, expect } from "vitest";
-import { getSourceTrust, getGeometryQuality } from "./source-trust";
+import { getSourceTrust } from "./source-trust";
 
 describe("getSourceTrust", () => {
-  it("returns trust 1.0 and quality 3 for toplo-bg", () => {
+  it("returns trust 1.0 for toplo-bg", () => {
     const entry = getSourceTrust("toplo-bg");
-    expect(entry).toEqual({ trust: 1.0, geometryQuality: 3 });
+    expect(entry).toEqual({ trust: 1.0 });
   });
 
-  it("returns trust 1.0 and quality 3 for sofiyska-voda", () => {
+  it("returns trust 1.0 for sofiyska-voda", () => {
     const entry = getSourceTrust("sofiyska-voda");
-    expect(entry).toEqual({ trust: 1.0, geometryQuality: 3 });
+    expect(entry).toEqual({ trust: 1.0 });
   });
 
-  it("returns trust 0.9 and quality 3 for erm-zapad", () => {
+  it("returns trust 0.9 for erm-zapad", () => {
     const entry = getSourceTrust("erm-zapad");
-    expect(entry).toEqual({ trust: 0.9, geometryQuality: 3 });
+    expect(entry).toEqual({ trust: 0.9 });
   });
 
-  it("returns trust 0.8 and quality 2 for municipality sources", () => {
+  it("returns trust 0.8 for municipality sources", () => {
     const entry = getSourceTrust("sofia-bg");
-    expect(entry).toEqual({ trust: 0.8, geometryQuality: 2 });
+    expect(entry).toEqual({ trust: 0.8 });
   });
 
   it("returns defaults for unknown source", () => {
     const entry = getSourceTrust("nonexistent-source");
-    expect(entry).toEqual({ trust: 0.5, geometryQuality: 0 });
-  });
-});
-
-describe("getGeometryQuality", () => {
-  it("returns 3 when hasPrecomputedGeoJson is true regardless of source", () => {
-    expect(getGeometryQuality("sofia-bg", true)).toBe(3);
-    expect(getGeometryQuality("nonexistent-source", true)).toBe(3);
-  });
-
-  it("returns source default quality when no precomputed GeoJSON", () => {
-    expect(getGeometryQuality("toplo-bg", false)).toBe(3);
-    expect(getGeometryQuality("sofia-bg", false)).toBe(2);
-  });
-
-  it("returns 0 for unknown source without precomputed GeoJSON", () => {
-    expect(getGeometryQuality("unknown", false)).toBe(0);
+    expect(entry).toEqual({ trust: 0.5 });
   });
 });

--- a/ingest/lib/source-trust.ts
+++ b/ingest/lib/source-trust.ts
@@ -1,58 +1,46 @@
 /**
  * Source trust configuration for event aggregation.
  *
- * Maps crawler names to trust scores and default geometry quality levels.
- * Trust (0–1): how reliable the source's metadata is.
- * Geometry quality (0–3): default quality of geometry this source produces.
- *   3 = official GeoJSON (precomputed)
- *   2 = geocoded exact address
- *   1 = street / intersection
- *   0 = unknown / no geometry
+ * Maps crawler names to trust scores.
+ * Trust (0–1): how reliable the source's metadata is (used for embedding selection).
+ *
+ * NOTE: Geometry quality is now derived per-feature from geocoder provider signals.
+ * This was previously hardcoded per-source; decoupling allows per-feature precision.
  */
 
 interface SourceTrustEntry {
   readonly trust: number;
-  readonly geometryQuality: number;
 }
 
 const SOURCE_TRUST: Record<string, SourceTrustEntry> = {
-  // Precomputed GeoJSON sources (quality 3)
-  "toplo-bg": { trust: 1.0, geometryQuality: 3 },
-  "sofiyska-voda": { trust: 1.0, geometryQuality: 3 },
-  "erm-zapad": { trust: 0.9, geometryQuality: 3 },
-  "nimh-severe-weather": { trust: 0.9, geometryQuality: 3 },
-  "sensor-community": { trust: 0.6, geometryQuality: 3 },
+  // Precomputed GeoJSON sources
+  "toplo-bg": { trust: 1.0 },
+  "sofiyska-voda": { trust: 1.0 },
+  "erm-zapad": { trust: 0.9 },
+  "nimh-severe-weather": { trust: 0.9 },
+  "sensor-community": { trust: 0.6 },
 
-  // Municipality / district websites (geocoded, quality 2)
-  "sofia-bg": { trust: 0.8, geometryQuality: 2 },
-  "rayon-oborishte-bg": { trust: 0.8, geometryQuality: 2 },
-  "mladost-bg": { trust: 0.8, geometryQuality: 2 },
-  "studentski-bg": { trust: 0.8, geometryQuality: 2 },
-  "sredec-sofia-org": { trust: 0.8, geometryQuality: 2 },
-  "so-slatina-org": { trust: 0.8, geometryQuality: 2 },
-  "lozenets-sofia-bg": { trust: 0.8, geometryQuality: 2 },
-  "raioniskar-bg": { trust: 0.8, geometryQuality: 2 },
-  "rayon-ilinden-bg": { trust: 0.8, geometryQuality: 2 },
-  "rayon-pancharevo-bg": { trust: 0.8, geometryQuality: 2 },
-  "triaditsa-org": { trust: 0.8, geometryQuality: 2 },
-  "krasna-polyana-org": { trust: 0.8, geometryQuality: 2 },
-  "vrabnitsa-org": { trust: 0.8, geometryQuality: 2 },
-  "nadezhda-org": { trust: 0.8, geometryQuality: 2 },
-  "inspectorat-so-org": { trust: 0.8, geometryQuality: 2 },
+  // Municipality / district websites (non-precomputed, will be geocoded)
+  "sofia-bg": { trust: 0.8 },
+  "rayon-oborishte-bg": { trust: 0.8 },
+  "mladost-bg": { trust: 0.8 },
+  "studentski-bg": { trust: 0.8 },
+  "sredec-sofia-org": { trust: 0.8 },
+  "so-slatina-org": { trust: 0.8 },
+  "lozenets-sofia-bg": { trust: 0.8 },
+  "raioniskar-bg": { trust: 0.8 },
+  "rayon-ilinden-bg": { trust: 0.8 },
+  "rayon-pancharevo-bg": { trust: 0.8 },
+  "triaditsa-org": { trust: 0.8 },
+  "krasna-polyana-org": { trust: 0.8 },
+  "vrabnitsa-org": { trust: 0.8 },
+  "nadezhda-org": { trust: 0.8 },
+  "inspectorat-so-org": { trust: 0.8 },
 };
 
-const DEFAULT_TRUST: SourceTrustEntry = { trust: 0.5, geometryQuality: 0 };
+const DEFAULT_TRUST: SourceTrustEntry = { trust: 0.5 };
 
 /** Get trust configuration for a source. Returns defaults for unknown sources. */
 export function getSourceTrust(source: string): SourceTrustEntry {
   return SOURCE_TRUST[source] ?? DEFAULT_TRUST;
-}
-
-/** Get geometry quality for a source, optionally overridden by precomputed GeoJSON. */
-export function getGeometryQuality(
-  source: string,
-  hasPrecomputedGeoJson: boolean,
-): number {
-  if (hasPrecomputedGeoJson) return 3;
-  return (SOURCE_TRUST[source] ?? DEFAULT_TRUST).geometryQuality;
 }

--- a/ingest/messageIngest/aggregate-quality.test.ts
+++ b/ingest/messageIngest/aggregate-quality.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from "vitest";
+import { aggregateMessageGeometryQuality } from "./aggregate-quality";
+
+describe("aggregateMessageGeometryQuality", () => {
+  it("returns 0 for null geoJson", () => {
+    const quality = aggregateMessageGeometryQuality(null);
+    expect(quality).toBe(0);
+  });
+
+  it("returns 0 for undefined geoJson", () => {
+    const quality = aggregateMessageGeometryQuality(undefined);
+    expect(quality).toBe(0);
+  });
+
+  it("returns 0 for empty features array", () => {
+    const quality = aggregateMessageGeometryQuality({
+      type: "FeatureCollection",
+      features: [],
+    });
+    expect(quality).toBe(0);
+  });
+
+  it("returns quality of single feature", () => {
+    const quality = aggregateMessageGeometryQuality({
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          geometry: { type: "Point", coordinates: [23.32, 42.69] },
+          properties: { geometryQuality: 3, qualityProvider: "precomputed" },
+        },
+      ],
+    });
+    expect(quality).toBe(3);
+  });
+
+  it("returns minimum quality across multiple features (conservative)", () => {
+    const quality = aggregateMessageGeometryQuality({
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          geometry: { type: "Point", coordinates: [23.32, 42.69] },
+          properties: { geometryQuality: 3 },
+        },
+        {
+          type: "Feature",
+          geometry: { type: "Point", coordinates: [23.33, 42.7] },
+          properties: { geometryQuality: 2 },
+        },
+        {
+          type: "Feature",
+          geometry: { type: "Point", coordinates: [23.34, 42.71] },
+          properties: { geometryQuality: 1 },
+        },
+      ],
+    });
+    expect(quality).toBe(1); // min(3, 2, 1) = 1
+  });
+
+  it("returns 0 when features lack geometryQuality property", () => {
+    const quality = aggregateMessageGeometryQuality({
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          geometry: { type: "Point", coordinates: [23.32, 42.69] },
+          properties: { feature_type: "pin" },
+        },
+      ],
+    });
+    expect(quality).toBe(0);
+  });
+
+  it("returns 0 when geometryQuality is not a number", () => {
+    const quality = aggregateMessageGeometryQuality({
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          geometry: { type: "Point", coordinates: [23.32, 42.69] },
+          properties: { geometryQuality: "high" },
+        },
+      ],
+    });
+    expect(quality).toBe(0);
+  });
+
+  it("treats features without geometryQuality as 0 (conservative)", () => {
+    const quality = aggregateMessageGeometryQuality({
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          geometry: { type: "Point", coordinates: [23.32, 42.69] },
+          properties: { feature_type: "pin" }, // no geometryQuality
+        },
+        {
+          type: "Feature",
+          geometry: { type: "Point", coordinates: [23.33, 42.7] },
+          properties: { geometryQuality: 2 },
+        },
+      ],
+    });
+    expect(quality).toBe(0); // missing quality treated as 0 → min(0, 2) = 0
+  });
+
+  it("treats any ungraded feature as 0 (conservative min)", () => {
+    const quality = aggregateMessageGeometryQuality({
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          geometry: { type: "Point", coordinates: [23.32, 42.69] },
+          properties: { geometryQuality: 2 },
+        },
+        {
+          type: "Feature",
+          geometry: { type: "Point", coordinates: [23.33, 42.7] },
+          properties: { feature_type: "street" }, // no geometryQuality → treated as 0
+        },
+        {
+          type: "Feature",
+          geometry: { type: "Point", coordinates: [23.34, 42.71] },
+          properties: { geometryQuality: 1 },
+        },
+      ],
+    });
+    expect(quality).toBe(0); // min(2, 0, 1) = 0
+  });
+
+  it("returns ungradedFallback when all features lack quality stamps (legacy data)", () => {
+    const quality = aggregateMessageGeometryQuality(
+      {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            geometry: { type: "Point", coordinates: [23.32, 42.69] },
+            properties: { feature_type: "pin" },
+          },
+        ],
+      },
+      1,
+    );
+    expect(quality).toBe(1);
+  });
+
+  it("floors non-integer quality values (conservative)", () => {
+    const quality = aggregateMessageGeometryQuality({
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          geometry: { type: "Point", coordinates: [23.32, 42.69] },
+          properties: { geometryQuality: 2.6 },
+        },
+      ],
+    });
+    expect(quality).toBe(2); // Math.floor(2.6) = 2, not 3
+  });
+});

--- a/ingest/messageIngest/aggregate-quality.ts
+++ b/ingest/messageIngest/aggregate-quality.ts
@@ -1,0 +1,47 @@
+import { GeoJsonFeatureCollection } from "@oboapp/shared";
+
+/**
+ * Aggregate geometry quality across all features in a GeoJSON feature collection.
+ *
+ * Uses conservative min() rule: the overall message quality is the minimum quality
+ * of all its features. This ensures we only trust the message at the level of the
+ * weakest link.
+ *
+ * Non-integer quality values are floored (conservative). If no features carry a
+ * quality stamp (legacy / external GeoJSON), `ungradedFallback` is returned instead
+ * of 0 so that existing geometry is not silently degraded.
+ *
+ * @param geoJson - GeoJSON feature collection with geometryQuality in feature.properties
+ * @param ungradedFallback - Value to return when features exist but none are graded (default 0)
+ * @returns Aggregated geometry quality (0–3), or 0 if no features
+ */
+export function aggregateMessageGeometryQuality(
+  geoJson: GeoJsonFeatureCollection | null | undefined,
+  ungradedFallback = 0,
+): number {
+  if (!geoJson || !geoJson.features || geoJson.features.length === 0) {
+    return 0; // No geometry
+  }
+
+  let minQuality: number | null = null;
+  let anyGraded = false;
+
+  for (const feature of geoJson.features) {
+    const quality = feature.properties?.geometryQuality;
+    const isValid = typeof quality === "number" && isFinite(quality);
+    const effectiveQuality = isValid ? Math.min(3, Math.max(0, Math.floor(quality))) : 0;
+    if (isValid) anyGraded = true;
+    if (minQuality === null) {
+      minQuality = effectiveQuality;
+    } else {
+      minQuality = Math.min(minQuality, effectiveQuality);
+    }
+  }
+
+  // Features exist but none carry quality stamps (legacy / external GeoJSON)
+  if (!anyGraded) {
+    return ungradedFallback;
+  }
+
+  return minQuality ?? 0;
+}

--- a/ingest/messageIngest/aggregate-quality.ts
+++ b/ingest/messageIngest/aggregate-quality.ts
@@ -28,9 +28,13 @@ export function aggregateMessageGeometryQuality(
 
   for (const feature of geoJson.features) {
     const quality = feature.properties?.geometryQuality;
+    const hasQualityKey = quality !== undefined;
     const isValid = typeof quality === "number" && isFinite(quality);
     const effectiveQuality = isValid ? Math.min(3, Math.max(0, Math.floor(quality))) : 0;
-    if (isValid) anyGraded = true;
+    // Treat any feature with a geometryQuality key as graded, even if the value is
+    // invalid (string/NaN/Infinity). Invalid values clamp to 0 rather than triggering
+    // the legacy ungradedFallback, preventing corrupt data from appearing high-quality.
+    if (hasQualityKey) anyGraded = true;
     if (minQuality === null) {
       minQuality = effectiveQuality;
     } else {

--- a/ingest/messageIngest/convert-to-geojson.test.ts
+++ b/ingest/messageIngest/convert-to-geojson.test.ts
@@ -232,6 +232,7 @@ describe("convertMessageGeocodingToGeoJson", () => {
     const result = await convertMessageGeocodingToGeoJson(
       extractedData,
       geocodedMap,
+      new Map(),
     );
 
     expect(result).toEqual(mockGeoJson);
@@ -242,6 +243,7 @@ describe("convertMessageGeocodingToGeoJson", () => {
         streets: [{ street: "Main St", from: "A", to: "B", timespans: [] }],
       }),
       geocodedMap,
+      expect.any(Map),
     );
   });
 
@@ -254,7 +256,7 @@ describe("convertMessageGeocodingToGeoJson", () => {
     const geocodedMap = new Map(); // Empty - nothing geocoded
 
     await expect(
-      convertMessageGeocodingToGeoJson(extractedData, geocodedMap),
+      convertMessageGeocodingToGeoJson(extractedData, geocodedMap, new Map()),
     ).resolves.toBeNull();
   });
 
@@ -291,6 +293,7 @@ describe("convertMessageGeocodingToGeoJson", () => {
     const result = await convertMessageGeocodingToGeoJson(
       extractedData,
       geocodedMap,
+      new Map(),
     );
 
     expect(result).toEqual(mockGeoJson);
@@ -301,6 +304,7 @@ describe("convertMessageGeocodingToGeoJson", () => {
         streets: [],
       }),
       geocodedMap,
+      expect.any(Map),
     );
   });
 
@@ -343,6 +347,7 @@ describe("convertMessageGeocodingToGeoJson", () => {
     const result = await convertMessageGeocodingToGeoJson(
       extractedData,
       geocodedMap,
+      new Map(),
       undefined,
       undefined,
       undefined,
@@ -375,8 +380,9 @@ describe("convertMessageGeocodingToGeoJson", () => {
       convertMessageGeocodingToGeoJson(
         extractedData,
         geocodedMap,
-        undefined,
-        [], // no geocoded bus stops
+        new Map(),
+        undefined, // no cadastral geometries
+        undefined, // no geocoded bus stops
       ),
     ).resolves.toBeNull();
   });
@@ -397,10 +403,10 @@ describe("convertMessageGeocodingToGeoJson", () => {
       convertMessageGeocodingToGeoJson(
         extractedData,
         geocodedMap,
+        new Map(),
         undefined,
         undefined,
-        undefined,
-        [], // no geocoded facilities
+        undefined, // no ingest errors
       ),
     ).resolves.toBeNull();
   });
@@ -446,6 +452,7 @@ describe("convertMessageGeocodingToGeoJson", () => {
     await convertMessageGeocodingToGeoJson(
       extractedData,
       geocodedMap,
+      new Map(),
       undefined,
       [], // bus stop not geocoded
       mockRecorder,
@@ -478,6 +485,7 @@ describe("convertMessageGeocodingToGeoJson", () => {
     const result = await convertMessageGeocodingToGeoJson(
       extractedData,
       geocodedMap,
+      new Map(),
       undefined,
       undefined,
       undefined,

--- a/ingest/messageIngest/convert-to-geojson.ts
+++ b/ingest/messageIngest/convert-to-geojson.ts
@@ -1,11 +1,13 @@
 import { convertToGeoJSON } from "@/geocoding/shared/geojson-service";
+import { gradeCadastre } from "@/geocoding/shared/quality";
 import {
   ExtractedLocations,
-  GeoJSONFeatureCollection,
-  GeoJSONFeature,
+  GeoJsonFeatureCollection,
+  GeoJsonFeature,
   Address,
   Coordinates,
-} from "@/lib/types";
+  QualitySignals,
+} from "@oboapp/shared";
 import { validateAndFixGeoJSON } from "../crawlers/shared/geojson-validation";
 import type { CadastralGeometry } from "@/geocoding/cadastre/service";
 import {
@@ -50,11 +52,12 @@ export function validatePinsAndStreetsGeocoded(
 export async function convertMessageGeocodingToGeoJson(
   extractedData: ExtractedLocations | null,
   preGeocodedMap: Map<string, Coordinates>,
+  qualityMap: Map<string, QualitySignals>,
   cadastralGeometries?: Map<string, CadastralGeometry>,
   geocodedBusStops?: Address[],
   ingestErrors?: IngestErrorRecorder,
   geocodedEducationalFacilities?: Address[],
-): Promise<GeoJSONFeatureCollection | null> {
+): Promise<GeoJsonFeatureCollection | null> {
   const recorder = getIngestErrorRecorder(ingestErrors);
   if (!extractedData) {
     return null;
@@ -114,7 +117,10 @@ export async function convertMessageGeocodingToGeoJson(
 
   // Track missing cadastral properties
   const missingCadastral: string[] = [];
-  if (extractedData.cadastralProperties && extractedData.cadastralProperties.length > 0) {
+  if (
+    extractedData.cadastralProperties &&
+    extractedData.cadastralProperties.length > 0
+  ) {
     for (const prop of extractedData.cadastralProperties) {
       if (!cadastralGeometries || !cadastralGeometries.has(prop.identifier)) {
         missingCadastral.push(`УПИ ${prop.identifier}`);
@@ -150,17 +156,30 @@ export async function convertMessageGeocodingToGeoJson(
   if (allMissing.length > 0) {
     const shownParts = [
       filteredData.pins.length > 0 && `${filteredData.pins.length} pins`,
-      filteredData.streets.length > 0 && `${filteredData.streets.length} streets`,
-      geocodedBusStops && geocodedBusStops.length > 0 && `${geocodedBusStops.length} bus stops`,
-      geocodedEducationalFacilities && geocodedEducationalFacilities.length > 0 && `${geocodedEducationalFacilities.length} facilities`,
-      cadastralGeometries && cadastralGeometries.size > 0 && `${cadastralGeometries.size} cadastral`,
-    ].filter(Boolean).join(" + ");
+      filteredData.streets.length > 0 &&
+        `${filteredData.streets.length} streets`,
+      geocodedBusStops &&
+        geocodedBusStops.length > 0 &&
+        `${geocodedBusStops.length} bus stops`,
+      geocodedEducationalFacilities &&
+        geocodedEducationalFacilities.length > 0 &&
+        `${geocodedEducationalFacilities.length} facilities`,
+      cadastralGeometries &&
+        cadastralGeometries.size > 0 &&
+        `${cadastralGeometries.size} cadastral`,
+    ]
+      .filter(Boolean)
+      .join(" + ");
     recorder.warn(
       `⚠️  Partial geocoding: ${allMissing.length} locations failed (showing ${shownParts}): ${allMissing.join(", ")}`,
     );
   }
 
-  const geoJson = await convertToGeoJSON(filteredData, preGeocodedMap);
+  const geoJson = await convertToGeoJSON(
+    filteredData,
+    preGeocodedMap,
+    qualityMap,
+  );
 
   // Add cadastral property features
   if (
@@ -168,12 +187,13 @@ export async function convertMessageGeocodingToGeoJson(
     cadastralGeometries.size > 0 &&
     extractedData.cadastralProperties
   ) {
-    const cadastralFeatures: GeoJSONFeature[] = [];
+    const cadastralFeatures: GeoJsonFeature[] = [];
 
     for (const cadastralProp of extractedData.cadastralProperties) {
       const geometry = cadastralGeometries.get(cadastralProp.identifier);
 
       if (geometry) {
+        const cadastreQuality = gradeCadastre();
         cadastralFeatures.push({
           type: "Feature",
           geometry: {
@@ -187,6 +207,9 @@ export async function convertMessageGeocodingToGeoJson(
             start_time: cadastralProp.timespans[0]?.start || "",
             end_time: cadastralProp.timespans[0]?.end || "",
             timespans: JSON.stringify(cadastralProp.timespans),
+            geometryQuality: cadastreQuality.geometryQuality,
+            qualityProvider: cadastreQuality.provider,
+            qualitySignals: cadastreQuality,
           },
         });
       } else {
@@ -211,7 +234,7 @@ export async function convertMessageGeocodingToGeoJson(
 
   // Add bus stop features
   if (geocodedBusStops && geocodedBusStops.length > 0) {
-    const busStopFeatures: GeoJSONFeature[] = geocodedBusStops.map((stop) => ({
+    const busStopFeatures: GeoJsonFeature[] = geocodedBusStops.map((stop) => ({
       type: "Feature",
       geometry: {
         type: "Point",
@@ -222,6 +245,11 @@ export async function convertMessageGeocodingToGeoJson(
         locationType: "bus_stop",
         stop_code: stop.originalText.replace("Спирка ", ""),
         stop_name: stop.formattedAddress,
+        ...(stop.qualitySignals && {
+          geometryQuality: stop.qualitySignals.geometryQuality,
+          qualityProvider: stop.qualitySignals.provider,
+          qualitySignals: stop.qualitySignals,
+        }),
       },
     }));
 
@@ -237,9 +265,12 @@ export async function convertMessageGeocodingToGeoJson(
   }
 
   // Add educational facility features
-  if (geocodedEducationalFacilities && geocodedEducationalFacilities.length > 0) {
-    const facilityFeatures: GeoJSONFeature[] = geocodedEducationalFacilities.map(
-      (facility) => {
+  if (
+    geocodedEducationalFacilities &&
+    geocodedEducationalFacilities.length > 0
+  ) {
+    const educationFeatures: GeoJsonFeature[] =
+      geocodedEducationalFacilities.map((facility: Address) => {
         // originalText format: "Учебно заведение {type}:{number}"
         const typeAndNumber = facility.originalText.replace(
           EDUCATIONAL_FACILITY_PREFIX,
@@ -252,9 +283,9 @@ export async function convertMessageGeocodingToGeoJson(
           colonIdx !== -1 ? typeAndNumber.slice(colonIdx + 1) : typeAndNumber;
 
         return {
-          type: "Feature",
+          type: "Feature" as const,
           geometry: {
-            type: "Point",
+            type: "Point" as const,
             coordinates: [facility.coordinates.lng, facility.coordinates.lat],
           },
           properties: {
@@ -263,18 +294,22 @@ export async function convertMessageGeocodingToGeoJson(
             facility_type: facilityType,
             facility_number: facilityNumber,
             facility_name: facility.formattedAddress,
+            ...(facility.qualitySignals && {
+              geometryQuality: facility.qualitySignals.geometryQuality,
+              qualityProvider: facility.qualitySignals.provider,
+              qualitySignals: facility.qualitySignals,
+            }),
           },
         };
-      },
-    );
+      });
 
     if (geoJson) {
-      geoJson.features.push(...facilityFeatures);
+      geoJson.features.push(...educationFeatures);
     } else {
       // Only educational facility features
       return {
         type: "FeatureCollection",
-        features: facilityFeatures,
+        features: educationFeatures,
       };
     }
   }

--- a/ingest/messageIngest/geocode-addresses.ts
+++ b/ingest/messageIngest/geocode-addresses.ts
@@ -17,12 +17,13 @@ import {
   Coordinates,
   QualitySignals,
   QUALITY_PROVIDERS,
+  isWithinBounds,
+  normalizePinAddress,
 } from "@oboapp/shared";
 import type { Feature, MultiLineString } from "geojson";
 import type { CadastralGeometry } from "@/geocoding/cadastre/service";
 import type { IngestErrorRecorder } from "@/lib/ingest-errors";
 import { logger } from "@/lib/logger";
-import { isWithinBounds, normalizePinAddress } from "@oboapp/shared";
 import { getLocality } from "@/lib/target-locality";
 import { roundCoordinate } from "@/geocoding/shared/coordinate-utils";
 import { gradeOverpass } from "@/geocoding/shared/quality";

--- a/ingest/messageIngest/geocode-addresses.ts
+++ b/ingest/messageIngest/geocode-addresses.ts
@@ -187,6 +187,7 @@ export function findMissingStreetEndpoints(
 export function createAddressFromCoordinates(
   text: string,
   coordinates: Coordinates,
+  qualitySignals?: QualitySignals,
 ): Address {
   return {
     originalText: text,
@@ -196,6 +197,7 @@ export function createAddressFromCoordinates(
       type: "Point",
       coordinates: [coordinates.lng, coordinates.lat],
     },
+    ...(qualitySignals && { qualitySignals }),
   };
 }
 
@@ -230,7 +232,10 @@ function processPinsWithPreResolvedCoordinates(
           geometryQuality: 1,
         });
         addresses.push(
-          createAddressFromCoordinates(pin.address, validatedCoords),
+          createAddressFromCoordinates(pin.address, validatedCoords, {
+            provider: QUALITY_PROVIDERS.SOURCE,
+            geometryQuality: 1,
+          }),
         );
       } else {
         logger.warn("Invalid geotagged coordinates for pin, will geocode", {
@@ -311,7 +316,12 @@ function processStreetEndpoint(
       provider: QUALITY_PROVIDERS.SOURCE,
       geometryQuality: 1,
     });
-    addresses.push(createAddressFromCoordinates(endpointName, validatedCoords));
+    addresses.push(
+      createAddressFromCoordinates(endpointName, validatedCoords, {
+        provider: QUALITY_PROVIDERS.SOURCE,
+        geometryQuality: 1,
+      }),
+    );
   } else {
     logger.warn(
       "Invalid geotagged coordinates for street endpoint, will geocode",
@@ -492,8 +502,9 @@ async function geocodeStreetIntersections(
         if (!preGeocodedMap.has(key)) {
           preGeocodedMap.set(key, coords);
           // Intersection points from Overpass: tier 1 (node-level, not full way geometry)
-          qualityMap.set(key, gradeOverpass("node"));
-          addresses.push(createAddressFromCoordinates(key, coords));
+          const qualitySignals = gradeOverpass("node");
+          qualityMap.set(key, qualitySignals);
+          addresses.push(createAddressFromCoordinates(key, coords, qualitySignals));
         }
       });
 

--- a/ingest/messageIngest/geocode-addresses.ts
+++ b/ingest/messageIngest/geocode-addresses.ts
@@ -15,7 +15,9 @@ import {
   ExtractedLocations,
   StreetSection,
   Coordinates,
-} from "@/lib/types";
+  QualitySignals,
+  QUALITY_PROVIDERS,
+} from "@oboapp/shared";
 import type { Feature, MultiLineString } from "geojson";
 import type { CadastralGeometry } from "@/geocoding/cadastre/service";
 import type { IngestErrorRecorder } from "@/lib/ingest-errors";
@@ -23,11 +25,13 @@ import { logger } from "@/lib/logger";
 import { isWithinBounds, normalizePinAddress } from "@oboapp/shared";
 import { getLocality } from "@/lib/target-locality";
 import { roundCoordinate } from "@/geocoding/shared/coordinate-utils";
+import { gradeOverpass } from "@/geocoding/shared/quality";
 import type { GeocodingProgressTracker } from "./geocoding-progress-tracker";
 
 // Internal types for the geocoding pipeline
 export interface GeocodingResult {
   preGeocodedMap: Map<string, Coordinates>;
+  qualityMap: Map<string, QualitySignals>;
   addresses: Address[];
   cadastralGeometries?: Map<string, CadastralGeometry>;
 }
@@ -206,6 +210,7 @@ function processPinsWithPreResolvedCoordinates(
     timespans: Array<{ start: string | null; end: string | null }>;
   }>,
   preGeocodedMap: Map<string, Coordinates>,
+  qualityMap: Map<string, QualitySignals>,
   addresses: Address[],
 ): string[] {
   const pinsToGeocode: string[] = [];
@@ -219,6 +224,11 @@ function processPinsWithPreResolvedCoordinates(
 
       if (validatedCoords) {
         preGeocodedMap.set(pin.address, validatedCoords);
+        // Pre-geotagged coordinates from source: tier 1 (approximate/source-provided)
+        qualityMap.set(pin.address, {
+          provider: QUALITY_PROVIDERS.SOURCE,
+          geometryQuality: 1,
+        });
         addresses.push(
           createAddressFromCoordinates(pin.address, validatedCoords),
         );
@@ -243,6 +253,7 @@ function processPinsWithPreResolvedCoordinates(
 async function geocodePins(
   extractedData: ExtractedLocations,
   preGeocodedMap: Map<string, Coordinates>,
+  qualityMap: Map<string, QualitySignals>,
   addresses: Address[],
   tracker?: GeocodingProgressTracker,
 ): Promise<void> {
@@ -253,6 +264,7 @@ async function geocodePins(
   const pinsToGeocode = processPinsWithPreResolvedCoordinates(
     extractedData.pins,
     preGeocodedMap,
+    qualityMap,
     addresses,
   );
 
@@ -262,6 +274,9 @@ async function geocodePins(
 
     geocodedPins.forEach((addr) => {
       preGeocodedMap.set(addr.originalText, addr.coordinates);
+      if (addr.qualitySignals) {
+        qualityMap.set(addr.originalText, addr.qualitySignals);
+      }
     });
   }
 
@@ -281,6 +296,7 @@ function processStreetEndpoint(
   endpointCoordinates: Coordinates,
   direction: "from" | "to",
   preGeocodedMap: Map<string, Coordinates>,
+  qualityMap: Map<string, QualitySignals>,
   addresses: Address[],
 ): void {
   const validatedCoords = getValidPreResolvedCoordinates(
@@ -290,6 +306,11 @@ function processStreetEndpoint(
 
   if (validatedCoords) {
     preGeocodedMap.set(endpointName, validatedCoords);
+    // Pre-geotagged street endpoints: tier 1 (source-provided)
+    qualityMap.set(endpointName, {
+      provider: QUALITY_PROVIDERS.SOURCE,
+      geometryQuality: 1,
+    });
     addresses.push(createAddressFromCoordinates(endpointName, validatedCoords));
   } else {
     logger.warn(
@@ -309,6 +330,7 @@ function processStreetEndpoint(
 function processStreetEndpointsWithPreResolvedCoordinates(
   streets: StreetSection[],
   preGeocodedMap: Map<string, Coordinates>,
+  qualityMap: Map<string, QualitySignals>,
   addresses: Address[],
 ): void {
   for (const street of streets) {
@@ -319,6 +341,7 @@ function processStreetEndpointsWithPreResolvedCoordinates(
         street.fromCoordinates,
         "from",
         preGeocodedMap,
+        qualityMap,
         addresses,
       );
     }
@@ -330,6 +353,7 @@ function processStreetEndpointsWithPreResolvedCoordinates(
         street.toCoordinates,
         "to",
         preGeocodedMap,
+        qualityMap,
         addresses,
       );
     }
@@ -348,7 +372,9 @@ async function recordStreetGeometryInTracker(
   tracker: GeocodingProgressTracker,
   fetchers: {
     getStreetGeometryCached: (name: string) => Feature<MultiLineString> | null;
-    getStreetGeometryFromOverpass: (name: string) => Promise<Feature<MultiLineString> | null>;
+    getStreetGeometryFromOverpass: (
+      name: string,
+    ) => Promise<Feature<MultiLineString> | null>;
     hasStreetGeometryQueried: (name: string) => boolean;
   },
   beforeFetch?: () => Promise<void>,
@@ -397,6 +423,7 @@ async function recordStreetGeometryInTracker(
 async function geocodeStreetIntersections(
   extractedData: ExtractedLocations,
   preGeocodedMap: Map<string, Coordinates>,
+  qualityMap: Map<string, QualitySignals>,
   addresses: Address[],
   tracker?: GeocodingProgressTracker,
 ): Promise<void> {
@@ -406,6 +433,7 @@ async function geocodeStreetIntersections(
   processStreetEndpointsWithPreResolvedCoordinates(
     extractedData.streets,
     preGeocodedMap,
+    qualityMap,
     addresses,
   );
 
@@ -414,7 +442,8 @@ async function geocodeStreetIntersections(
   // preGeocodedMap. Streets with invalid geotagged coordinates (rejected by bounds
   // validation) will not have their endpoints in the map and will not appear here.
   const fullyPreResolvedStreets = extractedData.streets.filter(
-    (street) => preGeocodedMap.has(street.from) && preGeocodedMap.has(street.to),
+    (street) =>
+      preGeocodedMap.has(street.from) && preGeocodedMap.has(street.to),
   );
 
   // Import Overpass service only when a tracker is active — these fetchers are only used
@@ -462,6 +491,8 @@ async function geocodeStreetIntersections(
       streetGeocodedMap.forEach((coords, key) => {
         if (!preGeocodedMap.has(key)) {
           preGeocodedMap.set(key, coords);
+          // Intersection points from Overpass: tier 1 (node-level, not full way geometry)
+          qualityMap.set(key, gradeOverpass("node"));
           addresses.push(createAddressFromCoordinates(key, coords));
         }
       });
@@ -512,6 +543,9 @@ async function geocodeStreetIntersections(
     const fallbackGeocoded = await overpassGeocodeAddresses(missingEndpoints);
     fallbackGeocoded.forEach((addr) => {
       preGeocodedMap.set(addr.originalText, addr.coordinates);
+      if (addr.qualitySignals) {
+        qualityMap.set(addr.originalText, addr.qualitySignals);
+      }
       addresses.push(addr);
     });
   }
@@ -552,6 +586,7 @@ async function geocodeCadastralProperties(
 async function geocodeBusStopsFromExtractedData(
   extractedData: ExtractedLocations,
   preGeocodedMap: Map<string, Coordinates>,
+  qualityMap: Map<string, QualitySignals>,
   addresses: Address[],
   tracker?: GeocodingProgressTracker,
 ): Promise<void> {
@@ -564,6 +599,9 @@ async function geocodeBusStopsFromExtractedData(
 
   geocodedBusStops.forEach((addr) => {
     preGeocodedMap.set(addr.originalText, addr.coordinates);
+    if (addr.qualitySignals) {
+      qualityMap.set(addr.originalText, addr.qualitySignals);
+    }
   });
 
   logger.info("Geocoded bus stops", {
@@ -580,6 +618,7 @@ async function geocodeBusStopsFromExtractedData(
 async function geocodeEducationalFacilitiesFromExtractedData(
   extractedData: ExtractedLocations,
   preGeocodedMap: Map<string, Coordinates>,
+  qualityMap: Map<string, QualitySignals>,
   addresses: Address[],
   ingestErrors?: IngestErrorRecorder,
   tracker?: GeocodingProgressTracker,
@@ -599,6 +638,9 @@ async function geocodeEducationalFacilitiesFromExtractedData(
 
   geocoded.forEach((addr) => {
     preGeocodedMap.set(addr.originalText, addr.coordinates);
+    if (addr.qualitySignals) {
+      qualityMap.set(addr.originalText, addr.qualitySignals);
+    }
   });
 
   tracker?.recordAttempted(extractedData.educationalFacilities.length);
@@ -615,10 +657,11 @@ export async function geocodeAddressesFromExtractedData(
   tracker?: GeocodingProgressTracker,
 ): Promise<GeocodingResult> {
   const preGeocodedMap = new Map<string, Coordinates>();
+  const qualityMap = new Map<string, QualitySignals>();
   const addresses: Address[] = [];
 
   if (!extractedData) {
-    return { preGeocodedMap, addresses };
+    return { preGeocodedMap, qualityMap, addresses };
   }
 
   // Pre-populate in-memory street geometry cache from DB (no-op after first call)
@@ -626,17 +669,46 @@ export async function geocodeAddressesFromExtractedData(
   await seedStreetCacheFromDb();
 
   // Geocode each location type using specialized services
-  await geocodePins(extractedData, preGeocodedMap, addresses, tracker);
-  await geocodeStreetIntersections(extractedData, preGeocodedMap, addresses, tracker);
-  const cadastralGeometries = await geocodeCadastralProperties(extractedData, tracker);
-  await geocodeBusStopsFromExtractedData(extractedData, preGeocodedMap, addresses, tracker);
-  await geocodeEducationalFacilitiesFromExtractedData(extractedData, preGeocodedMap, addresses, ingestErrors, tracker);
+  await geocodePins(
+    extractedData,
+    preGeocodedMap,
+    qualityMap,
+    addresses,
+    tracker,
+  );
+  await geocodeStreetIntersections(
+    extractedData,
+    preGeocodedMap,
+    qualityMap,
+    addresses,
+    tracker,
+  );
+  const cadastralGeometries = await geocodeCadastralProperties(
+    extractedData,
+    tracker,
+  );
+  await geocodeBusStopsFromExtractedData(
+    extractedData,
+    preGeocodedMap,
+    qualityMap,
+    addresses,
+    tracker,
+  );
+  await geocodeEducationalFacilitiesFromExtractedData(
+    extractedData,
+    preGeocodedMap,
+    qualityMap,
+    addresses,
+    ingestErrors,
+    tracker,
+  );
 
   // Deduplicate addresses before returning
   const deduplicatedAddresses = deduplicateAddresses(addresses);
 
   return {
     preGeocodedMap,
+    qualityMap,
     addresses: deduplicatedAddresses,
     cadastralGeometries,
   };

--- a/ingest/messageIngest/index.ts
+++ b/ingest/messageIngest/index.ts
@@ -1,10 +1,11 @@
 import {
   Address,
   ExtractedLocations,
-  GeoJSONFeatureCollection,
+  GeoJsonFeatureCollection,
   InternalMessage,
   Coordinates,
-} from "@/lib/types";
+  QualitySignals,
+} from "@oboapp/shared";
 import type { FilteredMessage } from "@/lib/filter-split.schema";
 import type { CadastralGeometry } from "@/geocoding/cadastre/service";
 import {
@@ -22,6 +23,8 @@ import {
 } from "./geocoding-progress-tracker";
 import { logger } from "@/lib/logger";
 import { getLocality } from "@/lib/target-locality";
+import { getSourceTrust } from "@/lib/source-trust";
+import { gradePrecomputed } from "@/geocoding/shared/quality";
 import {
   getString,
   getOptionalString,
@@ -46,7 +49,7 @@ export interface MessageIngestOptions {
    * Provide ready GeoJSON geometry to skip AI extraction + geocoding.
    * Used by crawlers or integrations with pre-geocoded data.
    */
-  precomputedGeoJson?: GeoJSONFeatureCollection | null;
+  precomputedGeoJson?: GeoJsonFeatureCollection | null;
   /**
    * Optional source URL for the message (e.g., original article URL).
    * Used as the user-facing link in message detail view.
@@ -61,7 +64,7 @@ export interface MessageIngestOptions {
    * Optional boundary filtering - if provided, only features within boundaries are kept
    * If no features are within boundaries, the message is not stored
    */
-  boundaryFilter?: GeoJSONFeatureCollection;
+  boundaryFilter?: GeoJsonFeatureCollection;
   /**
    * Optional crawledAt timestamp from the source document
    */
@@ -146,7 +149,7 @@ export async function messageIngest(
 async function processSingleMessage(
   messageId: string,
   text: string,
-  precomputedGeoJson: GeoJSONFeatureCollection | null,
+  precomputedGeoJson: GeoJsonFeatureCollection | null,
   options: MessageIngestOptions,
   extractedLocations: ExtractedLocations | null,
   ingestErrors: IngestErrorCollector,
@@ -164,7 +167,7 @@ async function processSingleMessage(
   }
 
   let addresses: Address[] = [];
-  let geoJson: GeoJSONFeatureCollection | null = precomputedGeoJson;
+  let geoJson: GeoJsonFeatureCollection | null = precomputedGeoJson;
 
   // Handle precomputed GeoJSON path
   if (precomputedGeoJson) {
@@ -284,10 +287,30 @@ async function processPrecomputedGeoJsonMessage(
     precomputedIngestErrors,
   );
 
+  // Annotate each precomputed feature with geometryQuality derived from source trust
+  const { trust } = getSourceTrust(source);
+  const precomputedQuality = gradePrecomputed(trust);
+  const annotatedGeoJson = options.precomputedGeoJson
+    ? {
+        ...options.precomputedGeoJson,
+        features: options.precomputedGeoJson.features.map((f) => ({
+          ...f,
+          properties: {
+            ...f.properties,
+            geometryQuality:
+              f.properties?.geometryQuality ??
+              precomputedQuality.geometryQuality,
+            qualityProvider:
+              f.properties?.qualityProvider ?? precomputedQuality.provider,
+          },
+        })),
+      }
+    : options.precomputedGeoJson;
+
   const message = await processSingleMessage(
     storedMessageId,
     text,
-    options.precomputedGeoJson || null,
+    annotatedGeoJson || null,
     options,
     null,
     precomputedIngestErrors,
@@ -728,7 +751,7 @@ async function performGeocodingWithErrorHandling(
   ingestErrors: IngestErrorCollector,
 ): Promise<{
   addresses: Address[];
-  geoJson: GeoJSONFeatureCollection | null;
+  geoJson: GeoJsonFeatureCollection | null;
 } | null> {
   const totalLocations =
     (extractedLocations.pins?.length ?? 0) +
@@ -771,6 +794,7 @@ async function performGeocodingWithErrorHandling(
     const geoJson = await convertToGeoJson(
       extractedLocations,
       geocodingResult.preGeocodedMap,
+      geocodingResult.qualityMap,
       geocodingResult.cadastralGeometries,
       geocodedBusStops,
       ingestErrors,
@@ -843,16 +867,18 @@ async function filterAndStoreAddresses(
 async function convertToGeoJson(
   extractedLocations: ExtractedLocations,
   preGeocodedMap: Map<string, Coordinates>,
+  qualityMap: Map<string, QualitySignals>,
   cadastralGeometries: Map<string, CadastralGeometry> | undefined,
   geocodedBusStops?: Address[],
   ingestErrors?: IngestErrorRecorder,
   geocodedEducationalFacilities?: Address[],
-): Promise<GeoJSONFeatureCollection | null> {
+): Promise<GeoJsonFeatureCollection | null> {
   const { convertMessageGeocodingToGeoJson } =
     await import("./convert-to-geojson");
   return await convertMessageGeocodingToGeoJson(
     extractedLocations,
     preGeocodedMap,
+    qualityMap,
     cadastralGeometries,
     geocodedBusStops,
     ingestErrors,
@@ -888,7 +914,7 @@ async function finalizeFailedMessage(
  * Exported for unit testing.
  */
 export function computeGeoJsonCentroidAddress(
-  geoJson: GeoJSONFeatureCollection,
+  geoJson: GeoJsonFeatureCollection,
 ): Address | null {
   const features = geoJson.features;
   if (!features || features.length === 0) return null;
@@ -961,7 +987,7 @@ export function computeGeoJsonCentroidAddress(
  */
 async function handlePrecomputedGeoJsonData(
   messageId: string,
-  precomputedGeoJson: GeoJSONFeatureCollection,
+  precomputedGeoJson: GeoJsonFeatureCollection,
   markdownText: string | undefined,
   timespanStart: Date | undefined,
   timespanEnd: Date | undefined,
@@ -976,7 +1002,12 @@ async function handlePrecomputedGeoJsonData(
   const { validateAndFallback } = await import("@/lib/timespan-utils");
   const validated = validateAndFallback(timespanStart, timespanEnd, crawledAt);
 
-  const locationFields = { addresses, pins, streets: [], cadastralProperties: [] };
+  const locationFields = {
+    addresses,
+    pins,
+    streets: [],
+    cadastralProperties: [],
+  };
 
   if (markdownText) {
     await updateMessage(messageId, {
@@ -1013,9 +1044,9 @@ class BoundaryFilterRejectedError extends Error {
  */
 async function applyBoundaryFilteringIfNeeded(
   messageId: string,
-  geoJson: GeoJSONFeatureCollection | null,
-  boundaryFilter: GeoJSONFeatureCollection | undefined,
-): Promise<GeoJSONFeatureCollection | null> {
+  geoJson: GeoJsonFeatureCollection | null,
+  boundaryFilter: GeoJsonFeatureCollection | undefined,
+): Promise<GeoJsonFeatureCollection | null> {
   if (!boundaryFilter || !geoJson) {
     return geoJson;
   }
@@ -1039,7 +1070,7 @@ async function applyBoundaryFilteringIfNeeded(
  */
 async function finalizeMessageWithResults(
   messageId: string,
-  geoJson: GeoJSONFeatureCollection | null,
+  geoJson: GeoJsonFeatureCollection | null,
   ingestErrors: IngestErrorCollector,
 ): Promise<void> {
   if (!geoJson) {

--- a/shared/src/schema/address.schema.ts
+++ b/shared/src/schema/address.schema.ts
@@ -2,11 +2,71 @@ import { z } from "../zod-openapi";
 import { CoordinatesSchema } from "./coordinates.schema";
 import { GeoJsonPointSchema } from "./geojson.schema";
 
+/**
+ * Google Geocoding API location types.
+ * Reference: https://developers.google.com/maps/documentation/geocoding/overview
+ */
+export const GOOGLE_LOCATION_TYPES = {
+  ROOFTOP: "ROOFTOP",
+  RANGE_INTERPOLATED: "RANGE_INTERPOLATED",
+  GEOMETRIC_CENTER: "GEOMETRIC_CENTER",
+  APPROXIMATE: "APPROXIMATE",
+} as const;
+
+export type GoogleLocationType =
+  (typeof GOOGLE_LOCATION_TYPES)[keyof typeof GOOGLE_LOCATION_TYPES];
+
+export const QUALITY_PROVIDERS = {
+  GOOGLE: "google",
+  OVERPASS: "overpass",
+  CADASTRE: "cadastre",
+  GTFS: "gtfs",
+  EDUCATIONAL: "educational",
+  PRECOMPUTED: "precomputed",
+  SOURCE: "source",
+  STREET: "street",
+} as const;
+
+export type QualityProvider = (typeof QUALITY_PROVIDERS)[keyof typeof QUALITY_PROVIDERS];
+
+export const OSM_ELEMENT_TYPES = {
+  NODE: "node",
+  WAY: "way",
+  RELATION: "relation",
+} as const;
+
+export type OsmElementType = (typeof OSM_ELEMENT_TYPES)[keyof typeof OSM_ELEMENT_TYPES];
+
+export const QualitySignalsSchema = z.object({
+  provider: z.enum([
+    QUALITY_PROVIDERS.GOOGLE,
+    QUALITY_PROVIDERS.OVERPASS,
+    QUALITY_PROVIDERS.CADASTRE,
+    QUALITY_PROVIDERS.GTFS,
+    QUALITY_PROVIDERS.EDUCATIONAL,
+    QUALITY_PROVIDERS.PRECOMPUTED,
+    QUALITY_PROVIDERS.SOURCE,
+    QUALITY_PROVIDERS.STREET,
+  ]),
+  locationType: z.enum([
+    GOOGLE_LOCATION_TYPES.ROOFTOP,
+    GOOGLE_LOCATION_TYPES.RANGE_INTERPOLATED,
+    GOOGLE_LOCATION_TYPES.GEOMETRIC_CENTER,
+    GOOGLE_LOCATION_TYPES.APPROXIMATE,
+  ]).optional(),
+  partialMatch: z.boolean().optional(),
+  osmElementType: z.enum([OSM_ELEMENT_TYPES.NODE, OSM_ELEMENT_TYPES.WAY, OSM_ELEMENT_TYPES.RELATION]).optional(),
+  geometryQuality: z.number().int().min(0).max(3),
+});
+
+export type QualitySignals = z.infer<typeof QualitySignalsSchema>;
+
 export const AddressSchema = z.object({
   originalText: z.string(),
   formattedAddress: z.string(),
   coordinates: CoordinatesSchema,
   geoJson: GeoJsonPointSchema.optional(),
+  qualitySignals: QualitySignalsSchema.optional(),
 });
 
 export type Address = z.infer<typeof AddressSchema>;

--- a/shared/src/schema/geojson.schema.ts
+++ b/shared/src/schema/geojson.schema.ts
@@ -27,6 +27,16 @@ export const GeoJsonGeometrySchema = z.discriminatedUnion("type", [
   GeoJsonPolygonSchema,
 ]);
 
+/**
+ * GeoJSON Feature with flexible properties
+ *
+ * Standard properties (when present):
+ * - `geometryQuality` (number, 0–3): Per-feature geometry precision grade
+ * - `qualityProvider` (string): The geocoding provider (google, overpass, cadastre, gtfs, educational, precomputed, source, street)
+ * - `qualitySignals` (object): Diagnostic metadata (locationType, partialMatch, osmElementType, etc.)
+ * - `feature_type` (string): Pin, street_closure, cadastral, bus_stop, educational, etc.
+ * - Other properties are application-specific
+ */
 export const GeoJsonFeatureSchema = z.object({
   type: z.literal("Feature"),
   geometry: GeoJsonGeometrySchema,

--- a/web/lib/v1-api-schema.ts
+++ b/web/lib/v1-api-schema.ts
@@ -5,7 +5,20 @@ import {
   OpenApiGeneratorV3,
 } from "@asteasolutions/zod-to-openapi";
 import type { OpenAPIObject } from "openapi3-ts/oas30";
-import { MessageSchema, SourceSchema } from "@oboapp/shared";
+import {
+  MessageSchema as SharedMessageSchema,
+  AddressSchema as SharedAddressSchema,
+  SourceSchema,
+} from "@oboapp/shared";
+
+// Public API contract — intentionally strips internal geocoding signals (qualitySignals)
+// so that changes to internal quality schemas don't silently alter the public API contract.
+const PublicAddressSchema = SharedAddressSchema.omit({
+  qualitySignals: true,
+});
+const MessageSchema = SharedMessageSchema.extend({
+  addresses: z.array(PublicAddressSchema).optional(),
+});
 
 const ErrorResponseSchema = z.object({
   error: z.string(),


### PR DESCRIPTION
Closes #322

## Summary

Replaces the static per-source `geometryQuality` field in `source-trust.ts` with deterministic per-feature scores derived from actual geocoder output. Decouples **source trust** (metadata reliability, 0–1) from **geometry quality** (location precision, 0–3).

## Quality tier system

| Score | Meaning | Examples |
|-------|---------|---------|
| 3 | Authoritative | Google ROOFTOP, cadastral polygon, GTFS stop, official precomputed GeoJSON (trust ≥ 0.9) |
| 2 | Address-level | Google RANGE_INTERPOLATED / GEOMETRIC_CENTER, Overpass way geometry, precomputed (trust < 0.9) |
| 1 | Approximate | Google APPROXIMATE, Overpass node/relation, source-provided coords, legacy ungraded geometry |
| 0 | None | No geometry, city-wide incident |

Street closures use `min()` across both endpoint qualities (conservative).

## New files

- `ingest/geocoding/shared/quality.ts` — pure `gradeGoogle()`, `gradeOverpass()`, `gradeCadastre()`, `gradeGtfs()`, `gradePrecomputed()`, `gradeUnknown()` helpers
- `ingest/messageIngest/aggregate-quality.ts` — `aggregateMessageGeometryQuality()` using `min()` across features; floors non-integer values; `ungradedFallback` param for legacy GeoJSON
- `ingest/messageIngest/aggregate-quality.test.ts` — 11 unit tests

## Key decisions

- **Tier 3 reserved for authoritative only** — Overpass `way` geometry caps at tier 2
- **Legacy GeoJSON** — call sites pass `ungradedFallback=1` so existing events with ungraded geometry aren't silently downgraded to 0
- **Public API unchanged** — `qualitySignals` stripped from v1 schema; internal quality fields stay internal
- **`SourceTrustEntry.precomputed` removed** — precomputed detection now done via `options.precomputedGeoJson` at ingest time; no duplicate config

## Checklist

- [x] `pnpm build` (shared)
- [x] `pnpm tsc --noEmit` (ingest, web, api)
- [x] `pnpm test:run` — 1273 tests, all passing
- [x] `pnpm lint` (ingest)