### PR TITLE
feat(open-source): make open-data sources instance-configurable

### DIFF
--- a/shared/src/geocoding-source-definition.ts
+++ b/shared/src/geocoding-source-definition.ts
@@ -40,3 +40,10 @@ export interface GeocodingSourceMetadata {
   readonly name: string;
   readonly url: string;
 }
+
+/** Shape of an open-data source entry displayed on the /open-source page */
+export interface OpenDataSource {
+  readonly name: string;
+  readonly url: string;
+  readonly description: string;
+}

--- a/shared/src/geocoding-sources.ts
+++ b/shared/src/geocoding-sources.ts
@@ -1,6 +1,14 @@
-export type { GeocodingResolverConfig, GeocodingSourceMetadata } from "./geocoding-source-definition";
+export type {
+  GeocodingResolverConfig,
+  GeocodingSourceMetadata,
+  OpenDataSource,
+} from "./geocoding-source-definition";
 
-import type { GeocodingResolverConfig, GeocodingSourceMetadata } from "./geocoding-source-definition";
+import type {
+  GeocodingResolverConfig,
+  GeocodingSourceMetadata,
+  OpenDataSource,
+} from "./geocoding-source-definition";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // INSTANCE ASSEMBLY — replace this file in your fork
@@ -25,13 +33,43 @@ export const GEOCODING_RESOLVERS: GeocodingResolverConfig = {
   pins: { provider: "google" },
   streets: { provider: "overpass" },
   "cadastral-properties": { provider: "cadastre" },
-  "bus-stops": { provider: "gtfs", url: "https://gtfs.sofiatraffic.bg/api/v1/static" },
+  "bus-stops": {
+    provider: "gtfs",
+    url: "https://gtfs.sofiatraffic.bg/api/v1/static",
+  },
   "educational-facilities": {
     provider: "educational-facilities",
     "schools-url": "https://api.sofiaplan.bg/datasets/166",
     "kindergartens-url": "https://api.sofiaplan.bg/datasets/142",
   },
 };
+
+/**
+ * Open-data sources displayed on the /open-source page.
+ * Fork operators replace this with their city's public datasets.
+ */
+export const OPEN_DATA_SOURCES: readonly OpenDataSource[] = [
+  {
+    name: "Sofia Traffic GTFS",
+    url: "https://gtfs.sofiatraffic.bg",
+    description: "спирки и маршрути на градския транспорт",
+  },
+  {
+    name: "Sofia Plan",
+    url: "https://sofiaplan.bg",
+    description: "училища и детски градини от Столична община",
+  },
+  {
+    name: "OpenStreetMap",
+    url: "https://www.openstreetmap.org",
+    description: "геокодиране и улична геометрия",
+  },
+  {
+    name: "sensor.community",
+    url: "https://sensor.community",
+    description: "данни за качеството на въздуха от граждански сензори",
+  },
+];
 
 /**
  * Geocoding source metadata — displayed on the web sources page.
@@ -44,7 +82,11 @@ export const GEOCODING_SOURCES: readonly GeocodingSourceMetadata[] = [
     name: "КАИС Портал - Агенция по геодезия, картография и кадастър",
     url: "https://kais.cadastre.bg",
   },
-  { id: "openstreetmap", name: "OpenStreetMap", url: "https://www.openstreetmap.org" },
+  {
+    id: "openstreetmap",
+    name: "OpenStreetMap",
+    url: "https://www.openstreetmap.org",
+  },
   {
     id: "gtfs-sofia-traffic",
     name: "Статични GTFS данни - urbandata.sofia.bg / sofiatraffic.bg",

--- a/web/app/open-source/OpenDataSection.tsx
+++ b/web/app/open-source/OpenDataSection.tsx
@@ -1,27 +1,5 @@
 import Link from "next/link";
-
-const OPEN_DATA_SOURCES = [
-  {
-    name: "Sofia Traffic GTFS",
-    url: "https://gtfs.sofiatraffic.bg",
-    description: "спирки и маршрути на градския транспорт",
-  },
-  {
-    name: "Sofia Plan",
-    url: "https://sofiaplan.bg",
-    description: "училища и детски градини от Столична община",
-  },
-  {
-    name: "OpenStreetMap",
-    url: "https://www.openstreetmap.org",
-    description: "геокодиране и улична геометрия",
-  },
-  {
-    name: "sensor.community",
-    url: "https://sensor.community",
-    description: "данни за качеството на въздуха от граждански сензори",
-  },
-] as const;
+import { OPEN_DATA_SOURCES } from "@oboapp/shared";
 
 export default function OpenDataSection() {
   return (


### PR DESCRIPTION
## Context

Closes #435

The `/open-source` page hardcoded Sofia-specific open-data source names (`Sofia Traffic GTFS`, `Sofia Plan`, etc.) directly in `OpenDataSection.tsx`. Forks would have had to either ship incorrect information or maintain a divergent copy of the component.

## Changes

- **`shared/src/geocoding-source-definition.ts`** — adds `OpenDataSource` interface (`name`, `url`, `description`) alongside the existing `GeocodingSourceMetadata`
- **`shared/src/geocoding-sources.ts`** — exports `OPEN_DATA_SOURCES` (Sofia defaults) from the existing instance-assembly file. Fork operators already replace this file to configure geocoding; they now configure open-data sources here too — one file, one conflict zone on rebase
- **`web/app/open-source/OpenDataSection.tsx`** — removes the hardcoded local const; renders from `OPEN_DATA_SOURCES` imported from `@oboapp/shared`

## Why this file, not a new one?

`shared/src/geocoding-sources.ts` is already the designated instance-assembly file for display-facing data source metadata (`GEOCODING_SOURCES`). Adding `OPEN_DATA_SOURCES` there avoids introducing a second file for fork operators to manage and keeps the rebase conflict zone consolidated.
