### PR TITLE
fix: fail fast when locality config is missing in API/Web runtime

### DIFF
--- a/api/src/lib/bounds-utils.ts
+++ b/api/src/lib/bounds-utils.ts
@@ -6,6 +6,7 @@
 import { bbox } from "@turf/turf";
 import { getBoundsForLocality } from "@oboapp/shared";
 import type { GeoJsonFeature } from "../schema/contract";
+import { getRequiredLocality } from "./locality";
 
 export interface ViewportBounds {
   north: number;
@@ -15,7 +16,7 @@ export interface ViewportBounds {
 }
 
 function getLocality(): string {
-  return process.env.LOCALITY || "bg.sofia";
+  return getRequiredLocality();
 }
 
 function getLocalityBounds() {

--- a/api/src/lib/locality.ts
+++ b/api/src/lib/locality.ts
@@ -1,0 +1,10 @@
+export const LOCALITY_ENV_ERROR_MESSAGE =
+  "LOCALITY environment variable is required but not set";
+
+export function getRequiredLocality(): string {
+  const locality = process.env.LOCALITY?.trim();
+  if (!locality) {
+    throw new Error(LOCALITY_ENV_ERROR_MESSAGE);
+  }
+  return locality;
+}

--- a/api/src/routes/messages.ts
+++ b/api/src/routes/messages.ts
@@ -15,6 +15,10 @@ import {
   type ViewportBounds,
 } from "../lib/bounds-utils";
 import { getCentroid } from "../lib/geometry-utils";
+import {
+  getRequiredLocality,
+  LOCALITY_ENV_ERROR_MESSAGE,
+} from "../lib/locality";
 
 const DEFAULT_RELEVANCE_DAYS = 7;
 const CLUSTER_ZOOM_THRESHOLD = 15;
@@ -461,6 +465,14 @@ messagesRoute.get(
         timespanEndGte,
       } = parsed.data;
 
+      let locality: string;
+      try {
+        locality = getRequiredLocality();
+      } catch {
+        console.error("Missing LOCALITY configuration for /v1/messages");
+        return c.json({ error: LOCALITY_ENV_ERROR_MESSAGE }, 500);
+      }
+
       const viewportBounds = toViewportBounds({ north, south, east, west });
       const cutoffDate = getCutoffDate(timespanEndGte);
 
@@ -469,7 +481,6 @@ messagesRoute.get(
       }
 
       // Build set of all known source IDs for validation
-      const locality = process.env.LOCALITY || "bg.sofia";
       const allSourceIds = new Set(
         SOURCES.filter((s) => s.localities.includes(locality)).map((s) => s.id),
       );

--- a/api/src/routes/routes.test.ts
+++ b/api/src/routes/routes.test.ts
@@ -155,19 +155,26 @@ describe("GET /v1/sources", () => {
   });
 
   it("returns 500 when LOCALITY is missing", async () => {
+    const previousLocality = process.env.LOCALITY;
     delete process.env.LOCALITY;
 
-    const res = await app.request("/v1/sources", {
-      headers: API_KEY_HEADER,
-    });
+    try {
+      const res = await app.request("/v1/sources", {
+        headers: API_KEY_HEADER,
+      });
 
-    expect(res.status).toBe(500);
-    const body: any = await res.json();
-    expect(body).toEqual({
-      error: "LOCALITY environment variable is required but not set",
-    });
-
-    process.env.LOCALITY = "bg.sofia";
+      expect(res.status).toBe(500);
+      const body: any = await res.json();
+      expect(body).toEqual({
+        error: "LOCALITY environment variable is required but not set",
+      });
+    } finally {
+      if (previousLocality === undefined) {
+        delete process.env.LOCALITY;
+      } else {
+        process.env.LOCALITY = previousLocality;
+      }
+    }
   });
 });
 
@@ -234,19 +241,26 @@ describe("GET /v1/messages", () => {
   });
 
   it("returns 500 when LOCALITY is missing", async () => {
+    const previousLocality = process.env.LOCALITY;
     delete process.env.LOCALITY;
 
-    const res = await app.request("/v1/messages", {
-      headers: API_KEY_HEADER,
-    });
+    try {
+      const res = await app.request("/v1/messages", {
+        headers: API_KEY_HEADER,
+      });
 
-    expect(res.status).toBe(500);
-    const body: any = await res.json();
-    expect(body).toEqual({
-      error: "LOCALITY environment variable is required but not set",
-    });
-
-    process.env.LOCALITY = "bg.sofia";
+      expect(res.status).toBe(500);
+      const body: any = await res.json();
+      expect(body).toEqual({
+        error: "LOCALITY environment variable is required but not set",
+      });
+    } finally {
+      if (previousLocality === undefined) {
+        delete process.env.LOCALITY;
+      } else {
+        process.env.LOCALITY = previousLocality;
+      }
+    }
   });
 
   it("returns empty messages when categories param is empty", async () => {

--- a/api/src/routes/routes.test.ts
+++ b/api/src/routes/routes.test.ts
@@ -153,6 +153,22 @@ describe("GET /v1/sources", () => {
     expect(source).toHaveProperty("url");
     expect(source).toHaveProperty("logoUrl");
   });
+
+  it("returns 500 when LOCALITY is missing", async () => {
+    delete process.env.LOCALITY;
+
+    const res = await app.request("/v1/sources", {
+      headers: API_KEY_HEADER,
+    });
+
+    expect(res.status).toBe(500);
+    const body: any = await res.json();
+    expect(body).toEqual({
+      error: "LOCALITY environment variable is required but not set",
+    });
+
+    process.env.LOCALITY = "bg.sofia";
+  });
 });
 
 describe("GET /v1/messages", () => {
@@ -215,6 +231,22 @@ describe("GET /v1/messages", () => {
       ],
       orderBy: [{ field: "timespanEnd", direction: "desc" }],
     });
+  });
+
+  it("returns 500 when LOCALITY is missing", async () => {
+    delete process.env.LOCALITY;
+
+    const res = await app.request("/v1/messages", {
+      headers: API_KEY_HEADER,
+    });
+
+    expect(res.status).toBe(500);
+    const body: any = await res.json();
+    expect(body).toEqual({
+      error: "LOCALITY environment variable is required but not set",
+    });
+
+    process.env.LOCALITY = "bg.sofia";
   });
 
   it("returns empty messages when categories param is empty", async () => {

--- a/api/src/routes/sources.ts
+++ b/api/src/routes/sources.ts
@@ -3,6 +3,10 @@ import { SOURCES } from "@oboapp/shared";
 import { apiKeyAuth } from "../middleware/api-key";
 import { rateLimit } from "../middleware/rate-limit";
 import { usageMetrics } from "../middleware/usage-metrics";
+import {
+  getRequiredLocality,
+  LOCALITY_ENV_ERROR_MESSAGE,
+} from "../lib/locality";
 
 export const sourcesRoute = new Hono();
 
@@ -14,7 +18,13 @@ sourcesRoute.get("/sources", apiKeyAuth, rateLimit, usageMetrics, (c) => {
       500,
     );
   }
-  const locality = process.env.LOCALITY || "bg.sofia";
+  let locality: string;
+  try {
+    locality = getRequiredLocality();
+  } catch {
+    console.error("Missing LOCALITY configuration for /v1/sources");
+    return c.json({ error: LOCALITY_ENV_ERROR_MESSAGE }, 500);
+  }
 
   const sources = SOURCES.filter((source) =>
     source.localities.includes(locality),

--- a/docs/features/air-quality-monitoring.md
+++ b/docs/features/air-quality-monitoring.md
@@ -75,7 +75,7 @@ Both the ingest package (for the fetch job and crawler) and the web package (for
 | `GCS_GENERIC_BUCKET` | ingest, web | Production | GCS bucket name for general-purpose file storage |
 | `LOCAL_READINGS_PATH` | ingest, web | No | Local filesystem path for development (default: `./tmp/air-quality`) |
 | `LOCALITY` | ingest | Yes | Locality identifier that determines the geographic bounds |
-| `NEXT_PUBLIC_LOCALITY` | web | No | Locality shown on the `/air-quality` monitoring page; defaults to `bg.sofia` if not set |
+| `NEXT_PUBLIC_LOCALITY` | web | Yes | Locality shown on the `/air-quality` monitoring page and used as the default locality in `/api/air-quality/status` when no `locality` query parameter is provided |
 
 See the `.env.example` files in each package for the full list of variables.
 

--- a/web/app/air-quality/page.tsx
+++ b/web/app/air-quality/page.tsx
@@ -11,6 +11,7 @@ import MessagesGrid from "@/components/MessagesGrid";
 import MessageDetailView from "@/components/MessageDetailView/MessageDetailView";
 import { useMessageByIdFallback } from "@/lib/hooks/useMessageByIdFallback";
 import { navigateBackOrReplace } from "@/lib/navigation-utils";
+import { getConfiguredLocality } from "@/lib/locality-metadata";
 import type { Message, InternalMessage } from "@/lib/types";
 
 // Leaflet requires a browser DOM — load client-side only
@@ -26,7 +27,7 @@ const AirQualityMap = dynamic(() => import("@/components/AirQualityMap"), {
   ),
 });
 
-const LOCALITY = process.env.NEXT_PUBLIC_LOCALITY ?? "bg.sofia";
+const LOCALITY = getConfiguredLocality();
 const SOURCE_ID = "sensor-community";
 
 interface AqiCell {

--- a/web/app/api/air-quality/status/__tests__/route.test.ts
+++ b/web/app/api/air-quality/status/__tests__/route.test.ts
@@ -66,6 +66,7 @@ describe("GET /api/air-quality/status", () => {
     // Pin env vars so tests are hermetic regardless of the host environment.
     // Force the GCS path so mockGcsDownload controls data supply consistently.
     vi.stubEnv("GCS_GENERIC_BUCKET", "test-bucket");
+    vi.stubEnv("NEXT_PUBLIC_LOCALITY", "bg.test-default");
     vi.stubEnv("FIREBASE_SERVICE_ACCOUNT_KEY", "");
     // Default: no data — GCS file not found
     mockGcsDownload.mockRejectedValue(gcsNotFound());
@@ -94,11 +95,23 @@ describe("GET /api/air-quality/status", () => {
       expect(body).toHaveProperty("error", "Unknown locality");
     });
 
-    it("defaults to bg.sofia when no locality param is provided", async () => {
+    it("defaults to NEXT_PUBLIC_LOCALITY when no locality param is provided", async () => {
       const res = await GET(makeRequest());
       expect(res.status).toBe(200);
       const body = await res.json();
-      expect(body.locality).toBe("bg.sofia");
+      expect(body.locality).toBe("bg.test-default");
+    });
+
+    it("returns 500 when neither locality param nor NEXT_PUBLIC_LOCALITY is set", async () => {
+      vi.stubEnv("NEXT_PUBLIC_LOCALITY", "");
+
+      const res = await GET(makeRequest());
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body).toHaveProperty(
+        "error",
+        "NEXT_PUBLIC_LOCALITY environment variable is required but not set",
+      );
     });
   });
 

--- a/web/app/api/air-quality/status/route.ts
+++ b/web/app/api/air-quality/status/route.ts
@@ -190,12 +190,16 @@ export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const localityFromQuery = searchParams.get("locality");
   let locality: string;
-  if (localityFromQuery) {
+  if (localityFromQuery !== null) {
     locality = localityFromQuery;
   } else {
     try {
       locality = getConfiguredLocality();
-    } catch {
+    } catch (err) {
+      console.error(
+        "Missing NEXT_PUBLIC_LOCALITY configuration for /api/air-quality/status",
+        err,
+      );
       return NextResponse.json(
         { error: LOCALITY_ENV_ERROR_MESSAGE },
         { status: 500 },

--- a/web/app/api/air-quality/status/route.ts
+++ b/web/app/api/air-quality/status/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 import {
+  getConfiguredLocality,
+  LOCALITY_ENV_ERROR_MESSAGE,
+} from "@/lib/locality-metadata";
+import {
   getBoundsForLocality,
   calculateNowCastAqi,
   getAqiLabel,
@@ -184,7 +188,20 @@ async function readGcsReadings(
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
-  const locality = searchParams.get("locality") ?? "bg.sofia";
+  const localityFromQuery = searchParams.get("locality");
+  let locality: string;
+  if (localityFromQuery) {
+    locality = localityFromQuery;
+  } else {
+    try {
+      locality = getConfiguredLocality();
+    } catch {
+      return NextResponse.json(
+        { error: LOCALITY_ENV_ERROR_MESSAGE },
+        { status: 500 },
+      );
+    }
+  }
 
   if (
     process.env.NODE_ENV === "production" &&


### PR DESCRIPTION
## Summary
- remove runtime  fallbacks from API locality resolution paths
- make  and  return explicit 500 config errors when  is missing
- require  for  runtime paths and for  default locality
- update route tests and air-quality docs to reflect fail-fast behavior

Closes #560