### PR TITLE
fix(web): capture server-side errors in Sentry via onRequestError

### DIFF
--- a/web/instrumentation.ts
+++ b/web/instrumentation.ts
@@ -1,3 +1,5 @@
+import * as Sentry from "@sentry/nextjs";
+
 export async function register() {
   if (process.env.NEXT_RUNTIME === "nodejs") {
     await import("./sentry.server.config");
@@ -6,3 +8,7 @@ export async function register() {
     await import("./sentry.edge.config");
   }
 }
+
+// Captures uncaught errors thrown in Server Components, route handlers, and
+// server actions. Without this, App Router server-side errors never reach Sentry.
+export const onRequestError = Sentry.captureRequestError;

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -64,6 +64,8 @@ export default withSentryConfig(config, {
   project: process.env.SENTRY_PROJECT,
   authToken: process.env.SENTRY_AUTH_TOKEN,
   silent: !process.env.CI,
+  // Route browser events through our own domain so ad-blockers don't drop them.
+  tunnelRoute: "/monitoring",
   webpack: {
     treeshake: {
       removeDebugLogging: true,


### PR DESCRIPTION
## Problem

In the Next.js App Router, `instrumentation.ts` `register()` only **initializes** the Sentry SDK — it does **not** automatically capture uncaught errors thrown in **Server Components, route handlers (`app/api/**`), and server actions**. Sentry requires the `onRequestError` hook to be exported as well.

As a result, server-side failures (e.g. a 500 from a route handler or a crashing server component) were **never reaching Sentry**. We only reliably heard about client-side crashes and anything routed through `console.error` or a manual `captureException`.

## Changes

- **`web/instrumentation.ts`** — export `onRequestError = Sentry.captureRequestError` so App Router server-side errors are reported to Sentry.
- **`web/next.config.ts`** — add `tunnelRoute: "/monitoring"` so browser error events are routed through our own domain and aren't silently dropped by ad-blockers.

## Verification (per AGENTS.md)

- `pnpm lint` (web) — passes (pre-existing `no-console` warnings only)
- `pnpm tsc --noEmit` (web) — clean
- `pnpm test:run` — the only failures were flaky timeouts in the unrelated `useSubscriptionStatus.test.ts` under parallel load; the file passes 9/9 in isolation. The changed files are Sentry config and are not exercised by those tests.

## Notes / possible follow-ups

- `sentry.client.config.ts` could be migrated to `instrumentation-client.ts` (preferred filename in Sentry v10 + Next 16).
- No route-level `error.tsx` exists; route errors bubble to `global-error.tsx`, which is acceptable but coarser.
