### PR TITLE
fix(db): stringify geoJson for sources collection to prevent Firestore nested array rejection

### DIFF
--- a/db/src/firestore-transforms.test.ts
+++ b/db/src/firestore-transforms.test.ts
@@ -53,16 +53,23 @@ describe("transformForFirestoreWrite", () => {
     expect(result.plainText).toBe("hello");
   });
 
-  it("does NOT stringify fields for non-messages collections", () => {
+  it("stringifies geoJson for sources collection", () => {
     const data = {
       geoJson: { type: "FeatureCollection", features: [] },
       name: "test",
     };
     const result = transformForFirestoreWrite("sources", data);
-    expect(result.geoJson).toEqual({
-      type: "FeatureCollection",
-      features: [],
-    });
+    expect(result.geoJson).toBe('{"type":"FeatureCollection","features":[]}');
+    expect(result.name).toBe("test");
+  });
+
+  it("does NOT stringify fields for unknown collections", () => {
+    const data = {
+      geoJson: { type: "FeatureCollection", features: [] },
+      name: "test",
+    };
+    const result = transformForFirestoreWrite("notifications", data);
+    expect(result.geoJson).toEqual({ type: "FeatureCollection", features: [] });
   });
 
   it("preserves primitive values unchanged", () => {
@@ -146,11 +153,20 @@ describe("transformFromFirestoreRead", () => {
     expect(result.geoJson).toEqual(geoJson);
   });
 
-  it("does NOT parse JSON strings for non-messages collections", () => {
+  it("parses geoJson JSON string for sources collection", () => {
+    const geoJson = { type: "FeatureCollection", features: [] };
+    const data = {
+      geoJson: JSON.stringify(geoJson),
+    };
+    const result = transformFromFirestoreRead("sources", data);
+    expect(result.geoJson).toEqual(geoJson);
+  });
+
+  it("does NOT parse JSON strings for unknown collections", () => {
     const data = {
       geoJson: '{"type":"FeatureCollection"}',
     };
-    const result = transformFromFirestoreRead("sources", data);
+    const result = transformFromFirestoreRead("notifications", data);
     expect(result.geoJson).toBe('{"type":"FeatureCollection"}');
   });
 

--- a/db/src/firestore-transforms.ts
+++ b/db/src/firestore-transforms.ts
@@ -12,6 +12,7 @@
 const STRINGIFY_ON_WRITE: Record<string, Set<string>> = {
   messages: new Set(["geoJson", "addresses"]),
   events: new Set(["geoJson"]),
+  sources: new Set(["geoJson"]),
   geocodeCacheStreets: new Set(["geoJson"]),
   geocodeCachePins: new Set(["geoJson"]),
 };
@@ -20,6 +21,7 @@ const STRINGIFY_ON_WRITE: Record<string, Set<string>> = {
 const PARSE_ON_READ: Record<string, Set<string>> = {
   messages: new Set(["geoJson", "addresses", "ingestErrors"]),
   events: new Set(["geoJson"]),
+  sources: new Set(["geoJson"]),
   geocodeCacheStreets: new Set(["geoJson"]),
   geocodeCachePins: new Set(["geoJson"]),
 };


### PR DESCRIPTION
Fixes #439

## Problem

The \crawl-sensor-community\ Cloud Run job was repeatedly failing with:

\\\
Failed to save alert
3 INVALID_ARGUMENT: Property geoJson contains an invalid nested entity.
\\\

Firestore cannot store nested arrays. A GeoJSON Polygon's \coordinates\ field is \[[[lng, lat], ...]]\ — three levels of nesting — which Firestore rejects when stored as a raw map.

The \sources\ collection was missing from \STRINGIFY_ON_WRITE\ and \PARSE_ON_READ\ in \db/src/firestore-transforms.ts\, so the sensor-community crawler stored its Polygon \geoJson\ as a raw object and hit this error on every alert-threshold breach.

## Fix

Add \sources\ to both maps, consistent with \messages\, \events\, and the geocode-cache collections.

All existing callers that read \geoJson\ from a source document (\rom-sources.ts\, \eprocess-message.ts\, \eprocess-failed-messages.ts\) already handle both string and object defensively, so the change is fully backward-compatible.