### PR TITLE
feat: show linked messages accordion in message detail view (issue #457)

### DIFF
--- a/web/app/api/messages/by-id/route.ts
+++ b/web/app/api/messages/by-id/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 import { isValidMessageId } from "@oboapp/shared";
-import { recordToMessage } from "@/lib/doc-to-message";
+import { recordToInternalMessage } from "@/lib/doc-to-message";
 
 /**
  * Strip a trailing split-index suffix (e.g. "-1", "-2") from a
@@ -37,7 +37,7 @@ export async function GET(request: Request) {
     if (isValidMessageId(id)) {
       const doc = await db.messages.findById(id);
       if (doc) {
-        return NextResponse.json({ message: recordToMessage(doc) });
+        return NextResponse.json({ message: recordToInternalMessage(doc) });
       }
       return NextResponse.json({ error: "Message not found" }, { status: 404 });
     }
@@ -47,7 +47,7 @@ export async function GET(request: Request) {
     const docs = await db.messages.findBySourceDocumentIds([sourceDocId]);
 
     if (docs.length > 0) {
-      return NextResponse.json({ message: recordToMessage(docs[0]) });
+      return NextResponse.json({ message: recordToInternalMessage(docs[0]) });
     }
 
     return NextResponse.json({ error: "Message not found" }, { status: 404 });

--- a/web/app/api/messages/route.ts
+++ b/web/app/api/messages/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
-import type { Message } from "@/lib/types";
+import type { InternalMessage } from "@/lib/types";
 import {
   clampBounds,
   addBuffer,
@@ -9,7 +9,7 @@ import {
 } from "@/lib/bounds-utils";
 import { getCentroid } from "@/lib/geometry-utils";
 import { messagesQuerySchema } from "@/lib/api-query.schema";
-import { recordToMessage } from "@/lib/doc-to-message";
+import { recordToInternalMessage } from "@/lib/doc-to-message";
 
 const DEFAULT_RELEVANCE_DAYS = 7;
 const CLUSTER_ZOOM_THRESHOLD = 15;
@@ -18,7 +18,7 @@ const FIRESTORE_IN_OPERATOR_LIMIT = 10;
 type DbClient = Awaited<ReturnType<typeof getDb>>;
 type MessageRecord = Record<string, unknown>;
 
-function sortMessagesByRelevance(messages: Message[]): Message[] {
+function sortMessagesByRelevance(messages: InternalMessage[]): InternalMessage[] {
   return [...messages].sort((a, b) => {
     const aFinalizedAt = a.finalizedAt ?? "";
     const bFinalizedAt = b.finalizedAt ?? "";
@@ -118,14 +118,14 @@ async function findMessagesBySources(
   db: DbClient,
   cutoffDate: Date,
   sources: string[],
-): Promise<Message[]> {
+): Promise<InternalMessage[]> {
   const results = await findRecentMessageDocsBySources(db, cutoffDate, sources);
-  const messagesMap = new Map<string, Message>();
+  const messagesMap = new Map<string, InternalMessage>();
 
   for (const doc of results) {
     const docId = typeof doc._id === "string" ? doc._id : "";
     if (docId && !messagesMap.has(docId)) {
-      messagesMap.set(docId, recordToMessage(doc));
+      messagesMap.set(docId, recordToInternalMessage(doc));
     }
   }
 
@@ -149,13 +149,13 @@ async function findUncategorizedDocs(
   return docs.filter((doc) => isUncategorizedDoc(doc));
 }
 
-function dedupeAndMapMessages(docs: MessageRecord[]): Message[] {
-  const messagesMap = new Map<string, Message>();
+function dedupeAndMapMessages(docs: MessageRecord[]): InternalMessage[] {
+  const messagesMap = new Map<string, InternalMessage>();
 
   for (const doc of docs) {
     const docId = typeof doc._id === "string" ? doc._id : "";
     if (docId && !messagesMap.has(docId)) {
-      messagesMap.set(docId, recordToMessage(doc));
+      messagesMap.set(docId, recordToInternalMessage(doc));
     }
   }
 
@@ -232,7 +232,7 @@ async function findMessagesByCategoryFilters(
   cutoffDate: Date,
   selectedCategories: string[],
   sourceSet?: Set<string>,
-): Promise<Message[]> {
+): Promise<InternalMessage[]> {
   const realCategories = selectedCategories.filter(
     (c) => c !== "uncategorized",
   );
@@ -253,7 +253,7 @@ async function findMessagesByCategoryFilters(
     includeUncategorized,
     sourceSet,
   );
-  const messagesMap = new Map<string, Message>();
+  const messagesMap = new Map<string, InternalMessage>();
 
   for (const plan of queryPlans) {
     const docs = applyOptionalSourceSet(plan.docs, sourceSet);
@@ -270,7 +270,7 @@ async function findMessagesByCategoryFilters(
 
       const docId = typeof doc._id === "string" ? doc._id : "";
       if (docId && !messagesMap.has(docId)) {
-        messagesMap.set(docId, recordToMessage(doc));
+        messagesMap.set(docId, recordToInternalMessage(doc));
       }
     }
   }
@@ -279,9 +279,9 @@ async function findMessagesByCategoryFilters(
 }
 
 function filterMessagesByGeoAndViewport(
-  messages: Message[],
+  messages: InternalMessage[],
   viewportBounds: ViewportBounds | null,
-): Message[] {
+): InternalMessage[] {
   let filtered = messages.filter(
     (message) => message.geoJson !== null && message.geoJson !== undefined,
   );
@@ -303,9 +303,9 @@ function filterMessagesByGeoAndViewport(
 }
 
 function simplifyMessagesForClusterZoom(
-  messages: Message[],
+  messages: InternalMessage[],
   zoom?: number,
-): Message[] {
+): InternalMessage[] {
   if (zoom === undefined || zoom >= CLUSTER_ZOOM_THRESHOLD) {
     return messages;
   }
@@ -408,7 +408,7 @@ export async function GET(request: Request) {
       return NextResponse.json({ messages: [] });
     }
 
-    let allMessages: Message[] = [];
+    let allMessages: InternalMessage[] = [];
     const hasSourceFilter = validatedSources && validatedSources.length > 0;
     const hasCategoryFilter =
       selectedCategories && selectedCategories.length > 0;
@@ -433,7 +433,7 @@ export async function GET(request: Request) {
         orderBy: [{ field: "timespanEnd", direction: "desc" }],
       });
 
-      allMessages = docs.map(recordToMessage);
+      allMessages = docs.map(recordToInternalMessage);
     }
 
     let messages = filterMessagesByGeoAndViewport(allMessages, viewportBounds);

--- a/web/app/api/v1/messages/route.test.ts
+++ b/web/app/api/v1/messages/route.test.ts
@@ -80,6 +80,34 @@ describe("GET /api/v1/messages", () => {
     );
   });
 
+  it("strips eventId from messages so it is never exposed in the public API", async () => {
+    validateApiKeyMock.mockResolvedValue(true);
+    getMessagesMock.mockResolvedValue(
+      Response.json(
+        {
+          messages: [
+            {
+              id: "abc12345",
+              text: "test",
+              locality: "Sofia",
+              createdAt: "2024-01-01T00:00:00.000Z",
+              cityWide: false,
+              eventId: "evt-should-be-stripped",
+            },
+          ],
+        },
+        { status: 200 },
+      ),
+    );
+
+    const request = new Request("http://localhost/api/v1/messages");
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.messages[0]).not.toHaveProperty("eventId");
+  });
+
   it("delegates to internal handler and passes through non-ok responses", async () => {
     validateApiKeyMock.mockResolvedValue(true);
     getMessagesMock.mockResolvedValue(

--- a/web/components/EventAccordion.tsx
+++ b/web/components/EventAccordion.tsx
@@ -8,6 +8,7 @@ import sources from "@/lib/sources";
 import { stripMarkdown } from "@/lib/markdown-utils";
 import { createSnippet } from "@/lib/text-utils";
 import { formatTimespan } from "@/lib/date-format";
+import { createMessageUrlFromId } from "@/lib/url-utils";
 import CategoryChips from "@/components/CategoryChips";
 import SourceLogo from "@/components/SourceLogo";
 import LoadingSpinner from "@/components/LoadingSpinner";
@@ -41,8 +42,8 @@ function MessageRow({
   const displayText = message.markdownText || message.text;
   const snippet = makeSnippet(displayText, 120);
 
-  return (
-    <div className="flex items-start gap-3 py-2 px-3 border-b border-neutral-border last:border-b-0">
+  const rowContent = (
+    <>
       <div className="flex-shrink-0 mt-0.5">
         {message.source && <SourceLogo sourceId={message.source} />}
       </div>
@@ -62,8 +63,21 @@ function MessageRow({
         </div>
         <p className="text-sm text-neutral leading-relaxed">{snippet}</p>
       </div>
-    </div>
+    </>
   );
+
+  const rowClass =
+    "flex items-start gap-3 py-2 px-3 border-b border-neutral-border last:border-b-0 hover:bg-neutral-light/50 transition-colors";
+
+  if (message.id) {
+    return (
+      <a href={createMessageUrlFromId(message.id)} className={rowClass}>
+        {rowContent}
+      </a>
+    );
+  }
+
+  return <div className={rowClass}>{rowContent}</div>;
 }
 
 function EventMessagesBody({ eventId }: { readonly eventId: string }) {

--- a/web/components/MessageDetailView/LinkedMessagesAccordion.test.tsx
+++ b/web/components/MessageDetailView/LinkedMessagesAccordion.test.tsx
@@ -1,0 +1,180 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import LinkedMessagesAccordion from "./LinkedMessagesAccordion";
+
+const { useQueryMock } = vi.hoisted(() => ({
+  useQueryMock: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: useQueryMock,
+}));
+
+vi.mock("@/lib/sources", () => ({
+  default: [{ id: "sofiatraffic", name: "СофияТрафик" }],
+}));
+
+vi.mock("@/components/SourceLogo", () => ({
+  default: ({ sourceId }: { sourceId: string }) => (
+    <span data-testid={`logo-${sourceId}`} />
+  ),
+}));
+
+const sibling = {
+  id: "m2",
+  text: "Свързано съобщение",
+  markdownText: "Свързано съобщение",
+  source: "sofiatraffic",
+  locality: "bg.sofia",
+  createdAt: "2026-05-01T00:00:00.000Z",
+};
+
+const eventMessage = {
+  id: "em2",
+  eventId: "evt1",
+  messageId: "m2",
+  source: "sofiatraffic",
+  confidence: 0.85,
+  geometryQuality: 2,
+  createdAt: "2026-05-01T00:00:00.000Z",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("LinkedMessagesAccordion", () => {
+  it("renders nothing while loading", () => {
+    useQueryMock.mockReturnValue({ data: undefined, isLoading: true });
+
+    const { container } = render(
+      <LinkedMessagesAccordion eventId="evt1" currentMessageId="m1" />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when there are no siblings after filtering current message", () => {
+    useQueryMock.mockReturnValue({
+      data: {
+        messages: [{ ...sibling, id: "m1" }],
+        eventMessages: [{ ...eventMessage, messageId: "m1" }],
+      },
+      isLoading: false,
+    });
+
+    const { container } = render(
+      <LinkedMessagesAccordion eventId="evt1" currentMessageId="m1" />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders an error message when the fetch fails", () => {
+    useQueryMock.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error("Network error"),
+    });
+
+    render(
+      <LinkedMessagesAccordion eventId="evt1" currentMessageId="m1" />,
+    );
+
+    expect(
+      screen.getByText(/Грешка при зареждане на свързаните съобщения\./),
+    ).toBeInTheDocument();
+  });
+
+  it("renders nothing when sibling has no id", () => {
+    useQueryMock.mockReturnValue({
+      data: {
+        messages: [{ ...sibling, id: undefined }],
+        eventMessages: [],
+      },
+      isLoading: false,
+    });
+
+    const { container } = render(
+      <LinkedMessagesAccordion eventId="evt1" currentMessageId="m1" />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders collapsed toggle button showing sibling count when siblings exist", () => {
+    useQueryMock.mockReturnValue({
+      data: { messages: [sibling], eventMessages: [eventMessage] },
+      isLoading: false,
+    });
+
+    render(
+      <LinkedMessagesAccordion eventId="evt1" currentMessageId="m1" />,
+    );
+
+    const button = screen.getByRole("button", {
+      name: "Свързани съобщения (1)",
+    });
+    expect(button).toHaveAttribute("aria-expanded", "false");
+    expect(screen.getByRole("region", { hidden: true })).not.toBeVisible();
+  });
+
+  it("expands and shows sibling rows on click", async () => {
+    const user = userEvent.setup();
+    useQueryMock.mockReturnValue({
+      data: { messages: [sibling], eventMessages: [eventMessage] },
+      isLoading: false,
+    });
+
+    render(
+      <LinkedMessagesAccordion eventId="evt1" currentMessageId="m1" />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Свързани съобщения (1)" }));
+
+    expect(screen.getByRole("region")).toBeVisible();
+    expect(screen.getByText("Свързано съобщение")).toBeInTheDocument();
+    expect(screen.getByText("85%")).toBeInTheDocument();
+  });
+
+  it("excludes the current message from the displayed list", () => {
+    useQueryMock.mockReturnValue({
+      data: {
+        messages: [
+          sibling,
+          { ...sibling, id: "m1", text: "Текущо съобщение" },
+        ],
+        eventMessages: [
+          eventMessage,
+          { ...eventMessage, messageId: "m1" },
+        ],
+      },
+      isLoading: false,
+    });
+
+    render(
+      <LinkedMessagesAccordion eventId="evt1" currentMessageId="m1" />,
+    );
+
+    expect(screen.getByRole("button", { name: "Свързани съобщения (1)" })).toBeInTheDocument();
+    expect(screen.queryByText("Текущо съобщение")).not.toBeInTheDocument();
+  });
+
+  it("sibling rows are links to the message detail page", async () => {
+    const user = userEvent.setup();
+    useQueryMock.mockReturnValue({
+      data: { messages: [sibling], eventMessages: [eventMessage] },
+      isLoading: false,
+    });
+
+    render(
+      <LinkedMessagesAccordion eventId="evt1" currentMessageId="m1" />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Свързани съобщения (1)" }));
+
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "/?messageId=m2");
+  });
+});

--- a/web/components/MessageDetailView/LinkedMessagesAccordion.tsx
+++ b/web/components/MessageDetailView/LinkedMessagesAccordion.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useState, useId } from "react";
+import { ChevronDown } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
+import type { Message, EventMessage } from "@oboapp/shared";
+import sources from "@/lib/sources";
+import { stripMarkdown } from "@/lib/markdown-utils";
+import { createSnippet } from "@/lib/text-utils";
+import { createMessageUrlFromId } from "@/lib/url-utils";
+import SourceLogo from "@/components/SourceLogo";
+
+interface LinkedMessagesAccordionProps {
+  readonly eventId: string;
+  readonly currentMessageId: string;
+}
+
+type EventMessagesResponse = {
+  messages: Message[];
+  eventMessages: EventMessage[];
+};
+
+function makeSnippet(text: string): string {
+  return createSnippet(stripMarkdown(text), 120);
+}
+
+function formatConfidence(confidence: number): string {
+  return `${Math.round(confidence * 100)}%`;
+}
+
+function SiblingRow({
+  message,
+  eventMessage,
+}: {
+  readonly message: Message & { id: string };
+  readonly eventMessage: EventMessage | undefined;
+}) {
+  const sourceInfo = sources.find((s) => s.id === message.source);
+  const displayText = message.markdownText || message.text;
+
+  return (
+    <a
+      href={createMessageUrlFromId(message.id)}
+      className="flex items-start gap-3 py-2 px-3 border-b border-neutral-border last:border-b-0 hover:bg-neutral-light/50 transition-colors"
+    >
+      <div className="flex-shrink-0 mt-0.5">
+        {message.source && <SourceLogo sourceId={message.source} />}
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 mb-0.5">
+          <span className="text-sm font-medium text-neutral-dark truncate">
+            {sourceInfo?.name || message.source || "Неизвестен"}
+          </span>
+          {eventMessage && (
+            <span
+              className="text-sm text-neutral flex-shrink-0"
+              title="Увереност на съвпадението"
+            >
+              {formatConfidence(eventMessage.confidence)}
+            </span>
+          )}
+        </div>
+        <p className="text-sm text-neutral leading-relaxed">
+          {makeSnippet(displayText)}
+        </p>
+      </div>
+    </a>
+  );
+}
+
+export default function LinkedMessagesAccordion({
+  eventId,
+  currentMessageId,
+}: LinkedMessagesAccordionProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const contentId = useId();
+  const labelId = useId();
+
+  const { data, isLoading, error } = useQuery<EventMessagesResponse>({
+    queryKey: ["eventMessages", eventId],
+    queryFn: async ({ signal }) => {
+      const res = await fetch(
+        `/api/events/messages?eventId=${encodeURIComponent(eventId)}`,
+        { signal },
+      );
+      if (!res.ok) throw new Error("Failed to fetch event messages");
+      return res.json();
+    },
+  });
+
+  const siblings = data
+    ? {
+        messages: data.messages.filter(
+          (m): m is typeof m & { id: string } =>
+            !!m.id && m.id !== currentMessageId,
+        ),
+        eventMessages: data.eventMessages.filter(
+          (em) => em.messageId !== currentMessageId,
+        ),
+      }
+    : null;
+
+  if (isLoading) return null;
+
+  if (error) {
+    return (
+      <p className="text-sm text-error px-1">
+        Грешка при зареждане на свързаните съобщения.
+      </p>
+    );
+  }
+
+  if (!siblings || siblings.messages.length === 0) {
+    return null;
+  }
+
+  const toggleLabel = `Свързани съобщения (${siblings.messages.length})`;
+  const eventMessagesByMessageId = new Map(
+    siblings.eventMessages.map((em) => [em.messageId, em]),
+  );
+
+  return (
+    <div className="space-y-3">
+      <button
+        type="button"
+        onClick={() => setIsOpen((prev) => !prev)}
+        aria-expanded={isOpen}
+        aria-controls={contentId}
+        className="w-full inline-flex items-center justify-between gap-2 text-sm font-medium text-neutral-dark bg-neutral-light rounded-md p-3 border border-neutral-border hover:bg-info-light hover:border-info-border transition-colors cursor-pointer"
+      >
+        <span id={labelId}>{toggleLabel}</span>
+        <ChevronDown
+          className={`h-4 w-4 transition-transform ${isOpen ? "rotate-180" : ""}`}
+        />
+      </button>
+
+      <div id={contentId} role="region" aria-labelledby={labelId} hidden={!isOpen}>
+        <div className="border border-neutral-border rounded-md bg-neutral-light/30 overflow-hidden">
+          {siblings.messages.map((message) => (
+            <SiblingRow
+              key={message.id}
+              message={message}
+              eventMessage={eventMessagesByMessageId.get(message.id ?? "")}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/components/MessageDetailView/MessageDetailView.test.tsx
+++ b/web/components/MessageDetailView/MessageDetailView.test.tsx
@@ -50,6 +50,12 @@ vi.mock("./Source", () => ({
   default: () => <div data-testid="message-detail-source" />,
 }));
 
+vi.mock("./LinkedMessagesAccordion", () => ({
+  default: ({ eventId, currentMessageId }: { eventId: string; currentMessageId: string }) => (
+    <div data-testid="linked-messages-accordion" data-event-id={eventId} data-current-message-id={currentMessageId} />
+  ),
+}));
+
 vi.mock("./Locations", () => ({
   hasAnyLocations: (groups: {
     pins?: unknown[] | null;
@@ -363,5 +369,43 @@ describe("MessageDetailView locations accordion", () => {
     );
 
     expect(screen.queryByText(/локации/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("MessageDetailView linked messages accordion", () => {
+  it("does not render when message has no eventId", () => {
+    render(<MessageDetailView message={baseMessage} onClose={vi.fn()} />);
+
+    expect(
+      screen.queryByTestId("linked-messages-accordion"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not render when message has no id", () => {
+    const { id: _id, ...messageWithoutId } = baseMessage;
+    render(
+      <MessageDetailView
+        message={{ ...messageWithoutId, eventId: "evt1" }}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.queryByTestId("linked-messages-accordion"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders accordion with correct props when message has eventId and id", () => {
+    render(
+      <MessageDetailView
+        message={{ ...baseMessage, eventId: "evt1" }}
+        onClose={vi.fn()}
+      />,
+    );
+
+    const accordion = screen.getByTestId("linked-messages-accordion");
+    expect(accordion).toBeInTheDocument();
+    expect(accordion).toHaveAttribute("data-event-id", "evt1");
+    expect(accordion).toHaveAttribute("data-current-message-id", "m1");
   });
 });

--- a/web/components/MessageDetailView/MessageDetailView.tsx
+++ b/web/components/MessageDetailView/MessageDetailView.tsx
@@ -9,7 +9,7 @@ import {
 } from "react";
 import { ChevronDown } from "lucide-react";
 import { trackEvent } from "@/lib/analytics";
-import { Message } from "@/lib/types";
+import type { InternalMessage } from "@/lib/types";
 import { classifyMessage } from "@/lib/message-classification";
 import { useDragPanel, type DragHandlers } from "@/lib/hooks/useDragPanel";
 import { useMessageAnimation } from "@/lib/hooks/useMessageAnimation";
@@ -24,6 +24,7 @@ import AiProcessedNotice, { hasValidSourceUrl } from "./AiProcessedNotice";
 import CategoryChips from "@/components/CategoryChips";
 import ExternalLinkIcon from "@/components/icons/ExternalLinkIcon";
 import { getFeaturesCentroid } from "@/lib/geometry-utils";
+import LinkedMessagesAccordion from "./LinkedMessagesAccordion";
 
 type CloseMethod = "drag" | "esc";
 
@@ -72,7 +73,7 @@ const NOOP_DRAG_HANDLERS: DragHandlers = {
 };
 
 interface MessageDetailViewProps {
-  readonly message: Message | null;
+  readonly message: InternalMessage | null;
   readonly onClose: () => void;
   readonly onAddressClick?: (lat: number, lng: number) => void;
 }
@@ -488,6 +489,13 @@ export default function MessageDetailView({
               />
             </div>
           </div>
+        )}
+
+        {message.eventId && message.id && (
+          <LinkedMessagesAccordion
+            eventId={message.eventId}
+            currentMessageId={message.id}
+          />
         )}
       </div>
     </aside>

--- a/web/lib/doc-to-message.ts
+++ b/web/lib/doc-to-message.ts
@@ -1,4 +1,4 @@
-import type { Message } from "@/lib/types";
+import type { InternalMessage, Message } from "@/lib/types";
 import {
   toOptionalISOString,
   toRequiredISOString,
@@ -47,5 +47,14 @@ export function recordToMessage(record: Record<string, unknown>): Message {
     streets: getStreets(record.streets),
     cadastralProperties: getCadastralProperties(record.cadastralProperties),
     busStops: getBusStops(record.busStops),
+  };
+}
+
+export function recordToInternalMessage(
+  record: Record<string, unknown>,
+): InternalMessage {
+  return {
+    ...recordToMessage(record),
+    eventId: optionalString(record.eventId),
   };
 }

--- a/web/lib/hooks/useMessageByIdFallback.ts
+++ b/web/lib/hooks/useMessageByIdFallback.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { isValidMessageId } from "@oboapp/shared";
-import type { Message } from "@/lib/types";
+import type { InternalMessage } from "@/lib/types";
 
 /**
  * Resolves a selected message from a URL `messageId` parameter.
@@ -16,11 +16,11 @@ import type { Message } from "@/lib/types";
  */
 export function useMessageByIdFallback(
   messageId: string | null,
-  listMatch: Message | null,
-): Message | null {
+  listMatch: InternalMessage | null,
+): InternalMessage | null {
   const [fetchedMessage, setFetchedMessage] = useState<{
     id: string;
-    message: Message;
+    message: InternalMessage;
   } | null>(null);
 
   // Tracks the messageId for which a fetch has been initiated, so the effect

--- a/web/lib/hooks/useMessages.ts
+++ b/web/lib/hooks/useMessages.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect, useMemo, useRef } from "react";
-import { Message } from "@/lib/types";
+import type { InternalMessage } from "@/lib/types";
 import { buildMessagesUrl } from "./useMessages.utils";
 import { debounce } from "@/lib/debounce";
 import type { Category } from "@oboapp/shared";
@@ -23,7 +23,7 @@ interface ViewportBounds {
  * - Message submission event listener
  */
 export function useMessages() {
-  const [messages, setMessages] = useState<Message[]>([]);
+  const [messages, setMessages] = useState<InternalMessage[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [viewportBounds, setViewportBounds] = useState<ViewportBounds | null>(


### PR DESCRIPTION
When a message belongs to an event, a collapsed "Свързани съобщения" accordion now appears at the bottom of the detail panel. It lazily fetches sibling messages from /api/events/messages on first open and displays each with source, confidence %, and a text snippet.

The BFF API now uses InternalMessage (which carries eventId) while the public /api/v1/messages response is unchanged — Zod strips the extra field automatically when re-parsing through MessageSchema.

https://github.com/oboapp/oboapp/issues/457