### PR TITLE
fix(terraform): raise heartbeat-check memory to 512Mi (gen2 minimum)

### DIFF
--- a/ingest/terraform/main.tf
+++ b/ingest/terraform/main.tf
@@ -1820,7 +1820,7 @@ resource "google_cloud_run_v2_job" "heartbeat_check" {
         resources {
           limits = {
             cpu    = "1"
-            memory = "256Mi"
+            memory = "512Mi"
           }
         }
 


### PR DESCRIPTION
## Problem

The `heartbeat_check` Cloud Run v2 job was created with `memory = "256Mi"`. GCP's gen2 execution environment with CPU always allocated (unthrottled) requires a minimum of **512Mi**, causing `Terraform Apply` to fail with:

```
Error 400: template.template.containers[0].limits.memory: Invalid value specified for memory.
Total memory < 512 Mi is not supported with gen2 execution environment with cpu always allocated (unthrottled).
```

This was breaking the `vbuch/oboapp` deployment (run [25689847801](https://github.com/vbuch/oboapp/actions/runs/25689847801)).

## Fix

Raise the memory limit from `256Mi` to `512Mi` — the minimum allowed value.

No functional change to the job's behaviour.
