### PR TITLE
feat(web): collapse bulky locations section in message details

### DIFF
--- a/web/components/MessageDetailView/Locations.tsx
+++ b/web/components/MessageDetailView/Locations.tsx
@@ -16,6 +16,28 @@ interface LocationsProps {
   onLocationClick?: (lat: number, lng: number) => void;
 }
 
+type LocationGroups = Pick<
+  LocationsProps,
+  "pins" | "streets" | "busStops" | "cadastralProperties"
+>;
+
+function listSize(list: unknown[] | null | undefined): number {
+  return list?.length ?? 0;
+}
+
+export function getLocationItemCount(groups: LocationGroups): number {
+  return (
+    listSize(groups.pins) +
+    listSize(groups.streets) +
+    listSize(groups.busStops) +
+    listSize(groups.cadastralProperties)
+  );
+}
+
+export function hasAnyLocations(groups: LocationGroups): boolean {
+  return getLocationItemCount(groups) > 0;
+}
+
 // Find matching address for a text by matching against addresses
 function findMatchingAddress(
   text: string,

--- a/web/components/MessageDetailView/MessageDetailView.test.tsx
+++ b/web/components/MessageDetailView/MessageDetailView.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { Message } from "@/lib/types";
 import MessageDetailView from "./MessageDetailView";
 
@@ -50,6 +51,27 @@ vi.mock("./Source", () => ({
 }));
 
 vi.mock("./Locations", () => ({
+  hasAnyLocations: (groups: {
+    pins?: unknown[] | null;
+    streets?: unknown[] | null;
+    busStops?: unknown[] | null;
+    cadastralProperties?: unknown[] | null;
+  }) =>
+    (groups.pins?.length ?? 0) +
+      (groups.streets?.length ?? 0) +
+      (groups.busStops?.length ?? 0) +
+      (groups.cadastralProperties?.length ?? 0) >
+    0,
+  getLocationItemCount: (groups: {
+    pins?: unknown[] | null;
+    streets?: unknown[] | null;
+    busStops?: unknown[] | null;
+    cadastralProperties?: unknown[] | null;
+  }) =>
+    (groups.pins?.length ?? 0) +
+    (groups.streets?.length ?? 0) +
+    (groups.busStops?.length ?? 0) +
+    (groups.cadastralProperties?.length ?? 0),
   default: () => <div data-testid="message-detail-locations" />,
 }));
 
@@ -173,5 +195,91 @@ describe("MessageDetailView AI notice", () => {
     expect(
       screen.getByRole("link", { name: /оригиналния източник/i }),
     ).toBeInTheDocument();
+  });
+
+  it("keeps location sections collapsed by default", () => {
+    render(
+      <MessageDetailView
+        message={{
+          ...baseMessage,
+          pins: [{ address: "ул. Шипка", timespans: [] }],
+          geoJson: {
+            type: "FeatureCollection",
+            features: [
+              {
+                type: "Feature",
+                geometry: { type: "Point", coordinates: [23.32, 42.69] },
+                properties: {},
+              },
+            ],
+          },
+        }}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Покажи локации (1)" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("message-detail-locations")).not.toBeInTheDocument();
+  });
+
+  it("toggles location sections when locations accordion is clicked", async () => {
+    const user = userEvent.setup();
+    render(
+      <MessageDetailView
+        message={{
+          ...baseMessage,
+          pins: [{ address: "ул. Шипка", timespans: [] }],
+          geoJson: {
+            type: "FeatureCollection",
+            features: [
+              {
+                type: "Feature",
+                geometry: { type: "Point", coordinates: [23.32, 42.69] },
+                properties: {},
+              },
+            ],
+          },
+        }}
+        onClose={vi.fn()}
+      />,
+    );
+
+    const toggleButton = screen.getByRole("button", {
+      name: "Покажи локации (1)",
+    });
+    await user.click(toggleButton);
+
+    expect(screen.getByTestId("message-detail-locations")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Скрий локации (1)" }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Скрий локации (1)" }));
+    expect(screen.queryByTestId("message-detail-locations")).not.toBeInTheDocument();
+  });
+
+  it("does not render locations accordion when there are no locations", () => {
+    render(
+      <MessageDetailView
+        message={{
+          ...baseMessage,
+          geoJson: {
+            type: "FeatureCollection",
+            features: [
+              {
+                type: "Feature",
+                geometry: { type: "Point", coordinates: [23.32, 42.69] },
+                properties: {},
+              },
+            ],
+          },
+        }}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText(/локации/i)).not.toBeInTheDocument();
   });
 });

--- a/web/components/MessageDetailView/MessageDetailView.test.tsx
+++ b/web/components/MessageDetailView/MessageDetailView.test.tsx
@@ -85,26 +85,26 @@ const baseMessage: Message = {
   responsibleEntity: "Столична община",
 };
 
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+  vi.stubGlobal("matchMedia", () => ({
+    matches: false,
+    media: "(max-width: 639px)",
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
 describe("MessageDetailView AI notice", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    vi.unstubAllGlobals();
-    vi.stubGlobal("matchMedia", () => ({
-      matches: false,
-      media: "(max-width: 639px)",
-      onchange: null,
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      addListener: vi.fn(),
-      removeListener: vi.fn(),
-      dispatchEvent: vi.fn(),
-    }));
-  });
-
-  afterEach(() => {
-    vi.unstubAllGlobals();
-  });
-
   it("shows source-aware notice when sourceUrl is valid https", () => {
     render(
       <MessageDetailView
@@ -196,7 +196,9 @@ describe("MessageDetailView AI notice", () => {
       screen.getByRole("link", { name: /оригиналния източник/i }),
     ).toBeInTheDocument();
   });
+});
 
+describe("MessageDetailView locations accordion", () => {
   it("keeps location sections collapsed by default", () => {
     render(
       <MessageDetailView
@@ -219,9 +221,9 @@ describe("MessageDetailView AI notice", () => {
     );
 
     expect(
-      screen.getByRole("button", { name: "Покажи локации (1)" }),
+      screen.getByRole("button", { name: "Покажи локация (1)" }),
     ).toBeInTheDocument();
-    expect(screen.queryByTestId("message-detail-locations")).not.toBeInTheDocument();
+    expect(screen.getByTestId("message-detail-locations")).not.toBeVisible();
   });
 
   it("toggles location sections when locations accordion is clicked", async () => {
@@ -247,17 +249,17 @@ describe("MessageDetailView AI notice", () => {
     );
 
     const toggleButton = screen.getByRole("button", {
-      name: "Покажи локации (1)",
+      name: "Покажи локация (1)",
     });
     await user.click(toggleButton);
 
-    expect(screen.getByTestId("message-detail-locations")).toBeInTheDocument();
+    expect(screen.getByTestId("message-detail-locations")).toBeVisible();
     expect(
-      screen.getByRole("button", { name: "Скрий локации (1)" }),
+      screen.getByRole("button", { name: "Скрий локация (1)" }),
     ).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Скрий локации (1)" }));
-    expect(screen.queryByTestId("message-detail-locations")).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Скрий локация (1)" }));
+    expect(screen.getByTestId("message-detail-locations")).not.toBeVisible();
   });
 
   it("does not render locations accordion when there are no locations", () => {

--- a/web/components/MessageDetailView/MessageDetailView.tsx
+++ b/web/components/MessageDetailView/MessageDetailView.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { useCallback, useRef, useState, useSyncExternalStore } from "react";
+import {
+  useCallback,
+  useId,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
+import { ChevronDown } from "lucide-react";
 import { trackEvent } from "@/lib/analytics";
 import { Message } from "@/lib/types";
 import { classifyMessage } from "@/lib/message-classification";
@@ -10,7 +17,7 @@ import { useEscapeKey } from "@/lib/hooks/useEscapeKey";
 import { zIndex } from "@/lib/colors";
 import Header from "./Header";
 import SourceDisplay from "./Source";
-import Locations from "./Locations";
+import Locations, { getLocationItemCount, hasAnyLocations } from "./Locations";
 import DetailItem from "./DetailItem";
 import MessageText from "./MessageText";
 import AiProcessedNotice from "./AiProcessedNotice";
@@ -211,6 +218,9 @@ export default function MessageDetailView({
 
   const headerHandlers = isMobile ? combinedHeaderHandlers : NOOP_DRAG_HANDLERS;
 
+  const [isLocationsOpen, setIsLocationsOpen] = useState(false);
+  const locationsContentId = useId();
+
   // Handle animation state
   const isVisible = useMessageAnimation(message);
 
@@ -224,6 +234,19 @@ export default function MessageDetailView({
   const activeDragOffset =
     pullDownOffset > 0 ? pullDownOffset : fallbackDragOffset;
   const isAnyDragging = isDragging || pullDownOffset > 0;
+  const locationGroups = {
+    pins: message.pins,
+    streets: message.streets,
+    busStops: message.busStops,
+    cadastralProperties: message.cadastralProperties,
+  };
+  const hasLocations = hasAnyLocations(locationGroups);
+  const locationsCount = getLocationItemCount(locationGroups);
+  const hasGeoObjects = (message.geoJson?.features?.length ?? 0) > 0;
+
+  const locationsToggleLabel = isLocationsOpen
+    ? `Скрий локации (${locationsCount})`
+    : `Покажи локации (${locationsCount})`;
 
   return (
     <aside
@@ -303,19 +326,9 @@ export default function MessageDetailView({
           <AiProcessedNotice sourceUrl={message.sourceUrl} />
         )}
 
-        <Locations
-          pins={message.pins}
-          streets={message.streets}
-          busStops={message.busStops}
-          cadastralProperties={message.cadastralProperties}
-          addresses={message.addresses}
-          onLocationClick={onAddressClick}
-        />
-
-        {message.geoJson?.features &&
-          message.geoJson.features.length > 0 &&
+        {hasGeoObjects &&
           (() => {
-            const centroid = getFeaturesCentroid(message.geoJson);
+            const centroid = getFeaturesCentroid(message.geoJson!);
             const isClickable = centroid && onAddressClick;
             const handleGeoClick = () => {
               if (centroid && onAddressClick) {
@@ -326,32 +339,102 @@ export default function MessageDetailView({
             };
             return (
               <DetailItem title="Обекти на картата">
-                {isClickable ? (
-                  <button
-                    type="button"
-                    onClick={handleGeoClick}
-                    className="w-full text-left bg-neutral-light rounded-md p-3 border border-neutral-border hover:bg-info-light hover:border-info-border transition-colors cursor-pointer"
-                  >
-                    <p className="text-sm text-foreground">
-                      {message.geoJson!.features.length}{" "}
-                      {message.geoJson!.features.length === 1
-                        ? "обект"
-                        : "обекта"}{" "}
-                      на картата
-                    </p>
-                  </button>
-                ) : (
-                  <p className="text-sm text-gray-900">
-                    {message.geoJson!.features.length}{" "}
-                    {message.geoJson!.features.length === 1
-                      ? "обект"
-                      : "обекта"}{" "}
-                    на картата
-                  </p>
-                )}
+                <div className="space-y-3">
+                  <div className="flex flex-col gap-2 sm:flex-row">
+                    {isClickable ? (
+                      <button
+                        type="button"
+                        onClick={handleGeoClick}
+                        className="flex-1 text-left bg-neutral-light rounded-md p-3 border border-neutral-border hover:bg-info-light hover:border-info-border transition-colors cursor-pointer"
+                      >
+                        <p className="text-sm text-foreground">
+                          {message.geoJson!.features.length}{" "}
+                          {message.geoJson!.features.length === 1
+                            ? "обект"
+                            : "обекта"}{" "}
+                          на картата
+                        </p>
+                      </button>
+                    ) : (
+                      <div className="flex-1 text-left bg-neutral-light rounded-md p-3 border border-neutral-border">
+                        <p className="text-sm text-gray-900">
+                          {message.geoJson!.features.length}{" "}
+                          {message.geoJson!.features.length === 1
+                            ? "обект"
+                            : "обекта"}{" "}
+                          на картата
+                        </p>
+                      </div>
+                    )}
+
+                    {hasLocations && (
+                      <button
+                        type="button"
+                        onClick={() => setIsLocationsOpen((current) => !current)}
+                        aria-expanded={isLocationsOpen}
+                        aria-controls={locationsContentId}
+                        className="w-full sm:w-auto inline-flex items-center justify-between gap-2 text-sm font-medium text-neutral-dark bg-neutral-light rounded-md p-3 border border-neutral-border hover:bg-info-light hover:border-info-border transition-colors cursor-pointer"
+                      >
+                        <span>{locationsToggleLabel}</span>
+                        <ChevronDown
+                          className={`h-4 w-4 transition-transform ${
+                            isLocationsOpen ? "rotate-180" : ""
+                          }`}
+                        />
+                      </button>
+                    )}
+                  </div>
+
+                  {hasLocations && isLocationsOpen && (
+                    <div id={locationsContentId} role="region" className="pt-1">
+                      <Locations
+                        pins={message.pins}
+                        streets={message.streets}
+                        busStops={message.busStops}
+                        cadastralProperties={message.cadastralProperties}
+                        addresses={message.addresses}
+                        onLocationClick={onAddressClick}
+                      />
+                    </div>
+                  )}
+                </div>
               </DetailItem>
             );
           })()}
+
+        {!hasGeoObjects && hasLocations && (
+          <DetailItem title="Локации">
+            <div className="space-y-3">
+              <button
+                type="button"
+                onClick={() => setIsLocationsOpen((current) => !current)}
+                aria-expanded={isLocationsOpen}
+                aria-controls={locationsContentId}
+                className="w-full inline-flex items-center justify-between gap-2 text-sm font-medium text-neutral-dark bg-neutral-light rounded-md p-3 border border-neutral-border hover:bg-info-light hover:border-info-border transition-colors cursor-pointer"
+              >
+                <span>{locationsToggleLabel}</span>
+                <ChevronDown
+                  className={`h-4 w-4 transition-transform ${
+                    isLocationsOpen ? "rotate-180" : ""
+                  }`}
+                />
+              </button>
+
+              {isLocationsOpen && (
+                <div id={locationsContentId} role="region" className="pt-1">
+                  <Locations
+                    pins={message.pins}
+                    streets={message.streets}
+                    busStops={message.busStops}
+                    cadastralProperties={message.cadastralProperties}
+                    addresses={message.addresses}
+                    onLocationClick={onAddressClick}
+                  />
+                </div>
+              )}
+            </div>
+          </DetailItem>
+        )}
       </div>
     </aside>
   );

--- a/web/components/MessageDetailView/MessageDetailView.tsx
+++ b/web/components/MessageDetailView/MessageDetailView.tsx
@@ -51,6 +51,10 @@ function getIsMobileServer() {
   return false;
 }
 
+function formatLocationNoun(count: number): string {
+  return count === 1 ? "локация" : "локации";
+}
+
 const INITIAL_PANEL_HEIGHT_VH = 50;
 const EXPANDED_PANEL_HEIGHT_VH = 90;
 const DRAG_CLOSE_THRESHOLD = 60;
@@ -218,7 +222,13 @@ export default function MessageDetailView({
 
   const headerHandlers = isMobile ? combinedHeaderHandlers : NOOP_DRAG_HANDLERS;
 
-  const [isLocationsOpen, setIsLocationsOpen] = useState(false);
+  const [locationsAccordionState, setLocationsAccordionState] = useState<{
+    messageId: string | null;
+    isOpen: boolean;
+  }>({
+    messageId: null,
+    isOpen: false,
+  });
   const locationsContentId = useId();
 
   // Handle animation state
@@ -243,10 +253,24 @@ export default function MessageDetailView({
   const hasLocations = hasAnyLocations(locationGroups);
   const locationsCount = getLocationItemCount(locationGroups);
   const hasGeoObjects = (message.geoJson?.features?.length ?? 0) > 0;
+  const locationNoun = formatLocationNoun(locationsCount);
+  const isLocationsOpen =
+    locationsAccordionState.messageId === message.id &&
+    locationsAccordionState.isOpen;
+
+  const toggleLocationsAccordion = () => {
+    setLocationsAccordionState((current) => {
+      const sameMessage = current.messageId === message.id;
+      return {
+        messageId: message.id ?? null,
+        isOpen: sameMessage ? !current.isOpen : true,
+      };
+    });
+  };
 
   const locationsToggleLabel = isLocationsOpen
-    ? `Скрий локации (${locationsCount})`
-    : `Покажи локации (${locationsCount})`;
+    ? `Скрий ${locationNoun} (${locationsCount})`
+    : `Покажи ${locationNoun} (${locationsCount})`;
 
   return (
     <aside
@@ -370,7 +394,7 @@ export default function MessageDetailView({
                     {hasLocations && (
                       <button
                         type="button"
-                        onClick={() => setIsLocationsOpen((current) => !current)}
+                        onClick={toggleLocationsAccordion}
                         aria-expanded={isLocationsOpen}
                         aria-controls={locationsContentId}
                         className="w-full sm:w-auto inline-flex items-center justify-between gap-2 text-sm font-medium text-neutral-dark bg-neutral-light rounded-md p-3 border border-neutral-border hover:bg-info-light hover:border-info-border transition-colors cursor-pointer"
@@ -385,8 +409,13 @@ export default function MessageDetailView({
                     )}
                   </div>
 
-                  {hasLocations && isLocationsOpen && (
-                    <div id={locationsContentId} role="region" className="pt-1">
+                  {hasLocations && (
+                    <div
+                      id={locationsContentId}
+                      role="region"
+                      className="pt-1"
+                      hidden={!isLocationsOpen}
+                    >
                       <Locations
                         pins={message.pins}
                         streets={message.streets}
@@ -403,37 +432,38 @@ export default function MessageDetailView({
           })()}
 
         {!hasGeoObjects && hasLocations && (
-          <DetailItem title="Локации">
-            <div className="space-y-3">
-              <button
-                type="button"
-                onClick={() => setIsLocationsOpen((current) => !current)}
-                aria-expanded={isLocationsOpen}
-                aria-controls={locationsContentId}
-                className="w-full inline-flex items-center justify-between gap-2 text-sm font-medium text-neutral-dark bg-neutral-light rounded-md p-3 border border-neutral-border hover:bg-info-light hover:border-info-border transition-colors cursor-pointer"
-              >
-                <span>{locationsToggleLabel}</span>
-                <ChevronDown
-                  className={`h-4 w-4 transition-transform ${
-                    isLocationsOpen ? "rotate-180" : ""
-                  }`}
-                />
-              </button>
+          <div className="space-y-3">
+            <button
+              type="button"
+              onClick={toggleLocationsAccordion}
+              aria-expanded={isLocationsOpen}
+              aria-controls={locationsContentId}
+              className="w-full inline-flex items-center justify-between gap-2 text-sm font-medium text-neutral-dark bg-neutral-light rounded-md p-3 border border-neutral-border hover:bg-info-light hover:border-info-border transition-colors cursor-pointer"
+            >
+              <span>{locationsToggleLabel}</span>
+              <ChevronDown
+                className={`h-4 w-4 transition-transform ${
+                  isLocationsOpen ? "rotate-180" : ""
+                }`}
+              />
+            </button>
 
-              {isLocationsOpen && (
-                <div id={locationsContentId} role="region" className="pt-1">
-                  <Locations
-                    pins={message.pins}
-                    streets={message.streets}
-                    busStops={message.busStops}
-                    cadastralProperties={message.cadastralProperties}
-                    addresses={message.addresses}
-                    onLocationClick={onAddressClick}
-                  />
-                </div>
-              )}
+            <div
+              id={locationsContentId}
+              role="region"
+              className="pt-1"
+              hidden={!isLocationsOpen}
+            >
+              <Locations
+                pins={message.pins}
+                streets={message.streets}
+                busStops={message.busStops}
+                cadastralProperties={message.cadastralProperties}
+                addresses={message.addresses}
+                onLocationClick={onAddressClick}
+              />
             </div>
-          </DetailItem>
+          </div>
         )}
       </div>
     </aside>


### PR DESCRIPTION
## Summary
- move detailed location cards in message details behind a collapsed-by-default accordion
- place the locations accordion toggle next to the "objects on map" control when geo objects are present
- keep map-centering behavior for geo objects and existing location click navigation intact
- add location presence/count helpers and cover accordion behavior with MessageDetailView tests

## Testing
- runTests web/components/MessageDetailView/MessageDetailView.test.tsx web/components/MessageDetailView/Locations.test.tsx
- pnpm -C web exec tsc --noEmit -p tsconfig.json
- pnpm -C web lint (warnings only from pre-existing no-console usage)

Closes #453
