### PR TITLE
fix(crawl-sofia): fall back to RSS title when page extractor returns empty title

### DIFF
--- a/ingest/crawlers/sofia-bg/extractors.test.ts
+++ b/ingest/crawlers/sofia-bg/extractors.test.ts
@@ -3,6 +3,7 @@ import {
   fetchFeedXml,
   parseFeedItems,
   extractPostDetails,
+  mergePostDetails,
   FEED_FETCH_TIMEOUT_MS,
 } from "./extractors";
 
@@ -320,6 +321,42 @@ describe("sofia-bg/extractors", () => {
       await extractPostDetails(page);
 
       expect(mockEvaluate).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("mergePostDetails", () => {
+    const rss = { title: "RSS Title", date: "2026-05-08T13:00:00.000Z" };
+
+    it("uses the RSS date regardless of extracted dateText", () => {
+      const result = mergePostDetails(
+        { title: "Page Title", dateText: "some date", contentHtml: "<p>hi</p>" },
+        rss,
+      );
+      expect(result.dateText).toBe("2026-05-08T13:00:00.000Z");
+    });
+
+    it("keeps the page title when it is non-empty", () => {
+      const result = mergePostDetails(
+        { title: "Page Title", dateText: "", contentHtml: "<p>hi</p>" },
+        rss,
+      );
+      expect(result.title).toBe("Page Title");
+    });
+
+    it("falls back to RSS title when the extracted title is empty", () => {
+      const result = mergePostDetails(
+        { title: "", dateText: "", contentHtml: "<p>hi</p>" },
+        rss,
+      );
+      expect(result.title).toBe("RSS Title");
+    });
+
+    it("preserves contentHtml from the extracted details", () => {
+      const result = mergePostDetails(
+        { title: "", dateText: "", contentHtml: "<p>article body</p>" },
+        rss,
+      );
+      expect(result.contentHtml).toBe("<p>article body</p>");
     });
   });
 });

--- a/ingest/crawlers/sofia-bg/extractors.ts
+++ b/ingest/crawlers/sofia-bg/extractors.ts
@@ -99,6 +99,24 @@ const UNWANTED_ELEMENTS = [
 ];
 
 /**
+ * Merge page-extracted post details with RSS feed data.
+ * The RSS date is always used (the detail page has no machine-readable date).
+ * The RSS title is used as a fallback when the page extractor returns an empty
+ * string (e.g. Liferay content pages where the first paragraph fragment has no
+ * CMS content placed in it).
+ */
+export function mergePostDetails(
+  extracted: { title: string; dateText: string; contentHtml: string },
+  rss: { title: string; date: string },
+): { title: string; dateText: string; contentHtml: string } {
+  return {
+    ...extracted,
+    dateText: rss.date,
+    title: extracted.title || rss.title,
+  };
+}
+
+/**
  * Extract post details from an individual post page.
  * Date is not extracted from the page — it comes from the RSS feed.
  *

--- a/ingest/crawlers/sofia-bg/index.ts
+++ b/ingest/crawlers/sofia-bg/index.ts
@@ -4,7 +4,7 @@ import dotenv from "dotenv";
 import { resolve } from "node:path";
 import type { Page } from "playwright";
 import type { PostLink } from "./types";
-import { fetchFeedXml, parseFeedItems, extractPostDetails } from "./extractors";
+import { fetchFeedXml, parseFeedItems, extractPostDetails, mergePostDetails } from "./extractors";
 import { processWordpressPost } from "../shared/webpage-crawlers";
 import { launchBrowser } from "../shared/browser";
 import { isUrlProcessed } from "../shared/firestore";
@@ -124,12 +124,12 @@ export async function crawl(): Promise<void> {
   try {
     for (const postLink of newPostLinks) {
       try {
-        // Inject the RSS date into the extracted details since the detail
-        // page does not expose a machine-readable date element.
-        const extractDetailsWithDate = async (page: Page) => {
-          const details = await extractPostDetails(page);
-          return { ...details, dateText: postLink.date };
-        };
+        // Inject the RSS date and apply title fallback via mergePostDetails.
+        // The detail page has no machine-readable date; Liferay content pages
+        // may also have an empty first paragraph fragment (no title widget),
+        // so the RSS title is used as a fallback.
+        const extractDetailsWithDate = async (page: Page) =>
+          mergePostDetails(await extractPostDetails(page), postLink);
 
         await processWordpressPost(
           browser,


### PR DESCRIPTION
Liferay content pages on sofia.bg sometimes have the first `.component-paragraph.text-break` fragment **empty** (the CMS author did not place a title widget there). `extractPostDetails` then returns `title: ''`, which `buildWebPageSourceDocument` rejects with `'Failed to extract title from <url>'`.

This triggered the **Crawler Failure: sofia** Cloud Monitoring alert on 2026-05-08 for URL `https://www.sofia.bg/w/7400330`.

Since the RSS feed always carries the article title in each `<item>`, fall back to `postLink.title` in the `extractDetailsWithDate` wrapper when the page extractor yields an empty string.

Fixes #437
