### PR TITLE
ci: remove implicit locality fallback from web build workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,7 @@ jobs:
       - name: Next.js build
         working-directory: ./web
         env:
-          NEXT_PUBLIC_LOCALITY: ${{ vars.LOCALITY || 'bg.sofia' }}
+          NEXT_PUBLIC_LOCALITY: bg.sofia
           NEXT_PUBLIC_BASE_URL: ${{ vars.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000' }}
           USE_FIREBASE_EMULATORS: "true"
           NEXT_PUBLIC_USE_FIREBASE_EMULATORS: "true"

--- a/docs/qa/overview.md
+++ b/docs/qa/overview.md
@@ -80,6 +80,8 @@ Every pull request triggers the [CI pipeline](../../.github/workflows/ci.yml):
 3. **Test web** — `pnpm test:run` in `web/`
 4. **Build web** — Next.js build check
 
+The web build job sets `NEXT_PUBLIC_LOCALITY` explicitly for deterministic behavior in upstream CI. Instance forks can change this value in their own workflow configuration when targeting a different locality.
+
 On push to `main`, a separate [deploy workflow](../../.github/workflows/deploy.yml) handles Docker build, push to GCP, and Terraform apply. This workflow lives only in instance forks, not in the upstream `oboapp/oboapp` repo.
 
 A [CI failure agent](../../.github/workflows/ci-failure-agent.yml) creates GitHub issues for failed runs and labels them for Copilot triage (`ci-failure`, `copilot`).


### PR DESCRIPTION
## Summary
- remove the implicit vars.LOCALITY || bg.sofia fallback from the CI web build job
- set NEXT_PUBLIC_LOCALITY explicitly in CI for deterministic upstream builds
- document CI locality expectation for upstream and instance forks

Closes #565
