### PR TITLE
fix(db): remove hardcoded locality fallback from migrations

### DIFF
--- a/db/migrate/2026-02-10-add-locality-field.ts
+++ b/db/migrate/2026-02-10-add-locality-field.ts
@@ -2,7 +2,10 @@
 
 /**
  * Migration script to backfill locality field for existing sources and messages
- * Run with: cd db && npx tsx migrate/2026-02-10-add-locality-field.ts
+ * Run with:
+ *   cd db && npx tsx migrate/2026-02-10-add-locality-field.ts --locality=bg.sofia
+ *   cd db && MIGRATION_LOCALITY=bg.sofia npx tsx migrate/2026-02-10-add-locality-field.ts
+ * Add --dry-run to preview counts without writing.
  */
 
 import dotenv from "dotenv";
@@ -10,6 +13,26 @@ import { resolve } from "node:path";
 
 // Load environment variables from ingest/.env.local
 dotenv.config({ path: resolve(process.cwd(), "../ingest/.env.local") });
+
+function parseRequiredLocality(): string {
+  const localityArg = process.argv
+    .slice(2)
+    .find((arg) => arg.startsWith("--locality="));
+  const locality = localityArg?.split("=")[1] ?? process.env.MIGRATION_LOCALITY;
+  const trimmed = locality?.trim();
+
+  if (!trimmed) {
+    throw new Error(
+      "Missing locality. Provide --locality=<id> or MIGRATION_LOCALITY.",
+    );
+  }
+
+  return trimmed;
+}
+
+function isDryRun(): boolean {
+  return process.argv.slice(2).includes("--dry-run");
+}
 
 async function main() {
   const { initializeApp, getApps, cert } = await import("firebase-admin/app");
@@ -27,9 +50,16 @@ async function main() {
   }
 
   console.log("Starting migration to add locality field...");
+  const locality = parseRequiredLocality();
+  const dryRun = isDryRun();
 
-  // Default locality for all existing records
-  const DEFAULT_LOCALITY = "bg.sofia";
+  console.log("Preflight configuration:");
+  console.log(`  locality: ${locality}`);
+  console.log(`  dry-run: ${dryRun ? "yes" : "no"}`);
+
+  if (dryRun) {
+    console.log("  mode: no writes (preview only)");
+  }
 
   // Migrate sources collection
   console.log("\n1. Migrating sources collection...");
@@ -48,8 +78,9 @@ async function main() {
       continue;
     }
 
-    // Update with default locality
-    await doc.ref.update({ locality: DEFAULT_LOCALITY });
+    if (!dryRun) {
+      await doc.ref.update({ locality });
+    }
     sourcesUpdated++;
 
     if (sourcesUpdated % 100 === 0) {
@@ -78,8 +109,9 @@ async function main() {
       continue;
     }
 
-    // Update with default locality
-    await doc.ref.update({ locality: DEFAULT_LOCALITY });
+    if (!dryRun) {
+      await doc.ref.update({ locality });
+    }
     messagesUpdated++;
 
     if (messagesUpdated % 100 === 0) {
@@ -108,8 +140,9 @@ async function main() {
       continue;
     }
 
-    // Update with default locality
-    await doc.ref.update({ locality: DEFAULT_LOCALITY });
+    if (!dryRun) {
+      await doc.ref.update({ locality });
+    }
     eventsUpdated++;
 
     if (eventsUpdated % 100 === 0) {
@@ -125,6 +158,7 @@ async function main() {
   console.log(`  Total sources updated: ${sourcesUpdated}`);
   console.log(`  Total messages updated: ${messagesUpdated}`);
   console.log(`  Total events updated: ${eventsUpdated}`);
+  console.log(`  Locality used: ${locality}`);
 }
 
 main().catch((error) => {

--- a/db/migrate/2026-03-15-create-events-from-messages.ts
+++ b/db/migrate/2026-03-15-create-events-from-messages.ts
@@ -14,7 +14,10 @@
  * Idempotent: skips messages that already have an eventId set.
  * Paginated: processes messages in batches to avoid loading entire collection.
  *
- * Run with: cd db && npx tsx migrate/2026-03-15-create-events-from-messages.ts
+ * Run with:
+ *   cd db && npx tsx migrate/2026-03-15-create-events-from-messages.ts --fallback-locality=bg.sofia
+ *   cd db && MIGRATION_FALLBACK_LOCALITY=bg.sofia npx tsx migrate/2026-03-15-create-events-from-messages.ts
+ * Add --dry-run to preview intended writes without committing.
  */
 
 import dotenv from "dotenv";
@@ -23,6 +26,27 @@ import { resolve } from "node:path";
 dotenv.config({ path: resolve(process.cwd(), "../ingest/.env.local") });
 
 const BATCH_SIZE = 200;
+
+function parseFallbackLocality(): string {
+  const fallbackArg = process.argv
+    .slice(2)
+    .find((arg) => arg.startsWith("--fallback-locality="));
+  const fallbackLocality =
+    fallbackArg?.split("=")[1] ?? process.env.MIGRATION_FALLBACK_LOCALITY;
+  const trimmed = fallbackLocality?.trim();
+
+  if (!trimmed) {
+    throw new Error(
+      "Missing fallback locality. Provide --fallback-locality=<id> or MIGRATION_FALLBACK_LOCALITY.",
+    );
+  }
+
+  return trimmed;
+}
+
+function isDryRun(): boolean {
+  return process.argv.slice(2).includes("--dry-run");
+}
 
 /** Source trust map (duplicated from ingest to avoid cross-package import) */
 const SOURCE_GEOMETRY_QUALITY: Record<string, number> = {
@@ -105,6 +129,16 @@ async function main() {
   }
 
   console.log("Starting migration: create events from messages...\n");
+  const fallbackLocality = parseFallbackLocality();
+  const dryRun = isDryRun();
+
+  console.log("Preflight configuration:");
+  console.log(`  fallback locality: ${fallbackLocality}`);
+  console.log(`  dry-run: ${dryRun ? "yes" : "no"}`);
+  if (dryRun) {
+    console.log("  mode: no writes (preview only)");
+  }
+  console.log("");
 
   let eventsCreated = 0;
   let skippedNoGeoJson = 0;
@@ -234,13 +268,15 @@ async function main() {
           sources: source ? [source] : [],
           messageCount: 1,
           confidence: 1.0,
-          locality: data.locality || "bg.sofia",
+          locality: data.locality || fallbackLocality,
           cityWide: data.cityWide || false,
           ...(data.embedding ? { embedding: data.embedding } : {}),
           createdAt: now,
           updatedAt: now,
         };
-        batch.set(eventRef, eventData);
+        if (!dryRun) {
+          batch.set(eventRef, eventData);
+        }
 
         // Create EventMessage link document (deterministic ID)
         const eventMessageRef = adminDb
@@ -259,16 +295,20 @@ async function main() {
         // the getAll() pre-check and batch.commit()) causes a hard failure rather
         // than silently overwriting an existing link. Run this migration with
         // ingestion paused; if it fails, re-run safely (idempotent via pre-check).
-        batch.create(eventMessageRef, eventMessageData);
+        if (!dryRun) {
+          batch.create(eventMessageRef, eventMessageData);
+        }
 
         // Store eventId on message
-        batch.update(doc.ref, { eventId: eventRef.id });
+        if (!dryRun) {
+          batch.update(doc.ref, { eventId: eventRef.id });
+        }
 
         batchCount += 3;
         eventsCreated++;
 
         // Firestore batches can have at most 500 operations
-        if (batchCount >= 498) {
+        if (!dryRun && batchCount >= 498) {
           await batch.commit();
           console.log(`  Committed batch (${eventsCreated} events so far)...`);
           batch = adminDb.batch();
@@ -278,7 +318,7 @@ async function main() {
     }
 
     // Commit remaining operations in this page
-    if (batchCount > 0) {
+    if (!dryRun && batchCount > 0) {
       await batch.commit();
     }
 
@@ -296,6 +336,7 @@ async function main() {
   console.log(`  Skipped (no geoJson): ${skippedNoGeoJson}`);
   console.log(`  Skipped (not finalized): ${skippedNotFinalized}`);
   console.log(`  Skipped (already linked): ${skippedAlreadyLinked}`);
+  console.log(`  Fallback locality used: ${fallbackLocality}`);
 }
 
 main().catch((error) => {

--- a/db/migrate/README.md
+++ b/db/migrate/README.md
@@ -10,3 +10,11 @@ npx tsx migrate/<script-name>.ts
 Each script must contain detailed description on purpose and usage.
 
 The date in the filename only serves as a way to sort them. Each one of them should be runnable without negative side effects at any point in time.
+
+## Locality-Sensitive Migrations
+
+Migrations that backfill or derive locality values must receive locality input explicitly from the operator.
+
+- Use script flags such as `--locality=<id>` or `--fallback-locality=<id>`.
+- Environment variable alternatives are available for automation (`MIGRATION_LOCALITY`, `MIGRATION_FALLBACK_LOCALITY`).
+- Prefer `--dry-run` first to verify the preflight output (target locality and write mode) before running a write execution.


### PR DESCRIPTION
## Summary
- remove hardcoded bg.sofia locality fallback from migration backfill paths
- require explicit operator input for locality via CLI flag or dedicated migration env vars
- add preflight output and dry-run mode to show intended locality and execution mode before writes
- document locality-sensitive migration expectations in db migration docs

## Validation
- cd db && pnpm tsc --noEmit

Closes #563
