### PR TITLE
fix(ingest): lazy Firebase Admin init for Mongo-only mode

### DIFF
--- a/ingest/lib/firebase-admin.ts
+++ b/ingest/lib/firebase-admin.ts
@@ -3,69 +3,113 @@ import { getFirestore, Firestore } from "firebase-admin/firestore";
 import { getAuth, Auth } from "firebase-admin/auth";
 import { logger } from "@/lib/logger";
 
-let adminApp: App;
-let adminDb: Firestore;
-let adminAuth: Auth;
+/**
+ * Lazy Firebase Admin initialization.
+ *
+ * The module no longer throws at import time when FIREBASE_SERVICE_ACCOUNT_KEY
+ * is absent (MongoDB-only mode). Errors are deferred until an exported value is
+ * actually accessed via the proxy objects below.
+ */
 
-const databaseId = process.env.FIREBASE_DATABASE_ID;
-const useEmulators = process.env.USE_FIREBASE_EMULATORS === "true";
+let _adminApp: App | undefined;
+let _adminDb: Firestore | undefined;
+let _adminAuth: Auth | undefined;
+let _initError: Error | null = null;
+let _initialized = false;
 
-// Initialize Firebase Admin SDK
-if (!getApps().length) {
-  if (useEmulators) {
-    // Emulator mode - no credentials needed
-    logger.info("Firebase Admin using emulators");
-    adminApp = initializeApp({
-      projectId: process.env.FIREBASE_PROJECT_ID || "demo-project",
-    });
-  } else {
-    // Production mode - use service account key from environment
-    if (process.env.FIREBASE_SERVICE_ACCOUNT_KEY) {
-      try {
-        const serviceAccount = JSON.parse(
-          process.env.FIREBASE_SERVICE_ACCOUNT_KEY,
-        );
+function initialize(): void {
+  if (_initialized) return;
+  _initialized = true;
 
-        adminApp = initializeApp({
-          credential: cert(serviceAccount),
-          projectId: process.env.FIREBASE_PROJECT_ID,
+  const emulatorHost = process.env.FIRESTORE_EMULATOR_HOST;
+  const useEmulators =
+    process.env.USE_FIREBASE_EMULATORS === "true" || Boolean(emulatorHost);
+
+  try {
+    if (!getApps().length) {
+      if (useEmulators) {
+        // Emulator mode - no credentials needed
+        logger.info("Firebase Admin using emulators");
+        _adminApp = initializeApp({
+          projectId: process.env.FIREBASE_PROJECT_ID || "demo-project",
         });
-      } catch (error) {
-        logger.error("Error parsing FIREBASE_SERVICE_ACCOUNT_KEY", { error: error instanceof Error ? error.message : String(error) });
-        throw new Error(
-          "Failed to initialize Firebase Admin SDK: Invalid service account JSON",
-        );
+      } else {
+        // Production mode - use service account key from environment
+        if (!process.env.FIREBASE_SERVICE_ACCOUNT_KEY) {
+          logger.warn(
+            "Firebase Admin not configured (FIREBASE_SERVICE_ACCOUNT_KEY missing) — running in MongoDB-only mode",
+          );
+          _initError = new Error(
+            "FIREBASE_SERVICE_ACCOUNT_KEY environment variable is required. " +
+              "Please add your Firebase service account JSON to .env.local",
+          );
+          return;
+        }
+        try {
+          const serviceAccount = JSON.parse(
+            process.env.FIREBASE_SERVICE_ACCOUNT_KEY,
+          );
+          _adminApp = initializeApp({
+            credential: cert(serviceAccount),
+            projectId: process.env.FIREBASE_PROJECT_ID,
+          });
+        } catch (error) {
+          logger.error("Error parsing FIREBASE_SERVICE_ACCOUNT_KEY", {
+            error: error instanceof Error ? error.message : String(error),
+          });
+          _initError = new Error(
+            "Failed to initialize Firebase Admin SDK: Invalid service account JSON",
+          );
+          return;
+        }
       }
     } else {
-      logger.error("FIREBASE_SERVICE_ACCOUNT_KEY environment variable not found");
-      throw new Error(
-        "FIREBASE_SERVICE_ACCOUNT_KEY environment variable is required. " +
-          "Please add your Firebase service account JSON to .env.local",
-      );
+      _adminApp = getApps()[0];
     }
-  }
 
-  adminDb = databaseId
-    ? getFirestore(adminApp, databaseId)
-    : getFirestore(adminApp);
-  adminAuth = getAuth(adminApp);
+    const databaseId = process.env.FIREBASE_DATABASE_ID;
+    _adminDb = databaseId
+      ? getFirestore(_adminApp, databaseId)
+      : getFirestore(_adminApp);
+    _adminAuth = getAuth(_adminApp);
 
-  // In emulator mode, ensure we connect to the emulator
-  if (useEmulators) {
-    const emulatorHost =
-      process.env.FIRESTORE_EMULATOR_HOST || "localhost:8080";
-    const [host, port] = emulatorHost.split(":");
-    adminDb.settings({
-      host: `${host}:${port}`,
-      ssl: false,
-    });
+    // In emulator mode, ensure we connect to the emulator
+    if (useEmulators) {
+      const [host, port] = (emulatorHost || "localhost:8080").split(":");
+      _adminDb.settings({
+        host: `${host}:${port}`,
+        ssl: false,
+      });
+    }
+  } catch (error) {
+    _initError = error instanceof Error ? error : new Error(String(error));
   }
-} else {
-  adminApp = getApps()[0];
-  adminDb = databaseId
-    ? getFirestore(adminApp, databaseId)
-    : getFirestore(adminApp);
-  adminAuth = getAuth(adminApp);
 }
 
-export { adminApp, adminDb, adminAuth };
+function makeProxy(label: "adminApp"): App;
+function makeProxy(label: "adminDb"): Firestore;
+function makeProxy(label: "adminAuth"): Auth;
+function makeProxy(
+  label: "adminApp" | "adminDb" | "adminAuth",
+): App | Firestore | Auth {
+  return new Proxy<App | Firestore | Auth>(Object.create(null), {
+    get(_target, prop) {
+      initialize();
+      const instance =
+        label === "adminDb"
+          ? _adminDb
+          : label === "adminAuth"
+            ? _adminAuth
+            : _adminApp;
+      if (!instance) {
+        throw _initError ?? new Error(`Firebase ${label} is not available`);
+      }
+      const value = Reflect.get(instance, prop);
+      return typeof value === "function" ? value.bind(instance) : value;
+    },
+  });
+}
+
+export const adminApp = makeProxy("adminApp");
+export const adminDb = makeProxy("adminDb");
+export const adminAuth = makeProxy("adminAuth");

--- a/ingest/messageIngest/from-sources.test.ts
+++ b/ingest/messageIngest/from-sources.test.ts
@@ -43,13 +43,9 @@ describe("isAlreadyIngested", () => {
   let mockAdminDb: MockFirestoreCollection;
   let mockQuery: MockFirestoreQuery;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     // Reset mocks
     vi.clearAllMocks();
-
-    // Import the function we want to test
-    // Note: This is an internal function, so we need to access it via a test export or dynamic import
-    const _module = await import("./from-sources");
 
     // Since isAlreadyIngested is not exported, we'll create a test helper
     // that mimics its functionality for testing purposes


### PR DESCRIPTION
## Summary
- make `ingest/lib/firebase-admin.ts` lazy-initialized so Mongo-only runs do not fail at import time when `FIREBASE_SERVICE_ACCOUNT_KEY` is missing
- preserve existing emulator and service-account behavior when Firebase is configured
- fix ingest test timeout by removing an unnecessary dynamic import from `ingest/messageIngest/from-sources.test.ts`

## Why
Running in Mongo-only mode should not require Firebase credentials unless Firebase functionality is actually used.

## Validation
- `pnpm --filter oboapp-ingest test:run` (full ingest suite): **passed**
- targeted `from-sources.test.ts`: **passed**