### PR TITLE
fix(ingest): propagate datePublished through message ingest handoff

### DIFF
--- a/ingest/messageIngest/from-sources.ts
+++ b/ingest/messageIngest/from-sources.ts
@@ -198,6 +198,7 @@ async function ingestSource(
     sourceDocumentId,
     boundaryFilter: boundaries ?? undefined,
     crawledAt: source.crawledAt,
+    datePublished: source.datePublished,
     markdownText: source.markdownText,
     categories: source.categories,
     isRelevant: source.isRelevant,

--- a/ingest/messageIngest/from-sources.ts
+++ b/ingest/messageIngest/from-sources.ts
@@ -58,7 +58,7 @@ function toDate(value: unknown): Date | undefined {
   if (value instanceof Date) return value;
   if (typeof value === "string") {
     const d = new Date(value);
-    return isNaN(d.getTime()) ? undefined : d;
+    return Number.isNaN(d.getTime()) ? undefined : d;
   }
   return undefined;
 }
@@ -309,6 +309,31 @@ async function maybeInitDb(): Promise<OboDb> {
   return getDb();
 }
 
+function handleIngestError(
+  summary: IngestSummary,
+  source: SourceDocument,
+  error: unknown,
+): void {
+  summary.failed++;
+  const errorMessage = error instanceof Error ? error.message : String(error);
+
+  if (errorMessage.includes("No features within specified boundaries")) {
+    logger.info("Source outside boundaries after geocoding", {
+      title: source.title,
+    });
+  } else if (errorMessage.includes("Message filtering failed")) {
+    summary.filtered++;
+    logger.info("Source filtered as irrelevant", { title: source.title });
+  } else {
+    summary.errors.push({ url: source.url, error: errorMessage });
+    logger.error("Failed to ingest source", {
+      title: source.title,
+      error: errorMessage,
+      url: source.url,
+    });
+  }
+}
+
 export async function ingest(
   options: IngestOptions = {},
 ): Promise<IngestSummary> {
@@ -376,26 +401,7 @@ export async function ingest(
         summary.ingested++;
       }
     } catch (error) {
-      summary.failed++;
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
-
-      // Don't log as error if it's just outside boundaries or filtered as irrelevant
-      if (errorMessage.includes("No features within specified boundaries")) {
-        logger.info("Source outside boundaries after geocoding", {
-          title: source.title,
-        });
-      } else if (errorMessage.includes("Message filtering failed")) {
-        summary.filtered++;
-        logger.info("Source filtered as irrelevant", { title: source.title });
-      } else {
-        summary.errors.push({ url: source.url, error: errorMessage });
-        logger.error("Failed to ingest source", {
-          title: source.title,
-          error: errorMessage,
-          url: source.url,
-        });
-      }
+      handleIngestError(summary, source, error);
     }
   }
 
@@ -449,7 +455,7 @@ if (require.main === module) {
     .option("-b, --boundaries <path>", "Path to GeoJSON boundaries file")
     .option("--dry-run", "Preview ingestion without actually writing")
     .option("-s, --source-type <type>", "Only ingest sources of this type")
-    .option("-l, --limit <n>", "Maximum number of sources to process", parseInt)
+    .option("-l, --limit <n>", "Maximum number of sources to process", Number.parseInt)
     .addHelpText(
       "after",
       `

--- a/ingest/messageIngest/index.test.ts
+++ b/ingest/messageIngest/index.test.ts
@@ -100,12 +100,12 @@ describe("computeGeoJsonCentroidAddress", () => {
       features: [
         {
           type: "Feature",
-          geometry: { type: "Point", coordinates: [23.0, 42.0] },
+          geometry: { type: "Point", coordinates: [23, 42] },
           properties: {},
         },
         {
           type: "Feature",
-          geometry: { type: "Point", coordinates: [24.0, 43.0] },
+          geometry: { type: "Point", coordinates: [24, 43] },
           properties: {},
         },
       ],
@@ -125,8 +125,8 @@ describe("computeGeoJsonCentroidAddress", () => {
           geometry: {
             type: "LineString",
             coordinates: [
-              [23.0, 42.0],
-              [24.0, 43.0],
+              [23, 42],
+              [24, 43],
             ],
           },
           properties: {},
@@ -149,11 +149,11 @@ describe("computeGeoJsonCentroidAddress", () => {
             type: "Polygon",
             coordinates: [
               [
-                [23.0, 42.0],
-                [24.0, 42.0],
-                [24.0, 43.0],
-                [23.0, 43.0],
-                [23.0, 42.0],
+                [23, 42],
+                [24, 42],
+                [24, 43],
+                [23, 43],
+                [23, 42],
               ],
             ],
           },
@@ -176,8 +176,8 @@ describe("computeGeoJsonCentroidAddress", () => {
           geometry: {
             type: "MultiPoint",
             coordinates: [
-              [23.0, 42.0],
-              [24.0, 43.0],
+              [23, 42],
+              [24, 43],
             ],
           },
           properties: {},
@@ -374,11 +374,11 @@ const BOUNDARY_GEOJSON: GeoJSONFeatureCollection = {
         type: "Polygon",
         coordinates: [
           [
-            [23.0, 42.0],
-            [24.0, 42.0],
-            [24.0, 43.0],
-            [23.0, 43.0],
-            [23.0, 42.0],
+            [23, 42],
+            [24, 42],
+            [24, 43],
+            [23, 43],
+            [23, 42],
           ],
         ],
       },
@@ -401,7 +401,7 @@ describe("event matching after finalization", () => {
     mockProcessEventMatching.mockResolvedValue({
       eventId: "evt-1",
       action: "created",
-      confidence: 1.0,
+      confidence: 1,
       candidateCount: 0,
     });
     mockDeleteOne.mockResolvedValue(undefined);

--- a/ingest/messageIngest/index.test.ts
+++ b/ingest/messageIngest/index.test.ts
@@ -536,3 +536,100 @@ describe("event matching after finalization", () => {
     );
   });
 });
+
+/**
+ * Tests for resolveReferenceDate behavior (issue #499).
+ * Verified indirectly through messageIngest with precomputed GeoJSON (no AI pipeline),
+ * observing the timespanStart/timespanEnd stored in the DB when no source timespans are
+ * provided — the fallback date should prefer datePublished over crawledAt.
+ */
+describe("resolveReferenceDate via messageIngest (issue #499)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockStoreIncomingMessage.mockResolvedValue("test-msg-id");
+    mockUpdateMessage.mockResolvedValue(undefined);
+    mockEncodeDocumentId.mockImplementation((url: string) => `encoded(${url})`);
+  });
+
+  function findTimespanUpdate() {
+    const updatePayloads = mockUpdateMessage.mock.calls.map((call) => call[1]);
+    return updatePayloads.find(
+      (payload) =>
+        payload &&
+        payload.timespanStart instanceof Date &&
+        payload.timespanEnd instanceof Date,
+    );
+  }
+
+  it("uses datePublished as fallback when valid and no source timespans provided", async () => {
+    const datePublished = "2026-05-15T00:00:00.000Z";
+    const crawledAt = new Date("2026-05-18T00:00:00.000Z");
+
+    await messageIngest("test text", "vrabnitsa-org", {
+      precomputedGeoJson: PRECOMPUTED_GEOJSON,
+      markdownText: "Test",
+      locality: "bg.sofia",
+      datePublished,
+      crawledAt,
+    });
+
+    const timespanUpdate = findTimespanUpdate();
+    expect(timespanUpdate).toBeDefined();
+    expect(timespanUpdate.timespanStart).toEqual(new Date(datePublished));
+    expect(timespanUpdate.timespanEnd).toEqual(new Date(datePublished));
+  });
+
+  it("falls back to crawledAt when datePublished is absent", async () => {
+    const crawledAt = new Date("2026-05-18T00:00:00.000Z");
+
+    await messageIngest("test text", "vrabnitsa-org", {
+      precomputedGeoJson: PRECOMPUTED_GEOJSON,
+      markdownText: "Test",
+      locality: "bg.sofia",
+      crawledAt,
+    });
+
+    const timespanUpdate = findTimespanUpdate();
+    expect(timespanUpdate).toBeDefined();
+    expect(timespanUpdate.timespanStart).toEqual(crawledAt);
+    expect(timespanUpdate.timespanEnd).toEqual(crawledAt);
+  });
+
+  it("falls back to crawledAt when datePublished is an invalid string", async () => {
+    const crawledAt = new Date("2026-05-18T00:00:00.000Z");
+
+    await messageIngest("test text", "vrabnitsa-org", {
+      precomputedGeoJson: PRECOMPUTED_GEOJSON,
+      markdownText: "Test",
+      locality: "bg.sofia",
+      datePublished: "not-a-valid-date",
+      crawledAt,
+    });
+
+    const timespanUpdate = findTimespanUpdate();
+    expect(timespanUpdate).toBeDefined();
+    expect(timespanUpdate.timespanStart).toEqual(crawledAt);
+    expect(timespanUpdate.timespanEnd).toEqual(crawledAt);
+  });
+
+  it("delayed crawl regression (#499): fallback is datePublished not crawledAt", async () => {
+    // Mirrors the May 2026 production incident: article published May 15, crawler ran May 18.
+    // Before the fix, timespans would fall back to May 18 (crawl time) instead of May 15.
+    const datePublished = "2026-05-15T00:00:00.000Z";
+    const crawledAt = new Date("2026-05-18T00:00:00.000Z");
+
+    await messageIngest("test text", "vrabnitsa-org", {
+      precomputedGeoJson: PRECOMPUTED_GEOJSON,
+      markdownText: "Test",
+      locality: "bg.sofia",
+      datePublished,
+      crawledAt,
+    });
+
+    const timespanUpdate = findTimespanUpdate();
+    expect(timespanUpdate).toBeDefined();
+    // Must be May 15 (datePublished), not May 18 (crawledAt)
+    expect(timespanUpdate.timespanStart.toISOString()).toBe(datePublished);
+    expect(timespanUpdate.timespanEnd.toISOString()).toBe(datePublished);
+  });
+});

--- a/ingest/messageIngest/index.test.ts
+++ b/ingest/messageIngest/index.test.ts
@@ -554,6 +554,8 @@ function findTimespanUpdate() {
 }
 
 describe("resolveReferenceDate via messageIngest (issue #499)", () => {
+  const CRAWLED_AT = new Date("2026-05-18T00:00:00.000Z");
+
   beforeEach(() => {
     vi.clearAllMocks();
     mockStoreIncomingMessage.mockResolvedValue("test-msg-id");
@@ -561,86 +563,53 @@ describe("resolveReferenceDate via messageIngest (issue #499)", () => {
     mockEncodeDocumentId.mockImplementation((url: string) => `encoded(${url})`);
   });
 
-  it("uses datePublished as fallback when valid and no source timespans provided", async () => {
-    const datePublished = "2026-05-15T00:00:00.000Z";
-    const crawledAt = new Date("2026-05-18T00:00:00.000Z");
-
+  it.each([
+    {
+      label: "valid datePublished → uses datePublished as anchor",
+      datePublished: "2026-05-15T00:00:00.000Z" as string | undefined,
+      expectedDate: new Date("2026-05-15T00:00:00.000Z"),
+    },
+    {
+      label: "absent datePublished → falls back to crawledAt",
+      datePublished: undefined as string | undefined,
+      expectedDate: CRAWLED_AT,
+    },
+    {
+      label: "invalid string datePublished → falls back to crawledAt",
+      datePublished: "not-a-valid-date" as string | undefined,
+      expectedDate: CRAWLED_AT,
+    },
+    {
+      label: "pre-2025 datePublished (e.g. 1970) → falls back to crawledAt",
+      datePublished: "1970-01-01T00:00:00.000Z" as string | undefined,
+      expectedDate: CRAWLED_AT,
+    },
+  ])("$label", async ({ datePublished, expectedDate }) => {
     await messageIngest("test text", "vrabnitsa-org", {
       precomputedGeoJson: PRECOMPUTED_GEOJSON,
       markdownText: "Test",
       locality: "bg.sofia",
       datePublished,
-      crawledAt,
+      crawledAt: CRAWLED_AT,
     });
 
     const timespanUpdate = findTimespanUpdate();
     expect(timespanUpdate).toBeDefined();
-    expect(timespanUpdate.timespanStart).toEqual(new Date(datePublished));
-    expect(timespanUpdate.timespanEnd).toEqual(new Date(datePublished));
-  });
-
-  it("falls back to crawledAt when datePublished is absent", async () => {
-    const crawledAt = new Date("2026-05-18T00:00:00.000Z");
-
-    await messageIngest("test text", "vrabnitsa-org", {
-      precomputedGeoJson: PRECOMPUTED_GEOJSON,
-      markdownText: "Test",
-      locality: "bg.sofia",
-      crawledAt,
-    });
-
-    const timespanUpdate = findTimespanUpdate();
-    expect(timespanUpdate).toBeDefined();
-    expect(timespanUpdate.timespanStart).toEqual(crawledAt);
-    expect(timespanUpdate.timespanEnd).toEqual(crawledAt);
-  });
-
-  it("falls back to crawledAt when datePublished is an invalid string", async () => {
-    const crawledAt = new Date("2026-05-18T00:00:00.000Z");
-
-    await messageIngest("test text", "vrabnitsa-org", {
-      precomputedGeoJson: PRECOMPUTED_GEOJSON,
-      markdownText: "Test",
-      locality: "bg.sofia",
-      datePublished: "not-a-valid-date",
-      crawledAt,
-    });
-
-    const timespanUpdate = findTimespanUpdate();
-    expect(timespanUpdate).toBeDefined();
-    expect(timespanUpdate.timespanStart).toEqual(crawledAt);
-    expect(timespanUpdate.timespanEnd).toEqual(crawledAt);
-  });
-
-  it("falls back to crawledAt when datePublished is before 2025-01-01 (lower-bound guard)", async () => {
-    const crawledAt = new Date("2026-05-18T00:00:00.000Z");
-
-    await messageIngest("test text", "vrabnitsa-org", {
-      precomputedGeoJson: PRECOMPUTED_GEOJSON,
-      markdownText: "Test",
-      locality: "bg.sofia",
-      datePublished: "1970-01-01T00:00:00.000Z",
-      crawledAt,
-    });
-
-    const timespanUpdate = findTimespanUpdate();
-    expect(timespanUpdate).toBeDefined();
-    expect(timespanUpdate.timespanStart).toEqual(crawledAt);
-    expect(timespanUpdate.timespanEnd).toEqual(crawledAt);
+    expect(timespanUpdate.timespanStart).toEqual(expectedDate);
+    expect(timespanUpdate.timespanEnd).toEqual(expectedDate);
   });
 
   it("delayed crawl regression (#499): fallback is datePublished not crawledAt", async () => {
     // Mirrors the May 2026 production incident: article published May 15, crawler ran May 18.
     // Before the fix, timespans would fall back to May 18 (crawl time) instead of May 15.
     const datePublished = "2026-05-15T00:00:00.000Z";
-    const crawledAt = new Date("2026-05-18T00:00:00.000Z");
 
     await messageIngest("test text", "vrabnitsa-org", {
       precomputedGeoJson: PRECOMPUTED_GEOJSON,
       markdownText: "Test",
       locality: "bg.sofia",
       datePublished,
-      crawledAt,
+      crawledAt: CRAWLED_AT,
     });
 
     const timespanUpdate = findTimespanUpdate();

--- a/ingest/messageIngest/index.test.ts
+++ b/ingest/messageIngest/index.test.ts
@@ -59,6 +59,26 @@ vi.mock("../geocoding/shared/boundary-utils", () => ({
     mockFilterFeaturesByBoundaries(...args),
 }));
 
+// Mock AI service for AI pipeline path tests
+const mockAiFilterAndSplit = vi.fn();
+const mockAiCategorize = vi.fn();
+const mockAiExtractLocations = vi.fn();
+const mockAiSummarize = vi.fn();
+vi.mock("../lib/ai-service", () => ({
+  filterAndSplit: (...args: unknown[]) => mockAiFilterAndSplit(...args),
+  categorize: (...args: unknown[]) => mockAiCategorize(...args),
+  extractLocations: (...args: unknown[]) => mockAiExtractLocations(...args),
+  summarize: (...args: unknown[]) => mockAiSummarize(...args),
+  SUMMARIZE_MIN_LENGTH: 1000,
+}));
+
+// Mock geocoding — keeps AI pipeline tests free of real geocoding calls
+const mockGeocodeAddressesFromExtractedData = vi.fn();
+vi.mock("./geocode-addresses", () => ({
+  geocodeAddressesFromExtractedData: (...args: unknown[]) =>
+    mockGeocodeAddressesFromExtractedData(...args),
+}));
+
 import { computeGeoJsonCentroidAddress, messageIngest } from "./index";
 import type { GeoJSONFeatureCollection } from "@/lib/types";
 
@@ -617,5 +637,82 @@ describe("resolveReferenceDate via messageIngest (issue #499)", () => {
     // Must be May 15 (datePublished), not May 18 (crawledAt)
     expect(timespanUpdate.timespanStart.toISOString()).toBe(datePublished);
     expect(timespanUpdate.timespanEnd.toISOString()).toBe(datePublished);
+  });
+});
+describe("resolveReferenceDate via AI pipeline (issue #499)", () => {
+  const CRAWLED_AT = new Date("2026-05-18T00:00:00.000Z");
+  const DATE_PUBLISHED = "2026-05-15T00:00:00.000Z";
+
+  // A minimal ExtractedLocations with no timespans — fallback will be used
+  const EMPTY_EXTRACTED_LOCATIONS = {
+    withSpecificAddress: false,
+    busStops: [] as string[],
+    educationalFacilities: [] as never[],
+    cityWide: false,
+    pins: [] as never[],
+    streets: [] as never[],
+    cadastralProperties: [] as never[],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockStoreIncomingMessage.mockResolvedValue("test-msg-id");
+    mockUpdateMessage.mockResolvedValue(undefined);
+    mockEncodeDocumentId.mockImplementation((url: string) => `encoded(${url})`);
+    // tryPreGeocodeMatch returns early when message not found
+    mockFindById.mockResolvedValue(null);
+
+    mockAiFilterAndSplit.mockResolvedValue([
+      {
+        plainText: "Water supply disruption",
+        isRelevant: true,
+        markdownText: "**Water supply** disruption",
+        isOneOfMany: false,
+        isInformative: false,
+        isUnreadable: false,
+        responsibleEntity: "",
+      },
+    ]);
+    mockAiCategorize.mockResolvedValue({ categories: ["water"] });
+    mockAiExtractLocations.mockResolvedValue(EMPTY_EXTRACTED_LOCATIONS);
+    mockAiSummarize.mockResolvedValue(null);
+    // Reject geocoding so processSingleMessage exits early without hitting real geocoders
+    mockGeocodeAddressesFromExtractedData.mockRejectedValue(
+      new Error("geocoding skipped in test"),
+    );
+  });
+
+  function findAiPipelineTimespanUpdate() {
+    const updatePayloads = mockUpdateMessage.mock.calls.map((call) => call[1]);
+    return updatePayloads.find(
+      (payload) =>
+        payload?.$set?.timespanStart instanceof Date &&
+        payload?.$set?.timespanEnd instanceof Date,
+    );
+  }
+
+  it("uses datePublished as timespan anchor in AI pipeline when valid", async () => {
+    await messageIngest("Water supply disruption", "vrabnitsa-org", {
+      locality: "bg.sofia",
+      crawledAt: CRAWLED_AT,
+      datePublished: DATE_PUBLISHED,
+    });
+
+    const timespanUpdate = findAiPipelineTimespanUpdate();
+    expect(timespanUpdate).toBeDefined();
+    expect(timespanUpdate.$set.timespanStart).toEqual(new Date(DATE_PUBLISHED));
+    expect(timespanUpdate.$set.timespanEnd).toEqual(new Date(DATE_PUBLISHED));
+  });
+
+  it("falls back to crawledAt in AI pipeline when no datePublished", async () => {
+    await messageIngest("Water supply disruption", "vrabnitsa-org", {
+      locality: "bg.sofia",
+      crawledAt: CRAWLED_AT,
+    });
+
+    const timespanUpdate = findAiPipelineTimespanUpdate();
+    expect(timespanUpdate).toBeDefined();
+    expect(timespanUpdate.$set.timespanStart).toEqual(CRAWLED_AT);
+    expect(timespanUpdate.$set.timespanEnd).toEqual(CRAWLED_AT);
   });
 });

--- a/ingest/messageIngest/index.test.ts
+++ b/ingest/messageIngest/index.test.ts
@@ -612,6 +612,23 @@ describe("resolveReferenceDate via messageIngest (issue #499)", () => {
     expect(timespanUpdate.timespanEnd).toEqual(crawledAt);
   });
 
+  it("falls back to crawledAt when datePublished is before 2025-01-01 (lower-bound guard)", async () => {
+    const crawledAt = new Date("2026-05-18T00:00:00.000Z");
+
+    await messageIngest("test text", "vrabnitsa-org", {
+      precomputedGeoJson: PRECOMPUTED_GEOJSON,
+      markdownText: "Test",
+      locality: "bg.sofia",
+      datePublished: "1970-01-01T00:00:00.000Z",
+      crawledAt,
+    });
+
+    const timespanUpdate = findTimespanUpdate();
+    expect(timespanUpdate).toBeDefined();
+    expect(timespanUpdate.timespanStart).toEqual(crawledAt);
+    expect(timespanUpdate.timespanEnd).toEqual(crawledAt);
+  });
+
   it("delayed crawl regression (#499): fallback is datePublished not crawledAt", async () => {
     // Mirrors the May 2026 production incident: article published May 15, crawler ran May 18.
     // Before the fix, timespans would fall back to May 18 (crawl time) instead of May 15.

--- a/ingest/messageIngest/index.test.ts
+++ b/ingest/messageIngest/index.test.ts
@@ -543,6 +543,16 @@ describe("event matching after finalization", () => {
  * observing the timespanStart/timespanEnd stored in the DB when no source timespans are
  * provided — the fallback date should prefer datePublished over crawledAt.
  */
+function findTimespanUpdate() {
+  const updatePayloads = mockUpdateMessage.mock.calls.map((call) => call[1]);
+  return updatePayloads.find(
+    (payload) =>
+      payload &&
+      payload.timespanStart instanceof Date &&
+      payload.timespanEnd instanceof Date,
+  );
+}
+
 describe("resolveReferenceDate via messageIngest (issue #499)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -550,16 +560,6 @@ describe("resolveReferenceDate via messageIngest (issue #499)", () => {
     mockUpdateMessage.mockResolvedValue(undefined);
     mockEncodeDocumentId.mockImplementation((url: string) => `encoded(${url})`);
   });
-
-  function findTimespanUpdate() {
-    const updatePayloads = mockUpdateMessage.mock.calls.map((call) => call[1]);
-    return updatePayloads.find(
-      (payload) =>
-        payload &&
-        payload.timespanStart instanceof Date &&
-        payload.timespanEnd instanceof Date,
-    );
-  }
 
   it("uses datePublished as fallback when valid and no source timespans provided", async () => {
     const datePublished = "2026-05-15T00:00:00.000Z";

--- a/ingest/messageIngest/index.ts
+++ b/ingest/messageIngest/index.ts
@@ -529,7 +529,6 @@ async function processWithAIPipeline(
     await storeExtractedLocations(
       storedMessageId,
       extractedLocations,
-      crawledAt,
       referenceDate,
     );
 
@@ -705,7 +704,6 @@ async function storeCategorization(
 async function storeExtractedLocations(
   messageId: string,
   extractedLocations: ExtractedLocations | null,
-  crawledAt: Date,
   referenceDate: Date,
 ): Promise<void> {
   const { extractTimespanRangeFromExtractedLocations, validateAndFallback } =
@@ -718,11 +716,12 @@ async function storeExtractedLocations(
   const educationalFacilities = extractedLocations?.educationalFacilities || [];
   const cityWide = extractedLocations?.cityWide || false;
 
-  // Extract timespans from extracted locations (pins/streets)
+  // Extract timespans from extracted locations (pins/streets), preferring referenceDate
+  // (datePublished when valid) over crawledAt as the fallback anchor.
   const { timespanStart, timespanEnd } =
-    extractTimespanRangeFromExtractedLocations(extractedLocations, crawledAt);
+    extractTimespanRangeFromExtractedLocations(extractedLocations, referenceDate);
 
-  // Validate and fallback to referenceDate (datePublished if valid, else crawledAt) if invalid
+  // Validate and fallback to referenceDate if extracted timespans are out of range
   const validated = validateAndFallback(timespanStart, timespanEnd, referenceDate);
 
   await updateMessage(messageId, {

--- a/ingest/messageIngest/index.ts
+++ b/ingest/messageIngest/index.ts
@@ -2,6 +2,7 @@ import {
   Address,
   ExtractedLocations,
   GeoJsonFeatureCollection,
+  GeoJsonGeometry,
   InternalMessage,
   Coordinates,
   QualitySignals,
@@ -1015,6 +1016,27 @@ async function finalizeFailedMessage(
   return await buildMessageResponse(messageId, text, locality, [], null);
 }
 
+/** Extract all vertices from a GeoJSON geometry as [lng, lat] pairs. */
+function getGeometryVertices(geom: GeoJsonGeometry): [number, number][] {
+  switch (geom.type) {
+    case "Point":
+      return [geom.coordinates];
+    case "MultiPoint":
+    case "LineString":
+      return geom.coordinates;
+    case "Polygon": {
+      const ring = geom.coordinates[0];
+      if (!ring || ring.length === 0) return [];
+      // Skip the closing vertex if it duplicates the first (standard GeoJSON rings are closed)
+      const isClosed =
+        ring.length > 1 &&
+        ring[0][0] === ring.at(-1)![0] &&
+        ring[0][1] === ring.at(-1)![1];
+      return isClosed ? ring.slice(0, -1) : ring;
+    }
+  }
+}
+
 /**
  * Compute the centroid of all features in a GeoJSON FeatureCollection.
  * Returns an Address with the centroid coordinates, or null if it cannot be computed.
@@ -1033,49 +1055,10 @@ export function computeGeoJsonCentroidAddress(
   let count = 0;
 
   for (const feature of features) {
-    const geom = feature.geometry;
-    if (!geom) continue;
-
-    switch (geom.type) {
-      case "Point": {
-        totalLng += geom.coordinates[0];
-        totalLat += geom.coordinates[1];
-        count++;
-        break;
-      }
-      case "MultiPoint": {
-        for (const coord of geom.coordinates) {
-          totalLng += coord[0];
-          totalLat += coord[1];
-          count++;
-        }
-        break;
-      }
-      case "LineString": {
-        for (const coord of geom.coordinates) {
-          totalLng += coord[0];
-          totalLat += coord[1];
-          count++;
-        }
-        break;
-      }
-      case "Polygon": {
-        const ring = geom.coordinates[0];
-        if (ring && ring.length > 0) {
-          // Skip the closing vertex if it duplicates the first (standard GeoJSON rings are closed)
-          const first = ring[0];
-          const last = ring[ring.length - 1];
-          const isClosed =
-            ring.length > 1 && first[0] === last[0] && first[1] === last[1];
-          const vertices = isClosed ? ring.slice(0, -1) : ring;
-          for (const coord of vertices) {
-            totalLng += coord[0];
-            totalLat += coord[1];
-            count++;
-          }
-        }
-        break;
-      }
+    for (const coord of getGeometryVertices(feature.geometry)) {
+      totalLng += coord[0];
+      totalLat += coord[1];
+      count++;
     }
   }
 

--- a/ingest/messageIngest/index.ts
+++ b/ingest/messageIngest/index.ts
@@ -70,6 +70,13 @@ export interface MessageIngestOptions {
    */
   crawledAt?: Date;
   /**
+   * Optional publication date from the source document (ISO 8601 string).
+   * When valid, preferred over crawledAt as the temporal anchor for LLM reasoning
+   * and as the fallback date for timespan validation. Relevant for batch crawlers
+   * where crawledAt can be days after the source was written.
+   */
+  datePublished?: string;
+  /**
    * Optional markdown-formatted text for display (when crawler produces markdown)
    */
   markdownText?: string;
@@ -155,6 +162,7 @@ async function processSingleMessage(
   ingestErrors: IngestErrorCollector,
 ): Promise<InternalMessage> {
   const crawledAt = ensureCrawledAtDate(options.crawledAt);
+  const referenceDate = resolveReferenceDate(options.datePublished, crawledAt);
 
   // Early exit: No extracted locations and no precomputed GeoJSON
   if (!precomputedGeoJson && !extractedLocations) {
@@ -178,7 +186,7 @@ async function processSingleMessage(
       options.markdownText!,
       options.timespanStart,
       options.timespanEnd,
-      crawledAt,
+      referenceDate,
     );
   }
 
@@ -345,8 +353,9 @@ async function processWithAIPipeline(
     await import("../lib/ai-service");
 
   const crawledAt = ensureCrawledAtDate(options.crawledAt);
+  const referenceDate = resolveReferenceDate(options.datePublished, crawledAt);
   const promptCtx = {
-    currentDate: crawledAt,
+    currentDate: referenceDate,
     sourceType: source,
     sourceUrl: options.sourceUrl,
   };
@@ -519,6 +528,7 @@ async function processWithAIPipeline(
       storedMessageId,
       extractedLocations,
       crawledAt,
+      referenceDate,
     );
 
     // Pre-geocode matching: try to reuse geometry from an existing high-quality event
@@ -694,6 +704,7 @@ async function storeExtractedLocations(
   messageId: string,
   extractedLocations: ExtractedLocations | null,
   crawledAt: Date,
+  referenceDate: Date,
 ): Promise<void> {
   const { extractTimespanRangeFromExtractedLocations, validateAndFallback } =
     await import("@/lib/timespan-utils");
@@ -709,8 +720,8 @@ async function storeExtractedLocations(
   const { timespanStart, timespanEnd } =
     extractTimespanRangeFromExtractedLocations(extractedLocations, crawledAt);
 
-  // Validate and fallback to crawledAt if invalid
-  const validated = validateAndFallback(timespanStart, timespanEnd, crawledAt);
+  // Validate and fallback to referenceDate (datePublished if valid, else crawledAt) if invalid
+  const validated = validateAndFallback(timespanStart, timespanEnd, referenceDate);
 
   await updateMessage(messageId, {
     $set: {
@@ -802,6 +813,24 @@ function ensureCrawledAtDate(crawledAt: Date | string | undefined): Date {
     }
   }
   return new Date();
+}
+
+/**
+ * Resolve the best temporal anchor date for LLM reasoning and timespan fallback.
+ * Prefers datePublished (when the source was written) over crawledAt (when crawled).
+ * Relevant for batch crawlers where crawledAt can be days after the article was published.
+ */
+function resolveReferenceDate(
+  datePublished: string | undefined,
+  crawledAt: Date,
+): Date {
+  if (datePublished) {
+    const parsed = new Date(datePublished);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed;
+    }
+  }
+  return crawledAt;
 }
 
 /**
@@ -1070,7 +1099,7 @@ async function handlePrecomputedGeoJsonData(
   markdownText: string,
   timespanStart: Date | undefined,
   timespanEnd: Date | undefined,
-  crawledAt: Date,
+  fallbackDate: Date,
 ): Promise<Address[]> {
   const centroidAddress = computeGeoJsonCentroidAddress(precomputedGeoJson);
   const addresses = centroidAddress ? [centroidAddress] : [];
@@ -1079,7 +1108,7 @@ async function handlePrecomputedGeoJsonData(
     : [];
 
   const { validateAndFallback } = await import("@/lib/timespan-utils");
-  const validated = validateAndFallback(timespanStart, timespanEnd, crawledAt);
+  const validated = validateAndFallback(timespanStart, timespanEnd, fallbackDate);
 
   const locationFields = {
     addresses,

--- a/ingest/messageIngest/index.ts
+++ b/ingest/messageIngest/index.ts
@@ -32,6 +32,7 @@ import {
   getNumberArray,
   getStringOrDateOrNull,
 } from "@/lib/record-fields";
+import { validateTimespanRange } from "@/lib/timespan-utils";
 
 export {
   geocodeAddressesFromExtractedData,
@@ -826,7 +827,7 @@ function resolveReferenceDate(
 ): Date {
   if (datePublished) {
     const parsed = new Date(datePublished);
-    if (!Number.isNaN(parsed.getTime())) {
+    if (!Number.isNaN(parsed.getTime()) && validateTimespanRange(parsed)) {
       return parsed;
     }
   }


### PR DESCRIPTION
## Problem

Closes #499

datePublished from crawled source documents was silently discarded at the from-sources → messageIngest handoff:
1. MessageIngestOptions had no datePublished field
2. rom-sources.ts never passed it into the messageIngest() call

This caused two failures for articles crawled days after publication:
- The LLM received crawledAt (crawl time) as currentDate, misinterpreting temporal references like 'yesterday'
- The alidateAndFallback timespan defaulted to crawledAt instead of the article's actual publication date

## Fix

- Add datePublished?: string to MessageIngestOptions
- Pass source.datePublished from ingestSource() in rom-sources.ts
- Add 
esolveReferenceDate() helper: prefers a valid datePublished over crawledAt; gracefully falls back to crawledAt for absent/invalid values
- Use the resolved date as PromptContext.currentDate in processWithAIPipeline
- Use the resolved date as the alidateAndFallback fallback in both the AI pipeline and precomputed GeoJSON paths

## Tests

4 new regression tests in messageIngest/index.test.ts:
- Uses valid datePublished as fallback when no source timespans extracted
- Falls back to crawledAt when datePublished is absent
- Falls back to crawledAt when datePublished is an invalid string
- Delayed-crawl regression (#499): article published 2026-05-15, crawled 2026-05-18 → timespans must anchor to May 15

## E2E Verification

Crawled rabnitsa-org, ingested 5 sources, confirmed events show article publication dates (28–29 May 2026) rather than the crawl date (30 May 2026).