### PR TITLE
fix: make timezone handling configurable in generic runtime paths (#562)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,7 @@ jobs:
         env:
           NEXT_PUBLIC_LOCALITY: bg.sofia
           NEXT_PUBLIC_BASE_URL: ${{ vars.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000' }}
+          NEXT_PUBLIC_TIMEZONE: "UTC"
           USE_FIREBASE_EMULATORS: "true"
           NEXT_PUBLIC_USE_FIREBASE_EMULATORS: "true"
           NEXT_PUBLIC_FIREBASE_PROJECT_ID: "demo-project"

--- a/ingest/crawlers/shared/date-utils.ts
+++ b/ingest/crawlers/shared/date-utils.ts
@@ -54,7 +54,7 @@ export function parseBulgarianDate(dateStr: string): string {
  * Parse Bulgarian date-time format "DD.MM.YYYY HH:MM" to Date object
  *
  * @param dateStr - Date string in Bulgarian format (e.g., "29.12.2025 10:51")
- * @returns Date object in local timezone
+ * @returns Date object in runtime local timezone
  * @throws Error if date string is invalid
  */
 export function parseBulgarianDateTime(dateStr: string): Date {
@@ -99,7 +99,7 @@ export function parseBulgarianDateTime(dateStr: string): Date {
     throw new Error(`Invalid minute: ${minute}`);
   }
 
-  // Create date in local timezone (assumed to be Europe/Sofia)
+  // Create date in runtime local timezone.
   const date = new Date(
     parsedYear,
     parsedMonth,
@@ -136,8 +136,8 @@ export function parseBulgarianDateTime(dateStr: string): Date {
  * @returns ISO date string
  *
  * @example
- * parseShortBulgarianDateTime("17.07.25", "18:48") // "2025-07-17T18:48:00.000Z" (in Sofia timezone)
- * parseShortBulgarianDateTime("17.07.25") // "2025-07-17T00:00:00.000Z" (in Sofia timezone)
+ * parseShortBulgarianDateTime("17.07.25", "18:48") // "2025-07-17T18:48:00.000Z" (runtime timezone)
+ * parseShortBulgarianDateTime("17.07.25") // "2025-07-17T00:00:00.000Z" (runtime timezone)
  */
 export function parseShortBulgarianDateTime(
   dateStr: string,
@@ -165,7 +165,7 @@ export function parseShortBulgarianDateTime(
         }
       }
 
-      // Create date in local timezone (assumed to be Europe/Sofia)
+      // Create date in runtime local timezone.
       const date = new Date(
         Number.parseInt(year, 10),
         Number.parseInt(month, 10) - 1, // 0-indexed months
@@ -229,7 +229,7 @@ export function parseBulgarianMonthDate(dateStr: string): string {
       return new Date().toISOString();
     }
 
-    // Create date in local timezone (assumed to be Europe/Sofia)
+    // Create date in runtime local timezone.
     const date = new Date(
       Number.parseInt(year, 10),
       month - 1, // 0-indexed months

--- a/ingest/terraform/README.md
+++ b/ingest/terraform/README.md
@@ -182,7 +182,7 @@ All variables are defined in `variables.tf`. Override them in `terraform.tfvars`
 | `image_name`                | Docker image name                      | `oborishte-ingest`    |
 | `image_tag`                 | Docker image tag                       | `latest`              |
 | `artifact_registry_repo_id` | Artifact Registry repository ID        | `oborishte-ingest`    |
-| `schedule_timezone`         | Timezone for schedules                 | `Europe/Sofia`        |
+| `schedule_timezone`         | Timezone for schedules                 | `UTC`                 |
 | `localities`                | Locality IDs to deploy crawlers for    | `["bg.sofia"]`        |
 | `crawlers`                  | Manual override for the crawler map    | `{}` (auto-assembled) |
 | `gcs_generic_bucket`        | GCS bucket for file storage (optional) | `""`                  |

--- a/ingest/terraform/variables.tf
+++ b/ingest/terraform/variables.tf
@@ -48,7 +48,7 @@ variable "image_tag" {
 variable "schedule_timezone" {
   description = "Timezone for scheduler jobs"
   type        = string
-  default     = "Europe/Sofia"
+  default     = "UTC"
 }
 
 variable "schedules" {

--- a/web/lib/message-classification.test.ts
+++ b/web/lib/message-classification.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   parseTimespanDate,
+  getClassificationTimeZone,
   getTodayBulgarianTime,
   isToday,
   classifyMessage,
@@ -80,10 +81,12 @@ describe("message-classification", () => {
   describe("getTodayBulgarianTime", () => {
     beforeEach(() => {
       vi.useFakeTimers();
+      vi.stubEnv("NEXT_PUBLIC_TIMEZONE", "Europe/Sofia");
     });
 
     afterEach(() => {
       vi.useRealTimers();
+      vi.unstubAllEnvs();
     });
 
     it("should return current date in Bulgarian timezone", () => {
@@ -110,6 +113,37 @@ describe("message-classification", () => {
       expect(result.getFullYear()).toBe(2024);
       expect(result.getMonth()).toBe(6); // July
       expect(result.getDate()).toBe(15);
+    });
+
+    it("should support non-Sofia timezone via env config", () => {
+      vi.stubEnv("NEXT_PUBLIC_TIMEZONE", "America/New_York");
+      // 01:30 UTC is still previous day in New York (UTC-5 winter)
+      vi.setSystemTime(new Date("2024-01-15T01:30:00.000Z"));
+
+      const result = getTodayBulgarianTime();
+
+      expect(result.getFullYear()).toBe(2024);
+      expect(result.getMonth()).toBe(0); // January
+      expect(result.getDate()).toBe(14);
+    });
+  });
+
+  describe("getClassificationTimeZone", () => {
+    afterEach(() => {
+      vi.unstubAllEnvs();
+    });
+
+    it("defaults to UTC when no timezone env is configured", () => {
+      vi.stubEnv("NEXT_PUBLIC_TIMEZONE", "");
+      vi.stubEnv("NEXT_PUBLIC_TIME_ZONE", "");
+
+      expect(getClassificationTimeZone()).toBe("UTC");
+    });
+
+    it("uses configured timezone from env", () => {
+      vi.stubEnv("NEXT_PUBLIC_TIMEZONE", "America/New_York");
+
+      expect(getClassificationTimeZone()).toBe("America/New_York");
     });
   });
 
@@ -155,12 +189,14 @@ describe("message-classification", () => {
   describe("classifyMessage", () => {
     beforeEach(() => {
       vi.useFakeTimers();
+      vi.stubEnv("NEXT_PUBLIC_TIMEZONE", "Europe/Sofia");
       // Set to January 15, 2024, 12:00 Bulgarian time
       vi.setSystemTime(new Date("2024-01-15T10:00:00.000Z")); // UTC+2 winter time
     });
 
     afterEach(() => {
       vi.useRealTimers();
+      vi.unstubAllEnvs();
     });
 
     it("should classify as active when latest timespan is today", () => {
@@ -329,6 +365,22 @@ describe("message-classification", () => {
 
       // Reset to original test time
       vi.setSystemTime(new Date("2024-01-15T10:00:00.000Z"));
+    });
+
+    it("respects non-Sofia configured timezone when classifying createdAt fallback", () => {
+      vi.stubEnv("NEXT_PUBLIC_TIMEZONE", "America/New_York");
+      // In New York this is Jan 14 20:30, so 'today' should be Jan 14.
+      vi.setSystemTime(new Date("2024-01-15T01:30:00.000Z"));
+
+      const message: Message = {
+        id: "test-ny-timezone",
+        text: "Test message",
+        source: "test",
+        locality: "bg.sofia",
+        createdAt: "2024-01-14T23:00:00.000Z",
+      };
+
+      expect(classifyMessage(message)).toBe("active" as MessageClassification);
     });
   });
 });

--- a/web/lib/message-classification.ts
+++ b/web/lib/message-classification.ts
@@ -2,6 +2,16 @@ import type { Message } from "./types";
 
 export type MessageClassification = "active" | "archived";
 
+const DEFAULT_CLASSIFICATION_TIME_ZONE = "UTC";
+
+export function getClassificationTimeZone(): string {
+  const configuredTimeZone =
+    process.env.NEXT_PUBLIC_TIMEZONE?.trim() ||
+    process.env.NEXT_PUBLIC_TIME_ZONE?.trim();
+
+  return configuredTimeZone || DEFAULT_CLASSIFICATION_TIME_ZONE;
+}
+
 /**
  * Parse Bulgarian timespan date format "DD.MM.YYYY HH:MM"
  * Returns null if parsing fails
@@ -52,17 +62,17 @@ export function parseTimespanDate(dateStr: string): Date | null {
 }
 
 /**
- * Get current date in Bulgarian timezone (EET/EEST, UTC+2/+3)
- * Returns a Date object representing "now" in Bulgarian time
+ * Get current date in instance classification timezone.
+ * The timezone comes from NEXT_PUBLIC_TIMEZONE (or NEXT_PUBLIC_TIME_ZONE)
+ * and defaults to UTC.
  */
 export function getTodayBulgarianTime(): Date {
-  // Get current time in Bulgarian timezone
-  const bulgarianTimeString = new Date().toLocaleString("en-US", {
-    timeZone: "Europe/Sofia",
+  const classificationTimeString = new Date().toLocaleString("en-US", {
+    timeZone: getClassificationTimeZone(),
   });
 
   // Parse the localized string back to a Date object
-  return new Date(bulgarianTimeString);
+  return new Date(classificationTimeString);
 }
 
 /**
@@ -83,7 +93,7 @@ export function isToday(date: Date, referenceDate: Date): boolean {
 
 /**
  * Classify a message as "active" (today or future) or "archived" (past)
- * Uses Bulgarian timezone for date determination
+ * Uses configured instance timezone for date determination
  *
  * Classification logic:
  * 1. Try to use denormalized timespanEnd field at message root
@@ -91,6 +101,7 @@ export function isToday(date: Date, referenceDate: Date): boolean {
  * 3. Fallback: use createdAt, check if today → "active", else "archived"
  */
 export function classifyMessage(message: Message): MessageClassification {
+  const classificationTimeZone = getClassificationTimeZone();
   const today = getTodayBulgarianTime();
 
   // Try denormalized timespanEnd first
@@ -100,15 +111,14 @@ export function classifyMessage(message: Message): MessageClassification {
         ? new Date(message.timespanEnd)
         : message.timespanEnd;
 
-    // Convert to Bulgarian time for comparison
-    const bulgarianTimespanEnd = new Date(
+    const localizedTimespanEnd = new Date(
       timespanEnd.toLocaleString("en-US", {
-        timeZone: "Europe/Sofia",
+        timeZone: classificationTimeZone,
       }),
     );
 
     // Check if the timespan ends today or in the future
-    return isToday(bulgarianTimespanEnd, today) || bulgarianTimespanEnd > today
+    return isToday(localizedTimespanEnd, today) || localizedTimespanEnd > today
       ? "active"
       : "archived";
   }
@@ -120,14 +130,13 @@ export function classifyMessage(message: Message): MessageClassification {
         ? new Date(message.createdAt)
         : message.createdAt;
 
-    // Convert to Bulgarian time for comparison
-    const bulgarianCreatedAt = new Date(
+    const localizedCreatedAt = new Date(
       createdDate.toLocaleString("en-US", {
-        timeZone: "Europe/Sofia",
+        timeZone: classificationTimeZone,
       }),
     );
 
-    return isToday(bulgarianCreatedAt, today) ? "active" : "archived";
+    return isToday(localizedCreatedAt, today) ? "active" : "archived";
   }
 
   // Default to archived if no date information available


### PR DESCRIPTION
## Summary
- make message classification timezone configurable via `NEXT_PUBLIC_TIMEZONE` (fallback `NEXT_PUBLIC_TIME_ZONE`, default `UTC`)
- remove Sofia-specific timezone assumptions in shared crawler date utils comments/examples
- switch Terraform `schedule_timezone` default to `UTC` and align docs
- set `NEXT_PUBLIC_TIMEZONE` in CI web build env to keep deterministic build-time behavior

## Validation
- `cd web && pnpm vitest run lib/message-classification.test.ts --config vitest.config.mts`
- `cd ingest && pnpm vitest run crawlers/shared/date-utils.test.ts --config vitest.config.mts`

## Notes
- source-specific explicit timezones (for example `sofiyska-voda`) are intentionally unchanged
