### PR TITLE
feat: make sources forkable - split into per-source files

### DIFF
--- a/.claude/skills/long-flow-crawler-generator/SKILL.md
+++ b/.claude/skills/long-flow-crawler-generator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: long-flow-crawler-generator
-description: Generate WordPress-style crawlers for Sofia public infrastructure disruption sources
+description: Generate WordPress-style crawlers for public infrastructure disruption sources
 agent-name: copilot
 version: 1.0.0
 keywords:
@@ -213,11 +213,11 @@ Include:
 
 ## Phase 6: Front-End Integration
 
-Add the new source to `shared/src/sources.ts` (`SOURCES` array):
+Create the source definition file and register it in the instance assembly:
 
-- Read existing entries to understand the `SourceDefinition` interface
-- Add entry with matching `id`, `url`, `name`, and `localities`
-- Add logo at `web/public/sources/{{source-name}}.png`
+1. Create `shared/src/sources/{source-name}.ts` — use `export default` for the `SourceDefinition` object (so the importer can choose the local name). Include `id`, `url`, `name`, `localities`. If this is an emergent crawler (30-min interval), add `emergent: true`.
+2. In `shared/src/sources.ts`, import the default export under a descriptive local name and add it to the `SOURCES` array. `EMERGENT_CRAWLERS` is derived automatically from the `emergent` flag — no separate list to update.
+3. Add logo at `web/public/sources/{{source-name}}.png`
 
 ## Critical Rules from AGENTS.md
 

--- a/.github/skills/long-flow-crawler-generator/SKILL.md
+++ b/.github/skills/long-flow-crawler-generator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: long-flow-crawler-generator
-description: Generate WordPress-style crawlers for Sofia public infrastructure disruption sources
+description: Generate WordPress-style crawlers for public infrastructure disruption sources
 agent-name: copilot
 version: 1.0.0
 keywords:
@@ -213,11 +213,11 @@ Include:
 
 ## Phase 6: Front-End Integration
 
-Add the new source to `shared/src/sources.ts` (`SOURCES` array):
+Create the source definition file and register it in the instance assembly:
 
-- Read existing entries to understand the `SourceDefinition` interface
-- Add entry with matching `id`, `url`, `name`, and `localities`
-- Add logo at `web/public/sources/{{source-name}}.png`
+1. Create `shared/src/sources/{source-name}.ts` — use `export default` for the `SourceDefinition` object (so the importer can choose the local name). Include `id`, `url`, `name`, `localities`. If this is an emergent crawler (30-min interval), add `emergent: true`.
+2. In `shared/src/sources.ts`, import the default export under a descriptive local name and add it to the `SOURCES` array. `EMERGENT_CRAWLERS` is derived automatically from the `emergent` flag — no separate list to update.
+3. Add logo at `web/public/sources/{{source-name}}.png`
 
 ## Critical Rules from AGENTS.md
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,7 @@ Always use `pnpm add` (or `pnpm add -D`), never edit `package.json` directly.
 
 ### Message Ingestion Pipeline
 
-The pipeline processes public infrastructure disruption messages for Sofia, Bulgaria. Crawlers with precomputed GeoJSON skip AI processing entirely. Others go through three LLM stages: **Filter & Split → Categorize → Extract Locations**, then geocoding and event matching.
+The pipeline processes public infrastructure disruption messages. Crawlers with precomputed GeoJSON skip AI processing entirely. Others go through three LLM stages: **Filter & Split → Categorize → Extract Locations**, then geocoding and event matching.
 
 See `ingest/README.md` for the full pipeline overview and `ingest/messageIngest/README.md` for stage details.
 
@@ -101,10 +101,26 @@ For the full implementation guide, see the `long-flow-crawler-generator` skill. 
 - **Workflow Sync (CRITICAL):** When adding/removing crawlers, update ALL:
   1. `ingest/crawlers/{source-name}/` — implementation
   2. `var.crawlers` in `ingest/terraform/variables.tf` — add entry (set `emergent = true` for 30-min crawlers)
-  3. `shared/src/sources.ts` — `SOURCES` array (display name, URL, localities)
-  4. If emergent (30-min intervals): also `EMERGENT_CRAWLERS` in `ingest/pipeline.ts`
+  3. `shared/src/sources/{source-name}.ts` — create the source definition file
+  4. `shared/src/sources.ts` — import the new definition and add it to the `SOURCES` array (this is the instance assembly; see Instance Configuration below)
+  5. If emergent (30-min intervals): set `emergent: true` on the source definition — `EMERGENT_CRAWLERS` is derived automatically
 
 - **Emergent Classification:** Emergent crawlers run every 30 minutes; all others run 3× daily. This affects workflow definitions and Cloud Scheduler.
+
+### Instance Configuration
+
+oboapp is designed to be forked and deployed for any city. The mechanism is `shared/src/sources.ts`:
+
+- **`shared/src/sources/{id}.ts`** — Individual source definitions (one file per source). These live in the upstream repo and merge cleanly when new sources are added upstream — a new source is a new file, no conflict.
+- **`shared/src/sources.ts`** — The instance assembly. This file imports whichever source definitions the instance wants and assembles them into the `SOURCES` array. `EMERGENT_CRAWLERS` is derived automatically from the `emergent` flag on each source definition.
+
+**For a new city fork:**
+1. Create a new repo forked from `oboapp/oboapp`
+2. Replace `shared/src/sources.ts` with an assembly that includes the new city's sources
+3. Add the new city's source definition files to `shared/src/sources/`
+4. Configure localities and deployment via environment variables and Terraform (see `docs/setup/new-locality-instance.md`)
+
+**On rebase from upstream:** `shared/src/sources/{id}.ts` files merge cleanly (each new upstream source is a new file). `shared/src/sources.ts` is the intentional conflict zone — the fork operator reviews it consciously to decide which upstream sources to include.
 
 ### Geocoding Rate Limits
 

--- a/agent-context/.apm/skills/long-flow-crawler-generator/SKILL.md
+++ b/agent-context/.apm/skills/long-flow-crawler-generator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: long-flow-crawler-generator
-description: Generate WordPress-style crawlers for Sofia public infrastructure disruption sources
+description: Generate WordPress-style crawlers for public infrastructure disruption sources
 agent-name: copilot
 version: 1.0.0
 keywords:
@@ -213,11 +213,11 @@ Include:
 
 ## Phase 6: Front-End Integration
 
-Add the new source to `shared/src/sources.ts` (`SOURCES` array):
+Create the source definition file and register it in the instance assembly:
 
-- Read existing entries to understand the `SourceDefinition` interface
-- Add entry with matching `id`, `url`, `name`, and `localities`
-- Add logo at `web/public/sources/{{source-name}}.png`
+1. Create `shared/src/sources/{source-name}.ts` — use `export default` for the `SourceDefinition` object (so the importer can choose the local name). Include `id`, `url`, `name`, `localities`. If this is an emergent crawler (30-min interval), add `emergent: true`.
+2. In `shared/src/sources.ts`, import the default export under a descriptive local name and add it to the `SOURCES` array. `EMERGENT_CRAWLERS` is derived automatically from the `emergent` flag — no separate list to update.
+3. Add logo at `web/public/sources/{{source-name}}.png`
 
 ## Critical Rules from AGENTS.md
 

--- a/docs/setup/new-locality-instance.md
+++ b/docs/setup/new-locality-instance.md
@@ -6,10 +6,20 @@ oboapp is designed to be deployed for any city. The upstream repository (`oboapp
 
 | Scope | What lives there |
 |---|---|
-| Upstream | Terraform modules, crawler implementations, per-locality crawler definitions |
-| Instance-only | Deployment workflows, secrets, CI environment variables, `terraform.tfvars` |
+| Upstream | Terraform modules, crawler implementations, per-locality crawler definitions, individual source definitions (`shared/src/sources/{id}.ts`) |
+| Instance-only | Deployment workflows, secrets, CI environment variables, `terraform.tfvars`, instance source assembly (`shared/src/sources.ts`) |
 
 Never override upstream Terraform logic in instance files — configure via variables instead.
+
+## Configuring Sources
+
+Each source has its own definition file at `shared/src/sources/{id}.ts`. These live in the upstream repo and merge cleanly across rebases — adding a new upstream source creates a new file, no conflicts.
+
+`shared/src/sources.ts` is the **instance assembly**: it imports the individual definition files and assembles the `SOURCES` array used by both the web app and ingest pipeline. Fork operators replace this file to configure which sources their instance exposes.
+
+When rebasing from upstream, `shared/src/sources/{id}.ts` files merge cleanly. `shared/src/sources.ts` is the intentional conflict zone — review it consciously to decide which upstream sources to include in your instance.
+
+`EMERGENT_CRAWLERS` (the list of crawlers that run on the 30-minute schedule) is derived automatically from the `emergent` flag on each source definition — no separate list to maintain.
 
 ## Configuring Which Localities to Deploy
 

--- a/ingest/pipeline.ts
+++ b/ingest/pipeline.ts
@@ -7,11 +7,9 @@ import { verifyEnvSet, verifyDbEnv } from "@/lib/verify-env";
 import { readdirSync, statSync } from "node:fs";
 import { logger } from "@/lib/logger";
 import { initSentry, flushSentry } from "@/lib/sentry";
+import { EMERGENT_CRAWLERS } from "@oboapp/shared";
 
 const program = new Command();
-
-// Define crawler groups
-const EMERGENT_CRAWLERS = ["erm-zapad", "toplo-bg", "sofiyska-voda", "sensor-community"];
 
 /**
  * Get available crawler sources by reading the crawlers directory
@@ -192,7 +190,7 @@ Examples:
     }
 
     if (options.emergent) {
-      await runPipeline(EMERGENT_CRAWLERS, "EMERGENT");
+      await runPipeline([...EMERGENT_CRAWLERS], "EMERGENT");
     } else if (options.all) {
       const allCrawlers = getAvailableSources();
       await runPipeline(allCrawlers, "FULL");

--- a/ingest/terraform/README.md
+++ b/ingest/terraform/README.md
@@ -231,8 +231,8 @@ terraform apply
 **Adding new crawlers**: Add an entry to the relevant locality file (e.g. `crawlers.bg.sofia.tf`):
 
 1. Add an entry to `crawlers.bg.<locality>.tf` — the workflow templates pick it up automatically via `local.crawlers`.
-2. For emergent crawlers (30-min intervals): set `emergent = true` in the crawler entry and update `EMERGENT_CRAWLERS` in `pipeline.ts`. This is a manual allowlist keyed by crawler source/directory names (not Terraform job keys).
-3. `pipeline.ts` automatically discovers the full list of available crawlers from the filesystem; only membership in the emergent group is controlled manually via `EMERGENT_CRAWLERS`.
+2. For emergent crawlers (30-min intervals): set `emergent = true` in the Terraform crawler entry — this controls Cloud Scheduler/Workflows scheduling. Also set `emergent: true` on the matching source definition in `shared/src/sources/{source-id}.ts` — this keeps `EMERGENT_CRAWLERS` (used by `pipeline --emergent`) in sync. The Terraform `source` value must match the source definition `id` (e.g., `toplo-bg`).
+3. The full list of available crawlers is discovered automatically via `local.crawlers` in Terraform.
 
 **Manual workflow testing**:
 

--- a/shared/src/source-definition.ts
+++ b/shared/src/source-definition.ts
@@ -1,0 +1,11 @@
+/** Shape of a source entry */
+export interface SourceDefinition {
+  readonly id: string;
+  readonly url: string;
+  readonly name: string;
+  readonly localities: readonly string[];
+  /** When true, notifications from this source require the user to opt-in */
+  readonly experimental?: boolean;
+  /** When true, this crawler runs on the emergent (30-minute) schedule */
+  readonly emergent?: boolean;
+}

--- a/shared/src/sources.ts
+++ b/shared/src/sources.ts
@@ -1,155 +1,46 @@
-/** Shape of a source entry */
-export interface SourceDefinition {
-  readonly id: string;
-  readonly url: string;
-  readonly name: string;
-  readonly localities: readonly string[];
-  /** When true, notifications from this source require the user to opt-in */
-  readonly experimental?: boolean;
-}
+export type { SourceDefinition } from "./source-definition";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// INSTANCE ASSEMBLY — replace this file in your fork
+// ─────────────────────────────────────────────────────────────────────────────
+// This file is the DEMO shipped with the upstream repo. It shows the pattern
+// but only includes a small sample of sources.
+//
+// When you fork oboapp for your city:
+//   1. Replace this file with your own assembly.
+//   2. Import the source definition files relevant to your deployment.
+//   3. Add any city-specific sources that live only in your fork.
+//
+// See docs/setup/new-locality-instance.md for the full guide.
+//
+// Each individual source lives in ./sources/{id}.ts and uses `export default`,
+// so you choose the local name when you import it here.
+//
+// EMERGENT_CRAWLERS is derived from this SOURCES assembly and is used by
+// `ingest/pipeline.ts --emergent` (and any consumer of @oboapp/shared).
+// It does NOT control Terraform scheduling — Terraform derives the emergent
+// workflow from `emergent = true` in the crawler's Terraform entry.
+// See AGENTS.md > Instance Configuration for details.
+// ─────────────────────────────────────────────────────────────────────────────
+import sofiaBg from "./sources/sofia-bg";
+import sofiyskavoda from "./sources/sofiyska-voda";
+import sensorCommunity from "./sources/sensor-community";
+
+// ─── Instance assembly ────────────────────────────────────────────────────────
+// This is the list of sources active for this instance.
+// Forks replace this file to configure their own city's sources.
+export const SOURCES = [
+  sofiaBg, // regular crawler (3× daily)
+  sofiyskavoda, // emergent: true  → runs every 30 minutes
+  sensorCommunity, // emergent: true, experimental: true
+] as const;
 
 /**
- * All source definitions.
- * To mark a source as experimental, set `experimental: true` on its entry.
+ * Source IDs passed to `pipeline --emergent` (the legacy ingest pipeline path).
+ * Derived from the `emergent` flag on each source in this SOURCES assembly.
+ * Note: Terraform scheduling is independent — it uses `emergent = true` in
+ * the crawler's Terraform entry, not this list.
  */
-export const SOURCES: readonly SourceDefinition[] = [
-  {
-    id: "rayon-oborishte-bg",
-    url: "https://rayon-oborishte.bg/%d1%83%d0%b2%d0%b5%d0%b4%d0%be%d0%bc%d0%bb%d0%b5%d0%bd%d0%b8%d1%8f-%d0%b7%d0%b0-%d1%80%d0%b5%d0%bc%d0%be%d0%bd%d1%82%d0%b8-%d1%81%d0%bc%d1%80-%d0%bf%d0%b8%d1%80%d0%be%d1%82%d0%b5%d1%85%d0%bd%d0%b8/",
-    name: 'Столична община, Район "Оборище"',
-    localities: ["bg.sofia"],
-  },
-  {
-    id: "sofiyska-voda",
-    url: "https://sofiyskavoda.bg/water-stops",
-    name: "Софийска вода",
-    localities: ["bg.sofia"],
-  },
-  {
-    id: "toplo-bg",
-    url: "https://toplo.bg/accidents-and-maintenance",
-    name: "Топлофикация София",
-    localities: ["bg.sofia"],
-  },
-  {
-    id: "sofia-bg",
-    url: "https://www.sofia.bg/repairs-and-traffic-changes",
-    name: "Столична община",
-    localities: ["bg.sofia"],
-  },
-  {
-    id: "erm-zapad",
-    url: "https://info.ermzapad.bg/webint/vok/avplan.php",
-    name: "ЕРМ Запад",
-    localities: ["bg.sofia"],
-  },
-  {
-    id: "mladost-bg",
-    url: "https://mladost.bg/%d0%b2%d1%81%d0%b8%d1%87%d0%ba%d0%b8-%d0%bd%d0%be%d0%b2%d0%b8%d0%bd%d0%b8/%d0%b8%d0%bd%d1%84%d0%be%d1%80%d0%bc%d0%b0%d1%86%d0%b8%d1%8f-%d0%be%d1%82%d0%bd%d0%be%d1%81%d0%bd%d0%be-%d0%bf%d0%bb%d0%b0%d0%bd%d0%be%d0%b2%d0%b8%d1%82%d0%b5-%d1%80%d0%b5%d0%bc%d0%be%d0%bd%d1%82/",
-    name: 'Столична община, Район "Младост"',
-    localities: ["bg.sofia"],
-  },
-  {
-    id: "studentski-bg",
-    url: "https://studentski.bg/category/%d0%b3%d1%80%d0%b0%d1%84%d0%b8%d1%86%d0%b8/",
-    name: 'Столична община, Район "Студентски"',
-    localities: ["bg.sofia"],
-  },
-  {
-    id: "sredec-sofia-org",
-    url: "https://sredec-sofia.org/category/публикации/полезна-информация/",
-    name: 'Столична община, Район "Средец"',
-    localities: ["bg.sofia"],
-  },
-  {
-    id: "so-slatina-org",
-    url: "https://so-slatina.org/",
-    name: 'Столична община, Район "Слатина"',
-    localities: ["bg.sofia"],
-  },
-  {
-    id: "nimh-severe-weather",
-    url: "https://weather.bg/obshtini/index.php?z=u&o=SOF",
-    name: "НИМХ - Опасно време",
-    localities: ["bg.sofia"],
-  },
-  {
-    id: "lozenets-sofia-bg",
-    url: "https://lozenets.sofia.bg/category/%d0%bd%d0%be%d0%b2%d0%b8%d0%bd%d0%b8/",
-    name: 'Столична община, Район "Лозенец"',
-    localities: ["bg.sofia"],
-  },
-  {
-    id: "raioniskar-bg",
-    url: "https://raioniskar.bg/?c=pages/static&template=home&lang=bg",
-    name: 'Столична община, Район "Искър"',
-    localities: ["bg.sofia"],
-  },
-  {
-    id: "rayon-pancharevo-bg",
-    url: "https://www.pancharevo.org/%D1%80%D0%B5%D0%BC%D0%BE%D0%BD%D1%82%D0%B8-%D0%B8-%D0%B8%D0%BD%D1%84%D1%80%D0%B0%D1%81%D1%82%D1%80%D1%83%D0%BA%D1%82%D1%83%D1%80%D0%B0",
-    name: 'Столична община, Район "Панчарево"',
-    localities: ["bg.sofia"],
-  },
-  {
-    id: "rayon-ilinden-bg",
-    url: "https://ilinden.sofia.bg/category/%d0%be%d0%b1%d1%89%d0%b8%d0%bd%d0%b0/",
-    name: 'Столична община, Район "Илинден"',
-    localities: ["bg.sofia"],
-  },
-  {
-    id: "triaditsa-org",
-    url: "https://triaditza.org/%D0%BD%D0%BE%D0%B2%D0%B8%D0%BD%D0%B8/",
-    name: 'Столична община, Район "Триадица"',
-    localities: ["bg.sofia"],
-  },
-  {
-    id: "krasna-polyana-org",
-    url: "https://krasnapolyana.bg/home/latest-news",
-    name: 'Столична община, Район "Красна поляна"',
-    localities: ["bg.sofia"],
-  },
-  {
-    id: "vrabnitsa-org",
-    url: "https://vrabnitsa.sofia.bg/aktualno/news",
-    name: 'Столична община, Район "Връбница"',
-    localities: ["bg.sofia"],
-  },
-  {
-    id: "nadezhda-org",
-    url: "https://nadezhda.sofia.bg/%D0%BE%D0%B1%D1%8F%D0%B2%D0%B8-%D0%B8-%D1%81%D1%8A%D0%BE%D0%B1%D1%89%D0%B5%D0%BD%D0%B8%D1%8F",
-    name: 'Столична община, Район "Надежда"',
-    localities: ["bg.sofia"],
-  },
-  {
-    id: "inspectorat-so-org",
-    url: "https://inspectorat-so.org/%D0%BD%D0%BE%D0%B2%D0%B8%D0%BD%D0%B8",
-    name: "Столичен инспекторат",
-    localities: ["bg.sofia"],
-  },
-  {
-    id: "sensor-community",
-    url: "https://sensor.community/",
-    name: "sensor.community",
-    localities: ["bg.sofia"],
-    experimental: true,
-  },
-  {
-    id: "sofia-capital-of-sport",
-    url: "https://sofia2018.bg/%d1%81%d1%8a%d0%b1%d0%b8%d1%82%d0%b8%d1%8f/",
-    name: "София - Европейска столица на спорта",
-    localities: ["bg.sofia"],
-  },
-  {
-    id: "serdika-egov-bg",
-    url: "https://serdika.egov.bg/wps/portal/municipality-serdika/actual/messages",
-    name: 'Столична община, Район "Сердика"',
-    localities: ["bg.sofia"],
-  },
-  {
-    id: "sdvr-mvr-bg",
-    url: "https://www.mvr.bg/sdvr/%D0%B8%D0%BD%D1%84%D0%BE%D1%80%D0%BC%D0%B0%D1%86%D0%B8%D0%BE%D0%BD%D0%B5%D0%BD-%D1%86%D0%B5%D0%BD%D1%82%D1%8A%D1%80/%D0%BF%D1%80%D0%B5%D1%81%D1%86%D0%B5%D0%BD%D1%82%D1%8A%D1%80/%D0%BD%D0%BE%D0%B2%D0%B8%D0%BD%D0%B8",
-    name: "СДВР",
-    localities: ["bg.sofia"],
-  },
-];
+export const EMERGENT_CRAWLERS: readonly string[] = SOURCES.filter(
+  (s) => s.emergent,
+).map((s) => s.id);

--- a/shared/src/sources/erm-zapad.ts
+++ b/shared/src/sources/erm-zapad.ts
@@ -1,0 +1,11 @@
+import type { SourceDefinition } from "../source-definition";
+
+const ermZapad: SourceDefinition = {
+  id: "erm-zapad",
+  url: "https://info.ermzapad.bg/webint/vok/avplan.php",
+  name: "ЕРМ Запад",
+  localities: ["bg.sofia"],
+  emergent: true,
+};
+
+export default ermZapad;

--- a/shared/src/sources/inspectorat-so-org.ts
+++ b/shared/src/sources/inspectorat-so-org.ts
@@ -1,0 +1,10 @@
+import type { SourceDefinition } from "../source-definition";
+
+const inspectoratSo: SourceDefinition = {
+  id: "inspectorat-so-org",
+  url: "https://inspectorat-so.org/%D0%BD%D0%BE%D0%B2%D0%B8%D0%BD%D0%B8",
+  name: "Столичен инспекторат",
+  localities: ["bg.sofia"],
+};
+
+export default inspectoratSo;

--- a/shared/src/sources/krasna-polyana-org.ts
+++ b/shared/src/sources/krasna-polyana-org.ts
@@ -1,0 +1,10 @@
+import type { SourceDefinition } from "../source-definition";
+
+const krasnaPolyanaOrg: SourceDefinition = {
+  id: "krasna-polyana-org",
+  url: "https://krasnapolyana.bg/home/latest-news",
+  name: 'Столична община, Район "Красна поляна"',
+  localities: ["bg.sofia"],
+};
+
+export default krasnaPolyanaOrg;

--- a/shared/src/sources/lozenets-sofia-bg.ts
+++ b/shared/src/sources/lozenets-sofia-bg.ts
@@ -1,0 +1,10 @@
+import type { SourceDefinition } from "../source-definition";
+
+const lozenets: SourceDefinition = {
+  id: "lozenets-sofia-bg",
+  url: "https://lozenets.sofia.bg/category/%d0%bd%d0%be%d0%b2%d0%b8%d0%bd%d0%b8/",
+  name: 'Столична община, Район "Лозенец"',
+  localities: ["bg.sofia"],
+};
+
+export default lozenets;

--- a/shared/src/sources/mladost-bg.ts
+++ b/shared/src/sources/mladost-bg.ts
@@ -1,0 +1,10 @@
+import type { SourceDefinition } from "../source-definition";
+
+const mladostBg: SourceDefinition = {
+  id: "mladost-bg",
+  url: "https://mladost.bg/%d0%b2%d1%81%d0%b8%d1%87%d0%ba%d0%b8-%d0%bd%d0%be%d0%b2%d0%b8%d0%bd%d0%b8/%d0%b8%d0%bd%d1%84%d0%be%d1%80%d0%bc%d0%b0%d1%86%d0%b8%d1%8f-%d0%be%d1%82%d0%bd%d0%be%d1%81%d0%bd%d0%be-%d0%bf%d0%bb%d0%b0%d0%bd%d0%be%d0%b2%d0%b8%d1%82%d0%b5-%d1%80%d0%b5%d0%bc%d0%be%d0%bd%d1%82/",
+  name: 'Столична община, Район "Младост"',
+  localities: ["bg.sofia"],
+};
+
+export default mladostBg;

--- a/shared/src/sources/nadezhda-org.ts
+++ b/shared/src/sources/nadezhda-org.ts
@@ -1,0 +1,10 @@
+import type { SourceDefinition } from "../source-definition";
+
+const nadezhda: SourceDefinition = {
+  id: "nadezhda-org",
+  url: "https://nadezhda.sofia.bg/%D0%BE%D0%B1%D1%8F%D0%B2%D0%B8-%D0%B8-%D1%81%D1%8A%D0%BE%D0%B1%D1%89%D0%B5%D0%BD%D0%B8%D1%8F",
+  name: 'Столична община, Район "Надежда"',
+  localities: ["bg.sofia"],
+};
+
+export default nadezhda;

--- a/shared/src/sources/nimh-severe-weather.ts
+++ b/shared/src/sources/nimh-severe-weather.ts
@@ -1,0 +1,10 @@
+import type { SourceDefinition } from "../source-definition";
+
+const nimhSevereWeather: SourceDefinition = {
+  id: "nimh-severe-weather",
+  url: "https://weather.bg/obshtini/index.php?z=u&o=SOF",
+  name: "НИМХ - Опасно време",
+  localities: ["bg.sofia"],
+};
+
+export default nimhSevereWeather;

--- a/shared/src/sources/raioniskar-bg.ts
+++ b/shared/src/sources/raioniskar-bg.ts
@@ -1,0 +1,10 @@
+import type { SourceDefinition } from "../source-definition";
+
+const raioniskarBg: SourceDefinition = {
+  id: "raioniskar-bg",
+  url: "https://raioniskar.bg/?c=pages/static&template=home&lang=bg",
+  name: 'Столична община, Район "Искър"',
+  localities: ["bg.sofia"],
+};
+
+export default raioniskarBg;

--- a/shared/src/sources/rayon-ilinden-bg.ts
+++ b/shared/src/sources/rayon-ilinden-bg.ts
@@ -1,0 +1,10 @@
+import type { SourceDefinition } from "../source-definition";
+
+const rayonIlinden: SourceDefinition = {
+  id: "rayon-ilinden-bg",
+  url: "https://ilinden.sofia.bg/category/%d0%be%d0%b1%d1%89%d0%b8%d0%bd%d0%b0/",
+  name: 'Столична община, Район "Илинден"',
+  localities: ["bg.sofia"],
+};
+
+export default rayonIlinden;

--- a/shared/src/sources/rayon-oborishte-bg.ts
+++ b/shared/src/sources/rayon-oborishte-bg.ts
@@ -1,0 +1,10 @@
+import type { SourceDefinition } from "../source-definition";
+
+const rayonOborishte: SourceDefinition = {
+  id: "rayon-oborishte-bg",
+  url: "https://rayon-oborishte.bg/%d1%83%d0%b2%d0%b5%d0%b4%d0%be%d0%bc%d0%bb%d0%b5%d0%bd%d0%b8%d1%8f-%d0%b7%d0%b0-%d1%80%d0%b5%d0%bc%d0%be%d0%bd%d1%82%d0%b8-%d1%81%d0%bc%d1%80-%d0%bf%d0%b8%d1%80%d0%be%d1%82%d0%b5%d1%85%d0%bd%d0%b8/",
+  name: 'Столична община, Район "Оборище"',
+  localities: ["bg.sofia"],
+};
+
+export default rayonOborishte;

--- a/shared/src/sources/rayon-pancharevo-bg.ts
+++ b/shared/src/sources/rayon-pancharevo-bg.ts
@@ -1,0 +1,10 @@
+import type { SourceDefinition } from "../source-definition";
+
+const rayonPancharevo: SourceDefinition = {
+  id: "rayon-pancharevo-bg",
+  url: "https://www.pancharevo.org/%D1%80%D0%B5%D0%BC%D0%BE%D0%BD%D1%82%D0%B8-%D0%B8-%D0%B8%D0%BD%D1%84%D1%80%D0%B0%D1%81%D1%82%D1%80%D1%83%D0%BA%D1%82%D1%83%D1%80%D0%B0",
+  name: 'Столична община, Район "Панчарево"',
+  localities: ["bg.sofia"],
+};
+
+export default rayonPancharevo;

--- a/shared/src/sources/sdvr-mvr-bg.ts
+++ b/shared/src/sources/sdvr-mvr-bg.ts
@@ -1,0 +1,10 @@
+import type { SourceDefinition } from "../source-definition";
+
+const sdvrMvrBg: SourceDefinition = {
+  id: "sdvr-mvr-bg",
+  url: "https://www.mvr.bg/sdvr/%D0%B8%D0%BD%D1%84%D0%BE%D1%80%D0%BC%D0%B0%D1%86%D0%B8%D0%BE%D0%BD%D0%B5%D0%BD-%D1%86%D0%B5%D0%BD%D1%82%D1%8A%D1%80/%D0%BF%D1%80%D0%B5%D1%81%D1%86%D0%B5%D0%BD%D1%82%D1%8A%D1%80/%D0%BD%D0%BE%D0%B2%D0%B8%D0%BD%D0%B8",
+  name: "СДВР",
+  localities: ["bg.sofia"],
+};
+
+export default sdvrMvrBg;

--- a/shared/src/sources/sensor-community.ts
+++ b/shared/src/sources/sensor-community.ts
@@ -1,0 +1,12 @@
+import type { SourceDefinition } from "../source-definition";
+
+const sensorCommunity: SourceDefinition = {
+  id: "sensor-community",
+  url: "https://sensor.community/",
+  name: "sensor.community",
+  localities: ["bg.sofia"],
+  experimental: true,
+  emergent: true,
+};
+
+export default sensorCommunity;

--- a/shared/src/sources/serdika-egov-bg.ts
+++ b/shared/src/sources/serdika-egov-bg.ts
@@ -1,0 +1,10 @@
+import type { SourceDefinition } from "../source-definition";
+
+const serdikaEgovBg: SourceDefinition = {
+  id: "serdika-egov-bg",
+  url: "https://serdika.egov.bg/wps/portal/municipality-serdika/actual/messages",
+  name: 'Столична община, Район "Сердика"',
+  localities: ["bg.sofia"],
+};
+
+export default serdikaEgovBg;

--- a/shared/src/sources/so-slatina-org.ts
+++ b/shared/src/sources/so-slatina-org.ts
@@ -1,0 +1,10 @@
+import type { SourceDefinition } from "../source-definition";
+
+const soSlatinaOrg: SourceDefinition = {
+  id: "so-slatina-org",
+  url: "https://so-slatina.org/",
+  name: 'Столична община, Район "Слатина"',
+  localities: ["bg.sofia"],
+};
+
+export default soSlatinaOrg;

--- a/shared/src/sources/sofia-bg.ts
+++ b/shared/src/sources/sofia-bg.ts
@@ -1,0 +1,10 @@
+import type { SourceDefinition } from "../source-definition";
+
+const sofiaBg: SourceDefinition = {
+  id: "sofia-bg",
+  url: "https://www.sofia.bg/repairs-and-traffic-changes",
+  name: "Столична община",
+  localities: ["bg.sofia"],
+};
+
+export default sofiaBg;

--- a/shared/src/sources/sofia-capital-of-sport.ts
+++ b/shared/src/sources/sofia-capital-of-sport.ts
@@ -1,0 +1,10 @@
+import type { SourceDefinition } from "../source-definition";
+
+const sofiaCapitalOfSport: SourceDefinition = {
+  id: "sofia-capital-of-sport",
+  url: "https://sofia2018.bg/%d1%81%d1%8a%d0%b1%d0%b8%d1%82%d0%b8%d1%8f/",
+  name: "София - Европейска столица на спорта",
+  localities: ["bg.sofia"],
+};
+
+export default sofiaCapitalOfSport;

--- a/shared/src/sources/sofiyska-voda.ts
+++ b/shared/src/sources/sofiyska-voda.ts
@@ -1,0 +1,11 @@
+import type { SourceDefinition } from "../source-definition";
+
+const sofiyskavoda: SourceDefinition = {
+  id: "sofiyska-voda",
+  url: "https://sofiyskavoda.bg/water-stops",
+  name: "Софийска вода",
+  localities: ["bg.sofia"],
+  emergent: true,
+};
+
+export default sofiyskavoda;

--- a/shared/src/sources/sredec-sofia-org.ts
+++ b/shared/src/sources/sredec-sofia-org.ts
@@ -1,0 +1,10 @@
+import type { SourceDefinition } from "../source-definition";
+
+const sredecSofiaOrg: SourceDefinition = {
+  id: "sredec-sofia-org",
+  url: "https://sredec-sofia.org/category/публикации/полезна-информация/",
+  name: 'Столична община, Район "Средец"',
+  localities: ["bg.sofia"],
+};
+
+export default sredecSofiaOrg;

--- a/shared/src/sources/studentski-bg.ts
+++ b/shared/src/sources/studentski-bg.ts
@@ -1,0 +1,10 @@
+import type { SourceDefinition } from "../source-definition";
+
+const studentskiBg: SourceDefinition = {
+  id: "studentski-bg",
+  url: "https://studentski.bg/category/%d0%b3%d1%80%d0%b0%d1%84%d0%b8%d1%86%d0%b8/",
+  name: 'Столична община, Район "Студентски"',
+  localities: ["bg.sofia"],
+};
+
+export default studentskiBg;

--- a/shared/src/sources/toplo-bg.ts
+++ b/shared/src/sources/toplo-bg.ts
@@ -1,0 +1,11 @@
+import type { SourceDefinition } from "../source-definition";
+
+const toploBg: SourceDefinition = {
+  id: "toplo-bg",
+  url: "https://toplo.bg/accidents-and-maintenance",
+  name: "Топлофикация София",
+  localities: ["bg.sofia"],
+  emergent: true,
+};
+
+export default toploBg;

--- a/shared/src/sources/triaditsa-org.ts
+++ b/shared/src/sources/triaditsa-org.ts
@@ -1,0 +1,10 @@
+import type { SourceDefinition } from "../source-definition";
+
+const triaditsaOrg: SourceDefinition = {
+  id: "triaditsa-org",
+  url: "https://triaditza.org/%D0%BD%D0%BE%D0%B2%D0%B8%D0%BD%D0%B8/",
+  name: 'Столична община, Район "Триадица"',
+  localities: ["bg.sofia"],
+};
+
+export default triaditsaOrg;

--- a/shared/src/sources/vrabnitsa-org.ts
+++ b/shared/src/sources/vrabnitsa-org.ts
@@ -1,0 +1,10 @@
+import type { SourceDefinition } from "../source-definition";
+
+const vrabnitsa: SourceDefinition = {
+  id: "vrabnitsa-org",
+  url: "https://vrabnitsa.sofia.bg/aktualno/news",
+  name: 'Столична община, Район "Връбница"',
+  localities: ["bg.sofia"],
+};
+
+export default vrabnitsa;

--- a/web/app/api/messages/__tests__/route.test.ts
+++ b/web/app/api/messages/__tests__/route.test.ts
@@ -4,6 +4,16 @@ import { GET } from "../route";
 // Mock data store — tests set this before each test
 let mockMessagesData: Record<string, unknown>[] = [];
 
+// Mock sources so source-validation in validateSources() is independent of the
+// upstream SOURCES assembly (which may be a minimal demo set).
+vi.mock("@/lib/sources", () => ({
+  default: [
+    { id: "sofia-bg", url: "https://sofia.bg", name: "Столична община", localities: ["bg.sofia"] },
+    { id: "toplo-bg", url: "https://toplo.bg", name: "Топлофикация", localities: ["bg.sofia"] },
+    { id: "erm-zapad", url: "https://erm.bg", name: "ЧЕЗ Разпределение", localities: ["bg.sofia"] },
+  ],
+}));
+
 // Mock the db module (replaces the old firebase-admin mock)
 vi.mock("@/lib/db", () => ({
   getDb: vi.fn().mockImplementation(async () => ({

--- a/web/app/geocode-cache/page.tsx
+++ b/web/app/geocode-cache/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { GoogleMap, Marker, Polyline, useJsApiLoader } from "@react-google-maps/api";
 import { getButtonClasses } from "@/lib/theme";
 import { zIndex } from "@/lib/colors";
+import { getLocalityCenter } from "@/lib/bounds-utils";
 
 interface FrequencyEntry {
   key: string;
@@ -38,8 +39,8 @@ type GeometryData =
   | { type: "pin"; items: PinGeometryItem[] }
   | { type: "street"; items: StreetGeometryItem[] };
 
-const SOFIA_CENTER = { lat: 42.6977, lng: 23.3219 };
 const MAP_CONTAINER_STYLE = { width: "100%", height: "360px" };
+const MAP_CENTER = getLocalityCenter();
 const MAP_STYLES: google.maps.MapTypeStyle[] = [
   { elementType: "geometry", stylers: [{ saturation: -60 }] },
   {
@@ -136,7 +137,7 @@ function GeometryMap({
   return (
     <GoogleMap
       mapContainerStyle={MAP_CONTAINER_STYLE}
-      center={SOFIA_CENTER}
+      center={MAP_CENTER}
       zoom={14}
       options={MAP_OPTIONS}
       onLoad={(map) => {

--- a/web/app/history/HistoryMapClient.tsx
+++ b/web/app/history/HistoryMapClient.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import { colors } from "@/lib/colors";
+import { getLocalityCenter } from "@/lib/bounds-utils";
 
 type HeatmapPoint = [number, number];
 
@@ -30,8 +31,8 @@ export interface HistoryMapClientProps {
   readonly onStatsLoaded?: (stats: HeatmapStats) => void;
 }
 
-const SOFIA_CENTER: [number, number] = [42.6977, 23.3219];
 const DEFAULT_ZOOM = 13;
+const MAP_CENTER = getLocalityCenter();
 
 // Heatmap gradient using theme colors: cool → warm → hot
 const HEATMAP_GRADIENT = {
@@ -102,7 +103,7 @@ export default function HistoryMapClient({
         leafletRef.current = L;
 
         const map = L.map(mapRef.current, {
-          center: SOFIA_CENTER,
+          center: [MAP_CENTER.lat, MAP_CENTER.lng],
           zoom: DEFAULT_ZOOM,
           zoomControl: true,
           minZoom: 10,

--- a/web/lib/hooks/useSourceFilter.test.ts
+++ b/web/lib/hooks/useSourceFilter.test.ts
@@ -6,6 +6,16 @@ import {
 } from "./useSourceFilter";
 import { Message } from "@/lib/types";
 
+// Mock sources so computeSourceCounts is independent of the upstream SOURCES
+// assembly (which may be a minimal demo set without all Sofia-specific sources).
+vi.mock("@/lib/sources", () => ({
+  default: [
+    { id: "sofia-bg", url: "https://sofia.bg", name: "Столична община", localities: ["bg.sofia"] },
+    { id: "toplo-bg", url: "https://toplo.bg", name: "Топлофикация", localities: ["bg.sofia"] },
+    { id: "erm-zapad", url: "https://erm.bg", name: "ЧЕЗ Разпределение", localities: ["bg.sofia"] },
+  ],
+}));
+
 const buildFeatureCollection = (count: number) => ({
   type: "FeatureCollection" as const,
   features: Array.from({ length: count }, (_, index) => ({


### PR DESCRIPTION
- Extract SourceDefinition interface to shared/src/source-definition.ts
- Split all source definitions into individual shared/src/sources/{id}.ts files (one file per source — merges cleanly on rebase from upstream)
- Add emergent?: boolean to SourceDefinition
- Rewrite shared/src/sources.ts as a thin instance assembly with a 3-source reference example (sofia-bg, sofiyska-voda, sensor-community)
- Derive EMERGENT_CRAWLERS from sources.emergent flag; remove hardcoded list from ingest/pipeline.ts
- Replace hardcoded Sofia coordinates in web pages with getLocalityCenter()
- Update AGENTS.md: crawler sync checklist, new Instance Configuration section
- Update docs/setup/new-locality-instance.md: sources table + Configuring Sources
- Update ingest/terraform/README.md: remove manual EMERGENT_CRAWLERS step
- Update long-flow-crawler-generator skill: two-file Phase 6, run apm:install