### PR TITLE
fix: avoid false "device not subscribed" status in notifications

### DIFF
--- a/web/lib/hooks/useSubscriptionStatus.test.ts
+++ b/web/lib/hooks/useSubscriptionStatus.test.ts
@@ -91,6 +91,22 @@ describe("useSubscriptionStatus", () => {
     expect(sentryCaptureExceptionMock).toHaveBeenCalledTimes(1);
   });
 
+  it("sets unsubscribed state when initial backend check fails", async () => {
+    const user = { uid: "user-initial-failure" } as User;
+    fetchWithAuthMock.mockResolvedValueOnce(new Response(null, { status: 503 }));
+
+    const { result } = renderHook(() => useSubscriptionStatus(user));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.isCurrentDeviceSubscribed).toBe(false);
+    expect(result.current.hasAnySubscriptions).toBe(false);
+    expect(result.current.hasStatusCheckError).toBe(true);
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledTimes(1);
+  });
+
   it("resets state when user changes before a failed status check", async () => {
     const user1 = { uid: "user-1" } as User;
     const user2 = { uid: "user-2" } as User;

--- a/web/lib/hooks/useSubscriptionStatus.test.ts
+++ b/web/lib/hooks/useSubscriptionStatus.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { renderHook, waitFor, act } from "@testing-library/react";
 import type { User } from "firebase/auth";
 import { useSubscriptionStatus } from "./useSubscriptionStatus";
@@ -35,7 +35,7 @@ vi.mock("@/lib/auth-fetch", () => ({
 describe("useSubscriptionStatus", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.unstubAllGlobals();
+    vi.unstubAllGlobals();
 
     isMessagingSupportedMock.mockResolvedValue(true);
     getMessagingMock.mockReturnValue({});
@@ -44,15 +44,15 @@ describe("useSubscriptionStatus", () => {
       new Response(JSON.stringify([{ token: "token-1" }]), { status: 200 }),
     );
 
-    vi.stubGlobal("Notification", { permission: "granted" });
+    vi.stubGlobal("Notification", { permission: "granted" });
 
     vi.stubEnv("NEXT_PUBLIC_FIREBASE_VAPID_KEY", "test-vapid-key");
   });
 
-  afterEach(() => {
-    vi.unstubAllEnvs();
-    vi.unstubAllGlobals();
-  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
   it("keeps last known subscription status when backend check fails", async () => {
     const user = {} as User;
     const { result } = renderHook(() => useSubscriptionStatus(user));

--- a/web/lib/hooks/useSubscriptionStatus.test.ts
+++ b/web/lib/hooks/useSubscriptionStatus.test.ts
@@ -295,4 +295,43 @@ describe("useSubscriptionStatus", () => {
     expect(result.current.hasAnySubscriptions).toBe(true);
     expect(result.current.hasStatusCheckError).toBe(false);
   });
+
+  it("ignores stale non-ok backend responses after user switch", async () => {
+    const user1 = { uid: "user-1" } as User;
+    const user2 = { uid: "user-2" } as User;
+    const deferredResponse = createDeferred<Response>();
+
+    fetchWithAuthMock
+      .mockImplementationOnce(async () => deferredResponse.promise)
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([{ token: "token-1" }]), { status: 200 }),
+      );
+
+    const { result, rerender } = renderHook(
+      ({ user }) => useSubscriptionStatus(user),
+      { initialProps: { user: user1 } },
+    );
+
+    await waitFor(() => {
+      expect(fetchWithAuthMock).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      rerender({ user: user2 });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    await act(async () => {
+      deferredResponse.resolve(new Response(null, { status: 503 }));
+      await Promise.resolve();
+    });
+
+    expect(result.current.isCurrentDeviceSubscribed).toBe(true);
+    expect(result.current.hasAnySubscriptions).toBe(true);
+    expect(result.current.hasStatusCheckError).toBe(false);
+    expect(sentryCaptureExceptionMock).not.toHaveBeenCalled();
+  });
 });

--- a/web/lib/hooks/useSubscriptionStatus.test.ts
+++ b/web/lib/hooks/useSubscriptionStatus.test.ts
@@ -3,6 +3,14 @@ import { renderHook, waitFor, act } from "@testing-library/react";
 import type { User } from "firebase/auth";
 import { useSubscriptionStatus } from "./useSubscriptionStatus";
 
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolveFn) => {
+    resolve = resolveFn;
+  });
+  return { promise, resolve };
+}
+
 const {
   isMessagingSupportedMock,
   getMessagingMock,
@@ -111,5 +119,71 @@ describe("useSubscriptionStatus", () => {
     expect(result.current.isCurrentDeviceSubscribed).toBe(false);
     expect(result.current.hasAnySubscriptions).toBe(false);
     expect(result.current.hasStatusCheckError).toBe(true);
+  });
+
+  it("reports exception failures on repeated checks", async () => {
+    const user = { uid: "user-1" } as User;
+    const { result } = renderHook(() => useSubscriptionStatus(user));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    fetchWithAuthMock.mockRejectedValueOnce(new Error("network failure 1"));
+    await act(async () => {
+      await result.current.checkStatus();
+    });
+
+    fetchWithAuthMock.mockRejectedValueOnce(new Error("network failure 2"));
+    await act(async () => {
+      await result.current.checkStatus();
+    });
+
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("ignores stale in-flight results after user switch", async () => {
+    const user1 = { uid: "user-1" } as User;
+    const user2 = { uid: "user-2" } as User;
+    const deferredResponse = createDeferred<Response>();
+
+    fetchWithAuthMock
+      .mockImplementationOnce(async () => deferredResponse.promise)
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([{ token: "token-1" }]), { status: 200 }),
+      );
+
+    const { result, rerender } = renderHook(
+      ({ user }) => useSubscriptionStatus(user),
+      { initialProps: { user: user1 } },
+    );
+
+    await waitFor(() => {
+      expect(fetchWithAuthMock).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      rerender({ user: user2 });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.isCurrentDeviceSubscribed).toBe(true);
+    expect(result.current.hasAnySubscriptions).toBe(true);
+
+    await act(async () => {
+      deferredResponse.resolve(
+        new Response(JSON.stringify([]), {
+          status: 200,
+        }),
+      );
+      await Promise.resolve();
+    });
+
+    expect(result.current.isCurrentDeviceSubscribed).toBe(true);
+    expect(result.current.hasAnySubscriptions).toBe(true);
+    expect(result.current.hasStatusCheckError).toBe(false);
   });
 });

--- a/web/lib/hooks/useSubscriptionStatus.test.ts
+++ b/web/lib/hooks/useSubscriptionStatus.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+﻿import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { renderHook, waitFor, act } from "@testing-library/react";
 import type { User } from "firebase/auth";
 import { useSubscriptionStatus } from "./useSubscriptionStatus";

--- a/web/lib/hooks/useSubscriptionStatus.test.ts
+++ b/web/lib/hooks/useSubscriptionStatus.test.ts
@@ -60,7 +60,7 @@ describe("useSubscriptionStatus", () => {
     vi.unstubAllGlobals();
   });
   it("keeps last known subscription status when backend check fails", async () => {
-    const user = {} as User;
+    const user = { uid: "user-1" } as User;
     const { result } = renderHook(() => useSubscriptionStatus(user));
 
     await waitFor(() => {
@@ -81,5 +81,35 @@ describe("useSubscriptionStatus", () => {
     expect(result.current.hasAnySubscriptions).toBe(true);
     expect(result.current.hasStatusCheckError).toBe(true);
     expect(sentryCaptureExceptionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets state when user changes before a failed status check", async () => {
+    const user1 = { uid: "user-1" } as User;
+    const user2 = { uid: "user-2" } as User;
+    const { result, rerender } = renderHook(
+      ({ user }) => useSubscriptionStatus(user),
+      { initialProps: { user: user1 } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.isCurrentDeviceSubscribed).toBe(true);
+    expect(result.current.hasAnySubscriptions).toBe(true);
+
+    fetchWithAuthMock.mockResolvedValueOnce(new Response(null, { status: 503 }));
+
+    await act(async () => {
+      rerender({ user: user2 });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.isCurrentDeviceSubscribed).toBe(false);
+    expect(result.current.hasAnySubscriptions).toBe(false);
+    expect(result.current.hasStatusCheckError).toBe(true);
   });
 });

--- a/web/lib/hooks/useSubscriptionStatus.test.ts
+++ b/web/lib/hooks/useSubscriptionStatus.test.ts
@@ -158,6 +158,99 @@ describe("useSubscriptionStatus", () => {
     expect(sentryCaptureExceptionMock).toHaveBeenCalledTimes(2);
   });
 
+  it("clears non-ok warning dedupe when user logs out", async () => {
+    const user = { uid: "user-1" } as User;
+    const { result, rerender } = renderHook(
+      ({ currentUser }) => useSubscriptionStatus(currentUser),
+      { initialProps: { currentUser: user as User | null } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    fetchWithAuthMock.mockResolvedValueOnce(new Response(null, { status: 503 }));
+    await act(async () => {
+      await result.current.checkStatus();
+    });
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      rerender({ currentUser: null });
+    });
+
+    fetchWithAuthMock.mockResolvedValueOnce(new Response(null, { status: 503 }));
+    await act(async () => {
+      rerender({ currentUser: user });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears non-ok warning dedupe when user changes", async () => {
+    const user1 = { uid: "user-1" } as User;
+    const user2 = { uid: "user-2" } as User;
+    const { result, rerender } = renderHook(
+      ({ user }) => useSubscriptionStatus(user),
+      { initialProps: { user: user1 } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    fetchWithAuthMock.mockResolvedValueOnce(new Response(null, { status: 503 }));
+    await act(async () => {
+      await result.current.checkStatus();
+    });
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledTimes(1);
+
+    fetchWithAuthMock.mockResolvedValueOnce(new Response(null, { status: 503 }));
+    await act(async () => {
+      rerender({ user: user2 });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips stale backend fetch when an older token lookup completes late", async () => {
+    const user1 = { uid: "user-1" } as User;
+    const user2 = { uid: "user-2" } as User;
+    const deferredToken = createDeferred<string | null>();
+
+    getTokenMock
+      .mockImplementationOnce(async () => deferredToken.promise)
+      .mockResolvedValueOnce("token-1");
+
+    const { rerender } = renderHook(
+      ({ user }) => useSubscriptionStatus(user),
+      { initialProps: { user: user1 } },
+    );
+
+    await waitFor(() => {
+      expect(getTokenMock).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      rerender({ user: user2 });
+    });
+
+    await act(async () => {
+      deferredToken.resolve("token-1");
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(fetchWithAuthMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it("ignores stale in-flight results after user switch", async () => {
     const user1 = { uid: "user-1" } as User;
     const user2 = { uid: "user-2" } as User;

--- a/web/lib/hooks/useSubscriptionStatus.test.ts
+++ b/web/lib/hooks/useSubscriptionStatus.test.ts
@@ -1,4 +1,4 @@
-﻿import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { renderHook, waitFor, act } from "@testing-library/react";
 import type { User } from "firebase/auth";
 import { useSubscriptionStatus } from "./useSubscriptionStatus";

--- a/web/lib/hooks/useSubscriptionStatus.test.ts
+++ b/web/lib/hooks/useSubscriptionStatus.test.ts
@@ -35,6 +35,7 @@ vi.mock("@/lib/auth-fetch", () => ({
 describe("useSubscriptionStatus", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllGlobals();
 
     isMessagingSupportedMock.mockResolvedValue(true);
     getMessagingMock.mockReturnValue({});
@@ -43,14 +44,15 @@ describe("useSubscriptionStatus", () => {
       new Response(JSON.stringify([{ token: "token-1" }]), { status: 200 }),
     );
 
-    Object.defineProperty(globalThis, "Notification", {
-      configurable: true,
-      value: { permission: "granted" },
-    });
+    vi.stubGlobal("Notification", { permission: "granted" });
 
     vi.stubEnv("NEXT_PUBLIC_FIREBASE_VAPID_KEY", "test-vapid-key");
   });
 
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
   it("keeps last known subscription status when backend check fails", async () => {
     const user = {} as User;
     const { result } = renderHook(() => useSubscriptionStatus(user));

--- a/web/lib/hooks/useSubscriptionStatus.test.ts
+++ b/web/lib/hooks/useSubscriptionStatus.test.ts
@@ -8,11 +8,17 @@ const {
   getMessagingMock,
   getTokenMock,
   fetchWithAuthMock,
+  sentryCaptureExceptionMock,
 } = vi.hoisted(() => ({
   isMessagingSupportedMock: vi.fn(),
   getMessagingMock: vi.fn(),
   getTokenMock: vi.fn(),
   fetchWithAuthMock: vi.fn(),
+  sentryCaptureExceptionMock: vi.fn(),
+}));
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: sentryCaptureExceptionMock,
 }));
 
 vi.mock("@/lib/notification-service", () => ({
@@ -74,5 +80,6 @@ describe("useSubscriptionStatus", () => {
     expect(result.current.isCurrentDeviceSubscribed).toBe(true);
     expect(result.current.hasAnySubscriptions).toBe(true);
     expect(result.current.hasStatusCheckError).toBe(true);
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/web/lib/hooks/useSubscriptionStatus.test.ts
+++ b/web/lib/hooks/useSubscriptionStatus.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import type { User } from "firebase/auth";
+import { useSubscriptionStatus } from "./useSubscriptionStatus";
+
+const {
+  isMessagingSupportedMock,
+  getMessagingMock,
+  getTokenMock,
+  fetchWithAuthMock,
+} = vi.hoisted(() => ({
+  isMessagingSupportedMock: vi.fn(),
+  getMessagingMock: vi.fn(),
+  getTokenMock: vi.fn(),
+  fetchWithAuthMock: vi.fn(),
+}));
+
+vi.mock("@/lib/notification-service", () => ({
+  isMessagingSupported: isMessagingSupportedMock,
+}));
+
+vi.mock("firebase/messaging", () => ({
+  getMessaging: getMessagingMock,
+  getToken: getTokenMock,
+}));
+
+vi.mock("@/lib/firebase", () => ({
+  app: {},
+}));
+
+vi.mock("@/lib/auth-fetch", () => ({
+  fetchWithAuth: fetchWithAuthMock,
+}));
+
+describe("useSubscriptionStatus", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    isMessagingSupportedMock.mockResolvedValue(true);
+    getMessagingMock.mockReturnValue({});
+    getTokenMock.mockResolvedValue("token-1");
+    fetchWithAuthMock.mockResolvedValue(
+      new Response(JSON.stringify([{ token: "token-1" }]), { status: 200 }),
+    );
+
+    Object.defineProperty(globalThis, "Notification", {
+      configurable: true,
+      value: { permission: "granted" },
+    });
+
+    vi.stubEnv("NEXT_PUBLIC_FIREBASE_VAPID_KEY", "test-vapid-key");
+  });
+
+  it("keeps last known subscription status when backend check fails", async () => {
+    const user = {} as User;
+    const { result } = renderHook(() => useSubscriptionStatus(user));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.isCurrentDeviceSubscribed).toBe(true);
+    expect(result.current.hasAnySubscriptions).toBe(true);
+    expect(result.current.hasStatusCheckError).toBe(false);
+
+    fetchWithAuthMock.mockResolvedValueOnce(new Response(null, { status: 503 }));
+
+    await act(async () => {
+      await result.current.checkStatus();
+    });
+
+    expect(result.current.isCurrentDeviceSubscribed).toBe(true);
+    expect(result.current.hasAnySubscriptions).toBe(true);
+    expect(result.current.hasStatusCheckError).toBe(true);
+  });
+});

--- a/web/lib/hooks/useSubscriptionStatus.ts
+++ b/web/lib/hooks/useSubscriptionStatus.ts
@@ -165,6 +165,7 @@ export function useSubscriptionStatus(user: User | null): SubscriptionStatus {
       throwIfStale(isStaleRequest);
 
       if (!response.ok) {
+        throwIfStale(isStaleRequest);
         if (!hasKnownStatusRef.current) {
           setIsCurrentDeviceSubscribed(false);
           setHasAnySubscriptions(false);

--- a/web/lib/hooks/useSubscriptionStatus.ts
+++ b/web/lib/hooks/useSubscriptionStatus.ts
@@ -48,6 +48,7 @@ async function resolveCurrentDeviceToken(
     return null;
   }
 
+  throwIfStale(isStaleRequest);
   const currentToken = await getToken(messaging, { vapidKey });
   throwIfStale(isStaleRequest);
   if (!currentToken) {
@@ -120,6 +121,7 @@ export function useSubscriptionStatus(user: User | null): SubscriptionStatus {
       setHasStatusCheckError(false);
       setIsLoading(false);
       previousUserIdRef.current = null;
+      reportedNonOkStatusCodesRef.current.clear();
       hasKnownStatusRef.current = false;
       return;
     }
@@ -133,6 +135,7 @@ export function useSubscriptionStatus(user: User | null): SubscriptionStatus {
       setIsCurrentDeviceSubscribed(false);
       setHasAnySubscriptions(false);
       setHasStatusCheckError(false);
+      reportedNonOkStatusCodesRef.current.clear();
       hasKnownStatusRef.current = false;
     }
     previousUserIdRef.current = user.uid;
@@ -154,6 +157,7 @@ export function useSubscriptionStatus(user: User | null): SubscriptionStatus {
       }
 
       // Check if this token is in the backend
+      throwIfStale(isStaleRequest);
       const response = await fetchWithAuth(
         user,
         "/api/notifications/subscription/all",

--- a/web/lib/hooks/useSubscriptionStatus.ts
+++ b/web/lib/hooks/useSubscriptionStatus.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { User } from "firebase/auth";
 import * as Sentry from "@sentry/nextjs";
 import { fetchWithAuth } from "@/lib/auth-fetch";
@@ -52,6 +52,7 @@ export function useSubscriptionStatus(user: User | null): SubscriptionStatus {
   const [hasAnySubscriptions, setHasAnySubscriptions] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [hasStatusCheckError, setHasStatusCheckError] = useState(false);
+  const previousUserIdRef = useRef<string | null>(null);
 
   const checkStatus = useCallback(async () => {
     if (!user) {
@@ -59,8 +60,21 @@ export function useSubscriptionStatus(user: User | null): SubscriptionStatus {
       setHasAnySubscriptions(false);
       setHasStatusCheckError(false);
       setIsLoading(false);
+      previousUserIdRef.current = null;
       return;
     }
+
+    if (
+      previousUserIdRef.current !== null &&
+      previousUserIdRef.current !== user.uid
+    ) {
+      // Reset cached state on account switch so transient failures cannot keep
+      // the previous account's last-known subscription status.
+      setIsCurrentDeviceSubscribed(false);
+      setHasAnySubscriptions(false);
+      setHasStatusCheckError(false);
+    }
+    previousUserIdRef.current = user.uid;
 
     try {
       setIsLoading(true);

--- a/web/lib/hooks/useSubscriptionStatus.ts
+++ b/web/lib/hooks/useSubscriptionStatus.ts
@@ -1,6 +1,38 @@
 import { useCallback, useEffect, useState } from "react";
 import type { User } from "firebase/auth";
+import * as Sentry from "@sentry/nextjs";
 import { fetchWithAuth } from "@/lib/auth-fetch";
+
+const reportedStatusCheckErrors = new Set<string>();
+
+function captureStatusCheckWarning(
+  error: unknown,
+  reason: "non_ok_response" | "exception",
+  details?: { statusCode?: number },
+): void {
+  const dedupeKey = `${reason}:${details?.statusCode ?? "none"}`;
+  if (reportedStatusCheckErrors.has(dedupeKey)) {
+    return;
+  }
+  reportedStatusCheckErrors.add(dedupeKey);
+
+  const normalizedError =
+    error instanceof Error
+      ? error
+      : new Error("Unknown error while checking notification subscription status");
+
+  Sentry.captureException(normalizedError, {
+    level: "warning",
+    tags: {
+      area: "notifications",
+      hook: "useSubscriptionStatus",
+      reason,
+    },
+    extra: {
+      statusCode: details?.statusCode,
+    },
+  });
+}
 
 export interface SubscriptionStatus {
   isCurrentDeviceSubscribed: boolean;
@@ -87,6 +119,13 @@ export function useSubscriptionStatus(user: User | null): SubscriptionStatus {
 
       if (!response.ok) {
         setHasStatusCheckError(true);
+        captureStatusCheckWarning(
+          new Error(
+            `Subscription status check failed with status ${response.status}`,
+          ),
+          "non_ok_response",
+          { statusCode: response.status },
+        );
         return;
       }
 
@@ -100,10 +139,10 @@ export function useSubscriptionStatus(user: User | null): SubscriptionStatus {
         Array.isArray(subscriptions) && subscriptions.length > 0,
       );
     } catch (err) {
-      console.error("Error checking subscription status:", err);
       // Preserve the last known status to avoid false "not subscribed" messages
       // when there are transient auth/network/backend failures.
       setHasStatusCheckError(true);
+      captureStatusCheckWarning(err, "exception");
     } finally {
       setIsLoading(false);
     }

--- a/web/lib/hooks/useSubscriptionStatus.ts
+++ b/web/lib/hooks/useSubscriptionStatus.ts
@@ -3,18 +3,36 @@ import type { User } from "firebase/auth";
 import * as Sentry from "@sentry/nextjs";
 import { fetchWithAuth } from "@/lib/auth-fetch";
 
-const reportedStatusCheckErrors = new Set<string>();
+const reportedNonOkStatusCodes = new Set<number>();
+
+class StaleStatusCheckError extends Error {
+  constructor() {
+    super("Stale subscription status check");
+    this.name = "StaleStatusCheckError";
+  }
+}
+
+function throwIfStale(isStaleRequest: () => boolean): void {
+  if (isStaleRequest()) {
+    throw new StaleStatusCheckError();
+  }
+}
+
+function isStaleStatusCheckError(error: unknown): boolean {
+  return error instanceof StaleStatusCheckError;
+}
 
 function captureStatusCheckWarning(
   error: unknown,
   reason: "non_ok_response" | "exception",
   details?: { statusCode?: number },
 ): void {
-  const dedupeKey = `${reason}:${details?.statusCode ?? "none"}`;
-  if (reportedStatusCheckErrors.has(dedupeKey)) {
-    return;
+  if (reason === "non_ok_response" && details?.statusCode !== undefined) {
+    if (reportedNonOkStatusCodes.has(details.statusCode)) {
+      return;
+    }
+    reportedNonOkStatusCodes.add(details.statusCode);
   }
-  reportedStatusCheckErrors.add(dedupeKey);
 
   const normalizedError =
     error instanceof Error
@@ -53,8 +71,11 @@ export function useSubscriptionStatus(user: User | null): SubscriptionStatus {
   const [isLoading, setIsLoading] = useState(true);
   const [hasStatusCheckError, setHasStatusCheckError] = useState(false);
   const previousUserIdRef = useRef<string | null>(null);
+  const requestIdRef = useRef(0);
 
   const checkStatus = useCallback(async () => {
+    const requestId = ++requestIdRef.current;
+
     if (!user) {
       setIsCurrentDeviceSubscribed(false);
       setHasAnySubscriptions(false);
@@ -75,6 +96,10 @@ export function useSubscriptionStatus(user: User | null): SubscriptionStatus {
       setHasStatusCheckError(false);
     }
     previousUserIdRef.current = user.uid;
+    const activeUserId = user.uid;
+
+    const isStaleRequest = (): boolean =>
+      requestId !== requestIdRef.current || previousUserIdRef.current !== activeUserId;
 
     try {
       setIsLoading(true);
@@ -83,7 +108,9 @@ export function useSubscriptionStatus(user: User | null): SubscriptionStatus {
       // Check if Firebase Messaging is supported
       const { isMessagingSupported } =
         await import("@/lib/notification-service");
+      throwIfStale(isStaleRequest);
       const supported = await isMessagingSupported();
+      throwIfStale(isStaleRequest);
 
       if (!supported) {
         setIsCurrentDeviceSubscribed(false);
@@ -95,6 +122,7 @@ export function useSubscriptionStatus(user: User | null): SubscriptionStatus {
       // Check notification permission
       const permission =
         "Notification" in globalThis ? Notification.permission : "denied";
+      throwIfStale(isStaleRequest);
 
       if (permission !== "granted") {
         setIsCurrentDeviceSubscribed(false);
@@ -117,6 +145,7 @@ export function useSubscriptionStatus(user: User | null): SubscriptionStatus {
       }
 
       const currentToken = await getToken(messaging, { vapidKey });
+      throwIfStale(isStaleRequest);
 
       if (!currentToken) {
         setIsCurrentDeviceSubscribed(false);
@@ -130,6 +159,7 @@ export function useSubscriptionStatus(user: User | null): SubscriptionStatus {
         user,
         "/api/notifications/subscription/all",
       );
+      throwIfStale(isStaleRequest);
 
       if (!response.ok) {
         setHasStatusCheckError(true);
@@ -144,6 +174,7 @@ export function useSubscriptionStatus(user: User | null): SubscriptionStatus {
       }
 
       const subscriptions = await response.json();
+      throwIfStale(isStaleRequest);
       const hasCurrentDevice =
         Array.isArray(subscriptions) &&
         subscriptions.some((sub) => sub.token === currentToken);
@@ -153,12 +184,17 @@ export function useSubscriptionStatus(user: User | null): SubscriptionStatus {
         Array.isArray(subscriptions) && subscriptions.length > 0,
       );
     } catch (err) {
+      if (isStaleStatusCheckError(err) || isStaleRequest()) {
+        return;
+      }
       // Preserve the last known status to avoid false "not subscribed" messages
       // when there are transient auth/network/backend failures.
       setHasStatusCheckError(true);
       captureStatusCheckWarning(err, "exception");
     } finally {
-      setIsLoading(false);
+      if (!isStaleRequest()) {
+        setIsLoading(false);
+      }
     }
   }, [user]);
 

--- a/web/lib/hooks/useSubscriptionStatus.ts
+++ b/web/lib/hooks/useSubscriptionStatus.ts
@@ -3,8 +3,6 @@ import type { User } from "firebase/auth";
 import * as Sentry from "@sentry/nextjs";
 import { fetchWithAuth } from "@/lib/auth-fetch";
 
-const reportedNonOkStatusCodes = new Set<number>();
-
 class StaleStatusCheckError extends Error {
   constructor() {
     super("Stale subscription status check");
@@ -25,6 +23,7 @@ function isStaleStatusCheckError(error: unknown): boolean {
 function captureStatusCheckWarning(
   error: unknown,
   reason: "non_ok_response" | "exception",
+  reportedNonOkStatusCodes: Set<number>,
   details?: { statusCode?: number },
 ): void {
   if (reason === "non_ok_response" && details?.statusCode !== undefined) {
@@ -72,6 +71,7 @@ export function useSubscriptionStatus(user: User | null): SubscriptionStatus {
   const [hasStatusCheckError, setHasStatusCheckError] = useState(false);
   const previousUserIdRef = useRef<string | null>(null);
   const requestIdRef = useRef(0);
+  const reportedNonOkStatusCodesRef = useRef(new Set<number>());
 
   const checkStatus = useCallback(async () => {
     const requestId = ++requestIdRef.current;
@@ -168,6 +168,7 @@ export function useSubscriptionStatus(user: User | null): SubscriptionStatus {
             `Subscription status check failed with status ${response.status}`,
           ),
           "non_ok_response",
+          reportedNonOkStatusCodesRef.current,
           { statusCode: response.status },
         );
         return;
@@ -190,7 +191,11 @@ export function useSubscriptionStatus(user: User | null): SubscriptionStatus {
       // Preserve the last known status to avoid false "not subscribed" messages
       // when there are transient auth/network/backend failures.
       setHasStatusCheckError(true);
-      captureStatusCheckWarning(err, "exception");
+      captureStatusCheckWarning(
+        err,
+        "exception",
+        reportedNonOkStatusCodesRef.current,
+      );
     } finally {
       if (!isStaleRequest()) {
         setIsLoading(false);

--- a/web/lib/hooks/useSubscriptionStatus.ts
+++ b/web/lib/hooks/useSubscriptionStatus.ts
@@ -20,6 +20,43 @@ function isStaleStatusCheckError(error: unknown): boolean {
   return error instanceof StaleStatusCheckError;
 }
 
+async function resolveCurrentDeviceToken(
+  isStaleRequest: () => boolean,
+): Promise<string | null> {
+  const { isMessagingSupported } =
+    await import("@/lib/notification-service");
+  throwIfStale(isStaleRequest);
+
+  const supported = await isMessagingSupported();
+  throwIfStale(isStaleRequest);
+  if (!supported) {
+    return null;
+  }
+
+  const permission =
+    "Notification" in globalThis ? Notification.permission : "denied";
+  throwIfStale(isStaleRequest);
+  if (permission !== "granted") {
+    return null;
+  }
+
+  const { getMessaging, getToken } = await import("firebase/messaging");
+  const { app } = await import("@/lib/firebase");
+  const messaging = getMessaging(app);
+  const vapidKey = process.env.NEXT_PUBLIC_FIREBASE_VAPID_KEY;
+  if (!vapidKey) {
+    return null;
+  }
+
+  const currentToken = await getToken(messaging, { vapidKey });
+  throwIfStale(isStaleRequest);
+  if (!currentToken) {
+    return null;
+  }
+
+  return currentToken;
+}
+
 function captureStatusCheckWarning(
   error: unknown,
   reason: "non_ok_response" | "exception",
@@ -72,6 +109,7 @@ export function useSubscriptionStatus(user: User | null): SubscriptionStatus {
   const previousUserIdRef = useRef<string | null>(null);
   const requestIdRef = useRef(0);
   const reportedNonOkStatusCodesRef = useRef(new Set<number>());
+  const hasKnownStatusRef = useRef(false);
 
   const checkStatus = useCallback(async () => {
     const requestId = ++requestIdRef.current;
@@ -82,6 +120,7 @@ export function useSubscriptionStatus(user: User | null): SubscriptionStatus {
       setHasStatusCheckError(false);
       setIsLoading(false);
       previousUserIdRef.current = null;
+      hasKnownStatusRef.current = false;
       return;
     }
 
@@ -94,6 +133,7 @@ export function useSubscriptionStatus(user: User | null): SubscriptionStatus {
       setIsCurrentDeviceSubscribed(false);
       setHasAnySubscriptions(false);
       setHasStatusCheckError(false);
+      hasKnownStatusRef.current = false;
     }
     previousUserIdRef.current = user.uid;
     const activeUserId = user.uid;
@@ -105,52 +145,11 @@ export function useSubscriptionStatus(user: User | null): SubscriptionStatus {
       setIsLoading(true);
       setHasStatusCheckError(false);
 
-      // Check if Firebase Messaging is supported
-      const { isMessagingSupported } =
-        await import("@/lib/notification-service");
-      throwIfStale(isStaleRequest);
-      const supported = await isMessagingSupported();
-      throwIfStale(isStaleRequest);
-
-      if (!supported) {
-        setIsCurrentDeviceSubscribed(false);
-        setHasAnySubscriptions(false);
-        setIsLoading(false);
-        return;
-      }
-
-      // Check notification permission
-      const permission =
-        "Notification" in globalThis ? Notification.permission : "denied";
-      throwIfStale(isStaleRequest);
-
-      if (permission !== "granted") {
-        setIsCurrentDeviceSubscribed(false);
-        setHasAnySubscriptions(false);
-        setIsLoading(false);
-        return;
-      }
-
-      // Get current device's FCM token
-      const { getMessaging, getToken } = await import("firebase/messaging");
-      const { app } = await import("@/lib/firebase");
-      const messaging = getMessaging(app);
-      const vapidKey = process.env.NEXT_PUBLIC_FIREBASE_VAPID_KEY;
-
-      if (!vapidKey) {
-        setIsCurrentDeviceSubscribed(false);
-        setHasAnySubscriptions(false);
-        setIsLoading(false);
-        return;
-      }
-
-      const currentToken = await getToken(messaging, { vapidKey });
-      throwIfStale(isStaleRequest);
-
+      const currentToken = await resolveCurrentDeviceToken(isStaleRequest);
       if (!currentToken) {
         setIsCurrentDeviceSubscribed(false);
         setHasAnySubscriptions(false);
-        setIsLoading(false);
+        hasKnownStatusRef.current = true;
         return;
       }
 
@@ -162,6 +161,10 @@ export function useSubscriptionStatus(user: User | null): SubscriptionStatus {
       throwIfStale(isStaleRequest);
 
       if (!response.ok) {
+        if (!hasKnownStatusRef.current) {
+          setIsCurrentDeviceSubscribed(false);
+          setHasAnySubscriptions(false);
+        }
         setHasStatusCheckError(true);
         captureStatusCheckWarning(
           new Error(
@@ -184,12 +187,17 @@ export function useSubscriptionStatus(user: User | null): SubscriptionStatus {
       setHasAnySubscriptions(
         Array.isArray(subscriptions) && subscriptions.length > 0,
       );
+      hasKnownStatusRef.current = true;
     } catch (err) {
       if (isStaleStatusCheckError(err) || isStaleRequest()) {
         return;
       }
       // Preserve the last known status to avoid false "not subscribed" messages
       // when there are transient auth/network/backend failures.
+      if (!hasKnownStatusRef.current) {
+        setIsCurrentDeviceSubscribed(false);
+        setHasAnySubscriptions(false);
+      }
       setHasStatusCheckError(true);
       captureStatusCheckWarning(
         err,

--- a/web/lib/hooks/useSubscriptionStatus.ts
+++ b/web/lib/hooks/useSubscriptionStatus.ts
@@ -6,6 +6,7 @@ export interface SubscriptionStatus {
   isCurrentDeviceSubscribed: boolean;
   hasAnySubscriptions: boolean;
   isLoading: boolean;
+  hasStatusCheckError: boolean;
   checkStatus: () => Promise<void>;
 }
 
@@ -18,17 +19,20 @@ export function useSubscriptionStatus(user: User | null): SubscriptionStatus {
     useState(true);
   const [hasAnySubscriptions, setHasAnySubscriptions] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
+  const [hasStatusCheckError, setHasStatusCheckError] = useState(false);
 
   const checkStatus = useCallback(async () => {
     if (!user) {
       setIsCurrentDeviceSubscribed(false);
       setHasAnySubscriptions(false);
+      setHasStatusCheckError(false);
       setIsLoading(false);
       return;
     }
 
     try {
       setIsLoading(true);
+      setHasStatusCheckError(false);
 
       // Check if Firebase Messaging is supported
       const { isMessagingSupported } =
@@ -82,8 +86,7 @@ export function useSubscriptionStatus(user: User | null): SubscriptionStatus {
       );
 
       if (!response.ok) {
-        setIsCurrentDeviceSubscribed(false);
-        setHasAnySubscriptions(false);
+        setHasStatusCheckError(true);
         return;
       }
 
@@ -98,9 +101,9 @@ export function useSubscriptionStatus(user: User | null): SubscriptionStatus {
       );
     } catch (err) {
       console.error("Error checking subscription status:", err);
-      // On error, assume not subscribed to show the prompt
-      setIsCurrentDeviceSubscribed(false);
-      setHasAnySubscriptions(false);
+      // Preserve the last known status to avoid false "not subscribed" messages
+      // when there are transient auth/network/backend failures.
+      setHasStatusCheckError(true);
     } finally {
       setIsLoading(false);
     }
@@ -115,6 +118,7 @@ export function useSubscriptionStatus(user: User | null): SubscriptionStatus {
     isCurrentDeviceSubscribed,
     hasAnySubscriptions,
     isLoading,
+    hasStatusCheckError,
     checkStatus,
   };
 }


### PR DESCRIPTION
## Summary
- avoid forcing the device status to unsubscribed when subscription status checks fail transiently
- preserve the last known subscription status on backend/auth/network check failures
- add a regression test for the hook to ensure transient failures do not cause false negatives

## Why
Issue #500 reports a false message that the current device is not subscribed immediately after receiving a push notification.

## Changes
- update subscription status hook state handling to keep last known values on failed checks
- add an explicit status-check-error signal in the hook
- add a test that verifies status is preserved when a subsequent check returns a non-OK response

Closes #500