### PR TITLE
docs: separate generic docs from Sofia examples (#564)

### DIFF
--- a/docs/features/cloud-workflows.md
+++ b/docs/features/cloud-workflows.md
@@ -33,12 +33,12 @@ Google Cloud Workflows
 
 1. **Emergent Workflow** (`pipeline-emergent`)
    - **Crawlers**: A subset of sources that publish short-lived disruptions (utility outages, emergency works)
-  - **Schedule**: Every 30 minutes in the configured scheduler timezone
+    - **Schedule**: Every 30 minutes in the configured scheduler timezone
    - **Use case**: Short-lived disruptions requiring frequent updates
 
 2. **All Workflow** (`pipeline-all`)
    - **Crawlers**: All currently deployed crawlers
-  - **Schedule**: 3 times daily in the configured scheduler timezone
+    - **Schedule**: 3 times daily in the configured scheduler timezone
    - **Use case**: Long-term construction/repair projects and municipal announcements from district administrations
 
 The scheduler timezone is configured through Terraform (`schedule_timezone`).

--- a/docs/features/cloud-workflows.md
+++ b/docs/features/cloud-workflows.md
@@ -33,13 +33,19 @@ Google Cloud Workflows
 
 1. **Emergent Workflow** (`pipeline-emergent`)
    - **Crawlers**: A subset of sources that publish short-lived disruptions (utility outages, emergency works)
-   - **Schedule**: Every 30 minutes (7:00 AM - 10:30 PM, Europe/Sofia timezone)
+  - **Schedule**: Every 30 minutes in the configured scheduler timezone
    - **Use case**: Short-lived disruptions requiring frequent updates
 
 2. **All Workflow** (`pipeline-all`)
    - **Crawlers**: All currently deployed crawlers
-   - **Schedule**: 3 times daily at 10:00 AM, 2:00 PM, 4:00 PM (Europe/Sofia timezone)
+  - **Schedule**: 3 times daily in the configured scheduler timezone
    - **Use case**: Long-term construction/repair projects and municipal announcements from district administrations
+
+The scheduler timezone is configured through Terraform (`schedule_timezone`).
+
+Example profile (Sofia deployment): emergent runs every 30 minutes between 7:00 and 22:30, and full runs at 10:00, 14:00, and 16:00.
+
+For adapting schedules and locality configuration for a new city instance, see [Deploying oboapp for a New City](../setup/new-locality-instance.md).
 
 ## Workflow Execution Flow
 

--- a/docs/features/public-api.md
+++ b/docs/features/public-api.md
@@ -2,16 +2,18 @@
 
 ## Overview
 
-OboApp exposes a read-only public REST API for external consumption of Sofia city-infrastructure disruption data.
+OboApp exposes a read-only public REST API for external consumption of disruption data in the localities configured for your deployment.
 
 The public API is served by the dedicated API module and (sub)domain.
 The web app does not serve public API endpoints directly.
 
 For backwards compatibility with existing clients that still call the web domain, web permanently redirects `/api/v1/*` requests to the configured public API host.
 
-**Base URL:** `https://api.oboapp.online/v1`
+**Base URL:** deployment-specific (for example `https://api.oboapp.online/v1`)
 
-**Interactive documentation:** [`https://api.oboapp.online/v1/docs`](https://api.oboapp.online/v1/docs)
+**Interactive documentation:** `<your-api-host>/v1/docs` (for example [`https://api.oboapp.online/v1/docs`](https://api.oboapp.online/v1/docs))
+
+For configuring hosts and locality-specific deployment setup, see [Deploying oboapp for a New City](../setup/new-locality-instance.md) and [Production Setup](../setup/production-setup.md).
 
 All data endpoints require a registered API key. The OpenAPI specification is available without authentication.
 

--- a/docs/setup/production-setup.md
+++ b/docs/setup/production-setup.md
@@ -228,7 +228,7 @@ Filter by error severity for issues.
 
 ## Cost Estimates
 
-Based on typical usage for Sofia, Bulgaria:
+Example profile (Sofia deployment):
 
 | Service             | Free Tier      | Typical Monthly Cost |
 | ------------------- | -------------- | -------------------- |
@@ -238,6 +238,10 @@ Based on typical usage for Sofia, Bulgaria:
 | Maps JavaScript API | $200 credit/mo | $0                   |
 | Gemini AI           | Free tier      | $0-5                 |
 | **Total**           | -              | **$1-22/month**      |
+
+Actual cost depends on your configured locality, traffic volume, crawler set, and schedule profile.
+
+For adapting configuration for another city/locality, see [Deploying oboapp for a New City](new-locality-instance.md).
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- rewrite Public API overview to describe deployment-generic locality behavior instead of Sofia-only framing
- rewrite Cloud Workflows schedule wording to use configured scheduler timezone, with Sofia timings kept as an explicit example profile
- relabel production cost section as an example Sofia profile and add locality-dependent caveat
- add cross-links to new-locality setup guidance where deployment adaptation is relevant

## Validation
- documentation content review for issue acceptance criteria:
  - no Sofia-specific operational assumptions presented as universal behavior
  - Sofia details retained only as clearly labeled examples
  - links to new-locality guidance added
