### PR TITLE
feat: migrate oborishte crawler to RSS feed discovery

### DIFF
--- a/ingest/crawlers/rayon-oborishte-bg/extractors.test.ts
+++ b/ingest/crawlers/rayon-oborishte-bg/extractors.test.ts
@@ -1,315 +1,150 @@
-import { describe, it, expect, vi } from "vitest";
-import { extractPostLinks, extractPostDetails } from "./extractors";
+import { describe, expect, it } from "vitest";
+import { extractFeedItems, mergePostDetails } from "./extractors";
 
-// Mock Page type from Playwright
-interface MockPage {
-  evaluate: <T>(fn: (...args: any[]) => T, ...args: any[]) => Promise<T>;
+function wrapInFeed(items: string): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>СО Оборище</title>
+    ${items}
+  </channel>
+</rss>`;
 }
 
-function createMockPage(mockEvaluate: any): MockPage {
-  return {
-    evaluate: mockEvaluate,
-  } as MockPage;
+function buildItemXml(
+  title: string,
+  url: string,
+  date: string,
+  description: string,
+): string {
+  return `<item>
+      <title>${title}</title>
+      <link>${url}</link>
+      <pubDate>${date}</pubDate>
+      <description><![CDATA[${description}]]></description>
+    </item>`;
 }
 
 describe("rayon-oborishte-bg/extractors", () => {
-  describe("extractPostLinks", () => {
-    it("should extract post links from valid HTML", async () => {
-      const mockEvaluate = vi.fn().mockResolvedValue([
-        {
-          url: "https://rayon-oborishte.bg/%d1%83%d0%b2%d0%b5%d0%b4%d0%be%d0%bc%d0%bb%d0%b5%d0%bd%d0%b8%d0%b5-test",
-          title: "Test Post",
-          date: "15 декември 2025",
-        },
-      ]);
+  it("parses a valid RSS item into a feed entry", () => {
+    const xml = wrapInFeed(
+      buildItemXml(
+        "Уведомление за ремонт",
+        "https://rayon-oborishte.bg/%d1%83%d0%b2%d0%b5%d0%b4%d0%be%d0%bc%d0%bb%d0%b5%d0%bd%d0%b8%d0%b5-test/",
+        "Mon, 04 May 2026 08:11:59 +0000",
+        "<p>Test content</p>",
+      ),
+    );
 
-      const page = createMockPage(mockEvaluate) as any;
-      const posts = await extractPostLinks(page);
+    const items = extractFeedItems(xml);
 
-      expect(posts).toHaveLength(1);
-      expect(posts[0].url).toContain("rayon-oborishte.bg");
-      expect(posts[0].title).toBe("Test Post");
-      expect(posts[0].date).toBe("15 декември 2025");
-    });
-
-    it("should extract multiple post links", async () => {
-      const mockEvaluate = vi.fn().mockResolvedValue([
-        {
-          url: "https://rayon-oborishte.bg/%d1%83%d0%b2%d0%b5%d0%b4%d0%be%d0%bc%d0%bb%d0%b5%d0%bd%d0%b8%d0%b5-1",
-          title: "Post 1",
-          date: "15 декември 2025",
-        },
-        {
-          url: "https://rayon-oborishte.bg/%d1%83%d0%b2%d0%b5%d0%b4%d0%be%d0%bc%d0%bb%d0%b5%d0%bd%d0%b8%d0%b5-2",
-          title: "Post 2",
-          date: "14 декември 2025",
-        },
-      ]);
-
-      const page = createMockPage(mockEvaluate) as any;
-      const posts = await extractPostLinks(page);
-
-      expect(posts).toHaveLength(2);
-      expect(posts[0].title).toBe("Post 1");
-      expect(posts[1].title).toBe("Post 2");
-    });
-
-    it("should return empty array when no posts found", async () => {
-      const mockEvaluate = vi.fn().mockResolvedValue([]);
-
-      const page = createMockPage(mockEvaluate) as any;
-      const posts = await extractPostLinks(page);
-
-      expect(posts).toEqual([]);
-    });
-
-    it("should filter posts by URL pattern (must contain specific path)", async () => {
-      // The extractor should only extract links with the specific URL pattern
-      const mockEvaluate = vi.fn().mockImplementation((fn) => {
-        // Simulate the actual DOM filtering logic
-        const validPost = {
-          url: "https://rayon-oborishte.bg/%d1%83%d0%b2%d0%b5%d0%b4%d0%be%d0%bc%d0%bb%d0%b5%d0%bd%d0%b8%d0%b5-test",
-          title: "Valid Post",
-          date: "15 декември 2025",
-        };
-        return Promise.resolve([validPost]);
-      });
-
-      const page = createMockPage(mockEvaluate) as any;
-      const posts = await extractPostLinks(page);
-
-      expect(posts).toHaveLength(1);
-      expect(posts[0].url).toContain(
-        "%d1%83%d0%b2%d0%b5%d0%b4%d0%be%d0%bc%d0%bb%d0%b5%d0%bd%d0%b8%d0%b5-",
-      );
-    });
-
-    it("should handle posts with empty dates", async () => {
-      const mockEvaluate = vi.fn().mockResolvedValue([
-        {
-          url: "https://rayon-oborishte.bg/%d1%83%d0%b2%d0%b5%d0%b4%d0%be%d0%bc%d0%bb%d0%b5%d0%bd%d0%b8%d0%b5-test",
-          title: "Test Post",
-          date: "",
-        },
-      ]);
-
-      const page = createMockPage(mockEvaluate) as any;
-      const posts = await extractPostLinks(page);
-
-      expect(posts).toHaveLength(1);
-      expect(posts[0].date).toBe("");
-    });
-
-    it("should accept URLs containing 'ремонт' (repair)", async () => {
-      const mockEvaluate = vi.fn().mockResolvedValue([
-        {
-          url: "https://rayon-oborishte.bg/%d0%bf%d0%be%d0%b5%d1%82%d0%b0%d0%bf%d0%bd%d0%b8-%d1%80%d0%b5%d0%bc%d0%be%d0%bd%d1%82%d0%bd%d0%b8-%d0%b4%d0%b5%d0%b9%d0%bd%d0%be%d1%81%d1%82%d0%b8/",
-          title: "Поетапни ремонтни дейности",
-          date: "05 февруари 2026",
-        },
-      ]);
-
-      const page = createMockPage(mockEvaluate) as any;
-      const posts = await extractPostLinks(page);
-
-      expect(posts).toHaveLength(1);
-      expect(posts[0].title).toBe("Поетапни ремонтни дейности");
-    });
-
-    it("should accept URLs containing 'затваряни' (closing)", async () => {
-      const mockEvaluate = vi.fn().mockResolvedValue([
-        {
-          url: "https://rayon-oborishte.bg/%d0%b7%d0%b0%d1%82%d0%b2%d0%b0%d1%80%d1%8f%d0%bd%d0%b8%d1%8f-%d0%bd%d0%b0-%d1%83%d0%bb%d0%b8%d1%86%d0%b0/",
-          title: "Затваряния на улица",
-          date: "04 февруари 2026",
-        },
-      ]);
-
-      const page = createMockPage(mockEvaluate) as any;
-      const posts = await extractPostLinks(page);
-
-      expect(posts).toHaveLength(1);
-      expect(posts[0].title).toBe("Затваряния на улица");
-    });
-
-    it("should accept URLs with numeric IDs like /21862-2/", async () => {
-      const mockEvaluate = vi.fn().mockResolvedValue([
-        {
-          url: "https://rayon-oborishte.bg/21862-2/",
-          title: "Уведомление за строителни дейности",
-          date: "05 февруари 2026",
-        },
-      ]);
-
-      const page = createMockPage(mockEvaluate) as any;
-      const posts = await extractPostLinks(page);
-
-      expect(posts).toHaveLength(1);
-      expect(posts[0].title).toBe("Уведомление за строителни дейности");
-    });
-
-    it("should accept URLs with simple numeric IDs like /12345/", async () => {
-      const mockEvaluate = vi.fn().mockResolvedValue([
-        {
-          url: "https://rayon-oborishte.bg/12345/",
-          title: "Some Post",
-          date: "03 февруари 2026",
-        },
-      ]);
-
-      const page = createMockPage(mockEvaluate) as any;
-      const posts = await extractPostLinks(page);
-
-      expect(posts).toHaveLength(1);
-    });
-
-    it("should filter out navigation pages like 'контакти'", async () => {
-      const mockEvaluate = vi.fn().mockResolvedValue([
-        {
-          url: "https://rayon-oborishte.bg/%d0%ba%d0%be%d0%bd%d1%82%d0%b0%d0%ba%d1%82%d0%b8/",
-          title: "Контакти",
-          date: "",
-        },
-      ]);
-
-      const page = createMockPage(mockEvaluate) as any;
-      const posts = await extractPostLinks(page);
-
-      expect(posts).toHaveLength(0);
-    });
-
-    it("should filter out navigation pages like 'администрация'", async () => {
-      const mockEvaluate = vi.fn().mockResolvedValue([
-        {
-          url: "https://rayon-oborishte.bg/%d0%b0%d0%b4%d0%bc%d0%b8%d0%bd%d0%b8%d1%81%d1%82%d1%80%d0%b0%d1%86%d0%b8%d1%8f/",
-          title: "Администрация",
-          date: "",
-        },
-      ]);
-
-      const page = createMockPage(mockEvaluate) as any;
-      const posts = await extractPostLinks(page);
-
-      expect(posts).toHaveLength(0);
-    });
-
-    it("should correctly filter mixed valid and invalid URLs", async () => {
-      const mockEvaluate = vi.fn().mockResolvedValue([
-        {
-          url: "https://rayon-oborishte.bg/%d1%83%d0%b2%d0%b5%d0%b4%d0%be%d0%bc%d0%bb%d0%b5%d0%bd%d0%b8%d0%b5-1/",
-          title: "Valid: уведомление",
-          date: "05 февруари 2026",
-        },
-        {
-          url: "https://rayon-oborishte.bg/%d0%ba%d0%be%d0%bd%d1%82%d0%b0%d0%ba%d1%82%d0%b8/",
-          title: "Invalid: контакти",
-          date: "",
-        },
-        {
-          url: "https://rayon-oborishte.bg/%d1%80%d0%b5%d0%bc%d0%be%d0%bd%d1%82-test/",
-          title: "Valid: ремонт",
-          date: "04 февруари 2026",
-        },
-        {
-          url: "https://rayon-oborishte.bg/21862-2/",
-          title: "Valid: numeric ID",
-          date: "03 февруари 2026",
-        },
-        {
-          url: "https://rayon-oborishte.bg/%d0%bf%d0%b0%d1%80%d1%82%d0%bd%d1%8c%d0%be%d1%80%d0%b8/",
-          title: "Invalid: партньори",
-          date: "",
-        },
-      ]);
-
-      const page = createMockPage(mockEvaluate) as any;
-      const posts = await extractPostLinks(page);
-
-      expect(posts).toHaveLength(3);
-      expect(posts.map((p) => p.title)).toEqual([
-        "Valid: уведомление",
-        "Valid: ремонт",
-        "Valid: numeric ID",
-      ]);
+    expect(items).toHaveLength(1);
+    expect(items[0]).toEqual({
+      url: "https://rayon-oborishte.bg/%d1%83%d0%b2%d0%b5%d0%b4%d0%be%d0%bc%d0%bb%d0%b5%d0%bd%d0%b8%d0%b5-test/",
+      title: "Уведомление за ремонт",
+      date: "2026-05-04T08:11:59.000Z",
+      contentHtml: "<p>Test content</p>",
     });
   });
 
-  describe("extractPostDetails", () => {
-    it("should extract post details from valid page", async () => {
-      const mockEvaluate = vi.fn().mockResolvedValue({
-        title: "Уведомление за ремонт",
-        dateText: "15 декември 2025",
-        contentHtml: "<p>Test content</p>",
-      });
+  it("removes the standard WordPress attribution from the description", () => {
+    const xml = wrapInFeed(
+      buildItemXml(
+        "Уведомление за предстоящи затваряния",
+        "https://rayon-oborishte.bg/%d1%83%d0%b2%d0%b5%d0%b4%d0%be%d0%bc%d0%bb%d0%b5%d0%bd%d0%b8%d0%b5-170/",
+        "Wed, 29 Apr 2026 09:20:58 +0000",
+        '<p>Първи параграф</p><p>Материалът <a href="https://rayon-oborishte.bg/%d1%83%d0%b2%d0%b5%d0%b4%d0%be%d0%bc%d0%bb%d0%b5%d0%bd%d0%b8%d0%b5-170/">Уведомление</a> е публикуван за пръв път на <a href="https://rayon-oborishte.bg">СО Оборище</a>.</p>',
+      ),
+    );
 
-      const page = createMockPage(mockEvaluate) as any;
-      const details = await extractPostDetails(page);
+    const items = extractFeedItems(xml);
 
-      expect(details.title).toBe("Уведомление за ремонт");
-      expect(details.dateText).toBe("15 декември 2025");
-      expect(details.contentHtml).toBe("<p>Test content</p>");
+    expect(items).toHaveLength(1);
+    expect(items[0].contentHtml).toBe("<p>Първи параграф</p>");
+  });
+
+  it("skips items from other hosts", () => {
+    const xml = wrapInFeed(
+      buildItemXml(
+        "External item",
+        "https://example.com/post/1",
+        "Mon, 04 May 2026 08:11:59 +0000",
+        "<p>External</p>",
+      ),
+    );
+
+    expect(extractFeedItems(xml)).toEqual([]);
+  });
+
+  it("skips items with invalid dates", () => {
+    const xml = wrapInFeed(
+      buildItemXml(
+        "Broken date",
+        "https://rayon-oborishte.bg/broken-date/",
+        "not-a-date",
+        "<p>Content</p>",
+      ),
+    );
+
+    expect(extractFeedItems(xml)).toEqual([]);
+  });
+
+  it("keeps items without a description for discovery", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <item>
+      <title>Уведомление без описание</title>
+      <link>https://rayon-oborishte.bg/%d1%83%d0%b2%d0%b5%d0%b4%d0%be%d0%bc%d0%bb%d0%b5%d0%bd%d0%b8%d0%b5-%d0%b1%d0%b5%d0%b7-%d0%be%d0%bf%d0%b8%d1%81%d0%b0%d0%bd%d0%b8%d0%b5/</link>
+      <pubDate>Mon, 04 May 2026 08:11:59 +0000</pubDate>
+    </item>
+  </channel>
+</rss>`;
+
+    expect(extractFeedItems(xml)).toEqual([
+      {
+        url: "https://rayon-oborishte.bg/%d1%83%d0%b2%d0%b5%d0%b4%d0%be%d0%bc%d0%bb%d0%b5%d0%bd%d0%b8%d0%b5-%d0%b1%d0%b5%d0%b7-%d0%be%d0%bf%d0%b8%d1%81%d0%b0%d0%bd%d0%b8%d0%b5/",
+        title: "Уведомление без описание",
+        date: "2026-05-04T08:11:59.000Z",
+        contentHtml: undefined,
+      },
+    ]);
+  });
+
+  it("prefers RSS date and keeps extracted title when present", () => {
+    const merged = mergePostDetails(
+      {
+        title: "Извлечено заглавие",
+        dateText: "старо",
+        contentHtml: "<p>Body</p>",
+      },
+      {
+        title: "RSS заглавие",
+        date: "2026-05-10T07:00:00.000Z",
+      },
+    );
+
+    expect(merged).toEqual({
+      title: "Извлечено заглавие",
+      dateText: "2026-05-10T07:00:00.000Z",
+      contentHtml: "<p>Body</p>",
     });
+  });
 
-    it("should handle missing title", async () => {
-      const mockEvaluate = vi.fn().mockResolvedValue({
+  it("falls back to RSS title when extracted title is empty", () => {
+    const merged = mergePostDetails(
+      {
         title: "",
-        dateText: "15 декември 2025",
-        contentHtml: "<p>Content</p>",
-      });
+        dateText: "старо",
+        contentHtml: "<p>Body</p>",
+      },
+      {
+        title: "RSS заглавие",
+        date: "2026-05-10T07:00:00.000Z",
+      },
+    );
 
-      const page = createMockPage(mockEvaluate) as any;
-      const details = await extractPostDetails(page);
-
-      expect(details.title).toBe("");
-    });
-
-    it("should handle missing date", async () => {
-      const mockEvaluate = vi.fn().mockResolvedValue({
-        title: "Test Title",
-        dateText: "",
-        contentHtml: "<p>Content</p>",
-      });
-
-      const page = createMockPage(mockEvaluate) as any;
-      const details = await extractPostDetails(page);
-
-      expect(details.dateText).toBe("");
-    });
-
-    it("should handle empty content", async () => {
-      const mockEvaluate = vi.fn().mockResolvedValue({
-        title: "Test Title",
-        dateText: "15 декември 2025",
-        contentHtml: "",
-      });
-
-      const page = createMockPage(mockEvaluate) as any;
-      const details = await extractPostDetails(page);
-
-      expect(details.contentHtml).toBe("");
-    });
-
-    it("should extract complex HTML content", async () => {
-      const mockEvaluate = vi.fn().mockResolvedValue({
-        title: "Complex Post",
-        dateText: "15 декември 2025",
-        contentHtml: `
-          <div>
-            <h2>Section 1</h2>
-            <p>Paragraph 1</p>
-            <ul>
-              <li>Item 1</li>
-              <li>Item 2</li>
-            </ul>
-          </div>
-        `,
-      });
-
-      const page = createMockPage(mockEvaluate) as any;
-      const details = await extractPostDetails(page);
-
-      expect(details.contentHtml).toContain("<h2>Section 1</h2>");
-      expect(details.contentHtml).toContain("<ul>");
-    });
+    expect(merged.title).toBe("RSS заглавие");
+    expect(merged.dateText).toBe("2026-05-10T07:00:00.000Z");
   });
 });

--- a/ingest/crawlers/rayon-oborishte-bg/extractors.ts
+++ b/ingest/crawlers/rayon-oborishte-bg/extractors.ts
@@ -1,39 +1,29 @@
 import type { Page } from "playwright";
+import {
+  parseRssFeedItems,
+  stripWordPressFeedAttribution,
+} from "../shared/rss";
+import type { RssFeedItem } from "../shared/rss";
 import type { PostLink } from "./types";
 import { SELECTORS } from "./selectors";
-import {
-  extractPostLinks as extractPostLinksShared,
-  extractPostDetailsGeneric,
-} from "../shared/extractors";
+import { extractPostDetailsGeneric } from "../shared/extractors";
+
+const SOURCE_HOSTNAME = "rayon-oborishte.bg";
 
 /**
- * Extract post links from the index page
+ * Parse RSS feed items from rayon-oborishte.bg.
  */
-export async function extractPostLinks(page: Page): Promise<PostLink[]> {
-  // Filter to include repair notifications while excluding navigation pages.
-  // Accept URLs containing: 'уведомление' (notification), 'ремонт' (repair),
-  // 'затваряни' (closing), or numeric IDs (e.g., /21862-2/).
-  // The AI categorization stage will handle final relevance filtering.
-  const urlFilter = (url: string) => {
-    let decodedUrl: string;
-    try {
-      decodedUrl = decodeURIComponent(url).toLowerCase();
-    } catch {
-      decodedUrl = url.toLowerCase();
-    }
-    return (
-      decodedUrl.includes("уведомление") ||
-      decodedUrl.includes("ремонт") ||
-      decodedUrl.includes("затваряни") ||
-      /\/\d+(-\d+)?\/?$/.test(decodedUrl) // Numeric IDs like /21862-2/
-    );
-  };
-
-  return extractPostLinksShared(page, SELECTORS, urlFilter);
+export function extractFeedItems(xml: string): RssFeedItem[] {
+  return parseRssFeedItems(xml, {
+    hostname: SOURCE_HOSTNAME,
+    dateTag: "pubDate",
+    contentTag: "description",
+    contentTransform: stripWordPressFeedAttribution,
+  });
 }
 
 /**
- * Extract post details from individual post page
+ * Extract post details from an individual article page.
  */
 export async function extractPostDetails(
   page: Page,
@@ -47,4 +37,18 @@ export async function extractPostDetails(
     ".navigation",
     ".post-navigation",
   ]);
+}
+
+/**
+ * Merge page-extracted details with RSS metadata.
+ */
+export function mergePostDetails(
+  extracted: { title: string; dateText: string; contentHtml: string },
+  rss: Pick<PostLink, "title" | "date">,
+): { title: string; dateText: string; contentHtml: string } {
+  return {
+    ...extracted,
+    dateText: rss.date,
+    title: extracted.title || rss.title,
+  };
 }

--- a/ingest/crawlers/rayon-oborishte-bg/index.ts
+++ b/ingest/crawlers/rayon-oborishte-bg/index.ts
@@ -2,33 +2,32 @@
 
 import dotenv from "dotenv";
 import { resolve } from "node:path";
-import { Browser } from "playwright";
+import type { Browser } from "playwright";
 import type { OboDb } from "@oboapp/db";
-import { PostLink } from "./types";
-import { extractPostLinks, extractPostDetails } from "./extractors";
+import type { PostLink } from "../shared/types";
 import {
-  crawlWordpressPage,
-  processWordpressPost,
-} from "../shared/webpage-crawlers";
+  extractFeedItems,
+  mergePostDetails,
+  extractPostDetails,
+} from "./extractors";
+import { fetchFeedXml } from "../shared/rss";
+import { launchBrowser } from "../shared/browser";
+import { isUrlProcessed } from "../shared/firestore";
+import { processWordpressPost } from "../shared/webpage-crawlers";
 import { logger } from "@/lib/logger";
 
 // Load environment variables from .env.local
 dotenv.config({ path: resolve(process.cwd(), ".env.local") });
 
-const INDEX_URL =
-  "https://rayon-oborishte.bg/%d1%83%d0%b2%d0%b5%d0%b4%d0%be%d0%bc%d0%bb%d0%b5%d0%bd%d0%b8%d1%8f-%d0%b7%d0%b0-%d1%80%d0%b5%d0%bc%d0%be%d0%bd%d1%82%d0%b8-%d1%81%d0%bc%d1%80-%d0%bf%d0%b8%d1%80%d0%be%d1%82%d0%b5%d1%85%d0%bd%d0%b8/";
+const FEED_URL = "https://rayon-oborishte.bg/feed/";
 const SOURCE_TYPE = "rayon-oborishte-bg";
 const LOCALITY = "bg.sofia";
-const DELAY_BETWEEN_REQUESTS = 2000; // 2 seconds
+const DELAY_BETWEEN_REQUESTS = 2000;
 
 /**
  * Process a single post
  */
-const processPost = (
-  browser: Browser,
-  postLink: PostLink,
-  db: OboDb,
-) =>
+const processPost = (browser: Browser, postLink: PostLink, db: OboDb) =>
   processWordpressPost(
     browser,
     postLink,
@@ -36,26 +35,111 @@ const processPost = (
     SOURCE_TYPE,
     LOCALITY,
     DELAY_BETWEEN_REQUESTS,
-    extractPostDetails,
+    async (page) => mergePostDetails(await extractPostDetails(page), postLink),
+    (dateText) => dateText,
   );
 
 /**
  * Main crawler function
  */
 export async function crawl(): Promise<void> {
-  await crawlWordpressPage({
-    indexUrl: INDEX_URL,
+  const { getDb } = await import("@/lib/db");
+  const db = await getDb();
+
+  logger.info("Starting crawler", { sourceType: SOURCE_TYPE });
+
+  let feedItems: PostLink[];
+  try {
+    const xml = await fetchFeedXml(FEED_URL);
+    feedItems = extractFeedItems(xml);
+  } catch (error) {
+    logger.error("Failed to fetch or parse RSS feed", {
+      sourceType: SOURCE_TYPE,
+      feedUrl: FEED_URL,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw error;
+  }
+
+  if (feedItems.length === 0) {
+    logger.warn("No posts found in RSS feed", { sourceType: SOURCE_TYPE });
+    return;
+  }
+
+  const seen = new Set<string>();
+  const uniqueItems = feedItems.filter((item) => {
+    if (seen.has(item.url)) {
+      return false;
+    }
+
+    seen.add(item.url);
+    return true;
+  });
+
+  logger.info("Fetched RSS feed", {
     sourceType: SOURCE_TYPE,
-    extractPostLinks,
-    processPost,
-    delayBetweenRequests: DELAY_BETWEEN_REQUESTS,
+    feedUrl: FEED_URL,
+    count: uniqueItems.length,
+  });
+
+  const browser = await launchBrowser();
+  let saved = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  try {
+    for (const item of uniqueItems) {
+      let wasProcessed = false;
+      try {
+        wasProcessed = await isUrlProcessed(item.url, db);
+      } catch (error) {
+        failed++;
+        logger.error("Failed to check existing URL state", {
+          sourceType: SOURCE_TYPE,
+          url: item.url,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        continue;
+      }
+
+      if (wasProcessed) {
+        skipped++;
+        continue;
+      }
+
+      try {
+        await processPost(browser, item, db);
+        saved++;
+      } catch (error) {
+        failed++;
+        // processWordpressPost already emits an error log with post-level context.
+        logger.debug("Post processing failed", {
+          sourceType: SOURCE_TYPE,
+          url: item.url,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+  } finally {
+    await browser.close();
+  }
+
+  logger.info("Crawl complete", {
+    sourceType: SOURCE_TYPE,
+    total: uniqueItems.length,
+    saved,
+    skipped,
+    failed,
   });
 }
 
 // Run the crawler if executed directly
 if (require.main === module) {
   crawl().catch((error) => {
-    logger.error("Fatal error", { sourceType: SOURCE_TYPE, error: error instanceof Error ? error.message : String(error) });
+    logger.error("Fatal error", {
+      sourceType: SOURCE_TYPE,
+      error: error instanceof Error ? error.message : String(error),
+    });
     process.exit(1);
   });
 }

--- a/ingest/crawlers/shared/rss.test.ts
+++ b/ingest/crawlers/shared/rss.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  fetchFeedXml,
+  parseRssFeedItems,
+  stripWordPressFeedAttribution,
+} from "./rss";
+
+describe("shared/rss", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("parses items and decodes entities/CDATA", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <item>
+      <title><![CDATA[Tom &amp; Jerry]]></title>
+      <link>https://example.com/post-1</link>
+      <pubDate>Mon, 04 May 2026 08:11:59 +0000</pubDate>
+      <description><![CDATA[<p>Body &amp; details</p>]]></description>
+    </item>
+  </channel>
+</rss>`;
+
+    expect(parseRssFeedItems(xml, { contentTag: "description" })).toEqual([
+      {
+        url: "https://example.com/post-1",
+        title: "Tom & Jerry",
+        date: "2026-05-04T08:11:59.000Z",
+        contentHtml: "<p>Body & details</p>",
+      },
+    ]);
+  });
+
+  it("filters by hostname and strips query/hash when configured", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <item>
+      <title>Keep me</title>
+      <link>https://www.sofia.bg/repairs?id=1#section</link>
+      <pubDate>Mon, 04 May 2026 08:11:59 +0000</pubDate>
+    </item>
+    <item>
+      <title>Drop me</title>
+      <link>https://example.com/post-2</link>
+      <pubDate>Mon, 04 May 2026 08:11:59 +0000</pubDate>
+    </item>
+  </channel>
+</rss>`;
+
+    expect(
+      parseRssFeedItems(xml, {
+        hostname: "www.sofia.bg",
+        stripQuery: true,
+      }),
+    ).toEqual([
+      {
+        url: "https://www.sofia.bg/repairs",
+        title: "Keep me",
+        date: "2026-05-04T08:11:59.000Z",
+        contentHtml: undefined,
+      },
+    ]);
+  });
+
+  it("strips WordPress feed attribution from the description", () => {
+    const html =
+      "<p>Първи параграф</p><p>Материалът <a href=\"https://rayon-oborishte.bg/test\">Тест</a> е публикуван за пръв път на <a href=\"https://rayon-oborishte.bg\">СО Оборище</a>.</p>";
+
+    expect(stripWordPressFeedAttribution(html)).toBe("<p>Първи параграф</p>");
+  });
+
+  it("fetches and returns RSS xml", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: async () => "<rss><channel></channel></rss>",
+      } as Response);
+
+    const xml = await fetchFeedXml("https://example.com/feed");
+
+    expect(xml).toContain("<rss>");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://example.com/feed",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "User-Agent": "Mozilla/5.0 (compatible; oboapp-crawler/1.0)",
+        }),
+      }),
+    );
+  });
+
+  it("throws when response is not RSS-like", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      {
+        ok: true,
+        status: 200,
+        text: async () => "<html><body>Blocked</body></html>",
+      } as Response,
+    );
+
+    await expect(fetchFeedXml("https://example.com/feed")).rejects.toThrow(
+      "RSS feed response does not look like RSS",
+    );
+  });
+});

--- a/ingest/crawlers/shared/rss.ts
+++ b/ingest/crawlers/shared/rss.ts
@@ -1,0 +1,146 @@
+import { decode as decodeHtmlEntities } from "html-entities";
+
+export const RSS_FEED_FETCH_TIMEOUT_MS = 30_000;
+
+export interface RssFeedItem {
+  url: string;
+  title: string;
+  date: string;
+  contentHtml?: string;
+}
+
+export interface ParseRssFeedItemsOptions {
+  hostname?: string;
+  titleTag?: string;
+  linkTag?: string;
+  dateTag?: string;
+  contentTag?: string;
+  stripQuery?: boolean;
+  contentTransform?: (contentHtml: string) => string;
+}
+
+function stripCdata(text: string): string {
+  return text.replace(/^<!\[CDATA\[([\s\S]*?)]]>$/, "$1");
+}
+
+function escapeRegExp(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function readTagValue(xml: string, tagName: string): string {
+  const tagRe = new RegExp(
+    `<${escapeRegExp(tagName)}>([\\s\\S]*?)<\/${escapeRegExp(tagName)}>`,
+    "i",
+  );
+  const value = tagRe.exec(xml)?.[1]?.trim() ?? "";
+  return decodeHtmlEntities(stripCdata(value));
+}
+
+/**
+ * Remove the standard WordPress attribution paragraph from RSS descriptions.
+ */
+export function stripWordPressFeedAttribution(contentHtml: string): string {
+  return contentHtml
+    .replace(
+      /(?:\s*<p>)?\s*Материалът[\s\S]*?публикуван за пръв път на[\s\S]*?<\/p>\s*$/i,
+      "",
+    )
+    .trim();
+}
+
+/**
+ * Fetch RSS XML with a small timeout and a browser-like user agent.
+ */
+export async function fetchFeedXml(
+  url: string,
+  timeoutMs: number = RSS_FEED_FETCH_TIMEOUT_MS,
+): Promise<string> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(url, {
+      headers: {
+        "User-Agent": "Mozilla/5.0 (compatible; oboapp-crawler/1.0)",
+      },
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      throw new Error(`RSS feed returned ${response.status} for ${url}`);
+    }
+
+    const text = await response.text();
+    if (!text.includes("<rss") && !text.includes("<channel>")) {
+      throw new Error(
+        `RSS feed response does not look like RSS (possible anti-bot or error page) for ${url}`,
+      );
+    }
+
+    return text;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+/**
+ * Parse RSS feed XML into structured items.
+ */
+export function parseRssFeedItems(
+  xml: string,
+  options: ParseRssFeedItemsOptions = {},
+): RssFeedItem[] {
+  const titleTag = options.titleTag ?? "title";
+  const linkTag = options.linkTag ?? "link";
+  const dateTag = options.dateTag ?? "pubDate";
+  const contentTag = options.contentTag;
+  const itemRe = /<item>([\s\S]*?)<\/item>/gi;
+  const items: RssFeedItem[] = [];
+  let match: RegExpExecArray | null;
+
+  while ((match = itemRe.exec(xml)) !== null) {
+    const itemXml = match[1];
+    const title = readTagValue(itemXml, titleTag);
+    const url = readTagValue(itemXml, linkTag);
+    const dateText = readTagValue(itemXml, dateTag);
+
+    if (!title || !url || !dateText) {
+      continue;
+    }
+
+    let parsedUrl: URL;
+    try {
+      parsedUrl = new URL(url);
+    } catch {
+      continue;
+    }
+
+    if (options.hostname && parsedUrl.hostname !== options.hostname) {
+      continue;
+    }
+
+    if (options.stripQuery) {
+      parsedUrl.search = "";
+      parsedUrl.hash = "";
+    }
+
+    const dateMs = Date.parse(dateText);
+    if (Number.isNaN(dateMs)) {
+      continue;
+    }
+
+    const contentValue = contentTag ? readTagValue(itemXml, contentTag) : "";
+    const contentHtml = contentValue
+      ? (options.contentTransform?.(contentValue) ?? contentValue)
+      : undefined;
+
+    items.push({
+      url: parsedUrl.toString(),
+      title,
+      date: new Date(dateMs).toISOString(),
+      contentHtml,
+    });
+  }
+
+  return items;
+}

--- a/ingest/crawlers/sofia-bg/extractors.ts
+++ b/ingest/crawlers/sofia-bg/extractors.ts
@@ -1,91 +1,10 @@
 import type { Page } from "playwright";
 import type { PostLink } from "./types";
-import { decode as decodeHtmlEntities } from "html-entities";
-
-export const FEED_FETCH_TIMEOUT_MS = 30_000;
-
-function stripCdata(text: string): string {
-  return text.replace(/^<!\[CDATA\[([\s\S]*?)]]>$/, "$1");
-}
-
-/**
- * Fetch the RSS feed XML for the sofia.bg repairs page.
- * Throws if the response is not an RSS feed (e.g. HTML anti-bot page).
- */
-export async function fetchFeedXml(url: string): Promise<string> {
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), FEED_FETCH_TIMEOUT_MS);
-  try {
-    const response = await fetch(url, {
-      headers: { "User-Agent": "Mozilla/5.0 (compatible; oboapp-crawler/1.0)" },
-      signal: controller.signal,
-    });
-    if (!response.ok) {
-      throw new Error(`RSS feed returned ${response.status} for ${url}`);
-    }
-    const text = await response.text();
-    if (!text.includes("<rss") && !text.includes("<channel>")) {
-      throw new Error(
-        `RSS feed response does not look like RSS (possible anti-bot or error page) for ${url}`,
-      );
-    }
-    return text;
-  } finally {
-    clearTimeout(timeoutId);
-  }
-}
-
-/**
- * Parse RSS feed XML into a list of post links.
- * Each <item> must have <title>, <link>, and <dc:date> (ISO 8601).
- * Items missing any required field are skipped.
- */
-export function parseFeedItems(xml: string): PostLink[] {
-  const postLinks: PostLink[] = [];
-  const itemRe = /<item>([\s\S]*?)<\/item>/g;
-  let m: RegExpExecArray | null;
-
-  while ((m = itemRe.exec(xml)) !== null) {
-    const itemXml = m[1];
-
-    const title = decodeHtmlEntities(
-      stripCdata(
-        itemXml.match(/<title>([\s\S]*?)<\/title>/)?.[1]?.trim() ?? "",
-      ),
-    );
-    const url = decodeHtmlEntities(
-      stripCdata(itemXml.match(/<link>([\s\S]*?)<\/link>/)?.[1]?.trim() ?? ""),
-    );
-    const date = stripCdata(
-      itemXml.match(/<dc:date>([\s\S]*?)<\/dc:date>/)?.[1]?.trim() ?? "",
-    );
-
-    if (!title || !url || !date) continue;
-
-    // Validate URL stays on the expected host to avoid navigating to arbitrary sites.
-    let parsedUrl: URL;
-    try {
-      parsedUrl = new URL(url);
-    } catch {
-      continue;
-    }
-    if (parsedUrl.hostname !== "www.sofia.bg") continue;
-
-    // Strip query parameters — RSS feed links (e.g. from the news feed) include a
-    // Liferay ?redirect=... param that causes redirect loops when navigated to
-    // unauthenticated. The article path (/w/{id}) is self-contained.
-    parsedUrl.search = "";
-    const cleanUrl = parsedUrl.toString();
-
-    // Validate date is parseable and normalize to canonical UTC ISO 8601.
-    const dateMs = Date.parse(date);
-    if (isNaN(dateMs)) continue;
-
-    postLinks.push({ url: cleanUrl, title, date: new Date(dateMs).toISOString() });
-  }
-
-  return postLinks;
-}
+import {
+  fetchFeedXml,
+  parseRssFeedItems,
+  RSS_FEED_FETCH_TIMEOUT_MS,
+} from "../shared/rss";
 
 const UNWANTED_ELEMENTS = [
   "script",
@@ -114,6 +33,26 @@ export function mergePostDetails(
     dateText: rss.date,
     title: extracted.title || rss.title,
   };
+}
+
+/**
+ * Fetch the RSS feed XML for the sofia.bg repairs page.
+ */
+export { fetchFeedXml, RSS_FEED_FETCH_TIMEOUT_MS as FEED_FETCH_TIMEOUT_MS };
+
+/**
+ * Parse RSS feed XML into a list of post links.
+ */
+export function parseFeedItems(xml: string): PostLink[] {
+  return parseRssFeedItems(xml, {
+    hostname: "www.sofia.bg",
+    dateTag: "dc:date",
+    stripQuery: true,
+  }).map((item) => ({
+    url: item.url,
+    title: item.title,
+    date: item.date,
+  }));
 }
 
 /**


### PR DESCRIPTION
- Add shared RSS parser (fetchFeedXml, parseRssFeedItems) for reusable feed handling
- Convert rayon-oborishte-bg to discover articles via RSS instead of Playwright index scraping
- Preserve browser-based detail-page fetching for full article body extraction
- Refactor sofia-bg to use shared RSS helper, reducing duplication
- Replace oborishte tests with RSS-focused test coverage (5 tests)
- Merge RSS metadata with page extraction for canonical dates and title fallbacks